### PR TITLE
Add search/filter capability to label dialog (Issue #10)

### DIFF
--- a/libs/labelDialog.py
+++ b/libs/labelDialog.py
@@ -1,3 +1,6 @@
+# libs/labelDialog.py
+"""Label dialog with search/filter capability for selecting annotation labels."""
+
 try:
     from PyQt5.QtGui import *
     from PyQt5.QtCore import *
@@ -16,17 +19,24 @@ class LabelDialog(QDialog):
     def __init__(self, text="Enter object label", parent=None, list_item=None):
         super(LabelDialog, self).__init__(parent)
 
+        self.list_item = list_item or []
+
+        # Label input field
         self.edit = QLineEdit()
         self.edit.setText(text)
         self.edit.setValidator(label_validator())
         self.edit.editingFinished.connect(self.post_process)
+        self.edit.setPlaceholderText("Enter label name...")
 
+        # Autocomplete for label input
         model = QStringListModel()
-        model.setStringList(list_item)
+        model.setStringList(self.list_item)
         completer = QCompleter()
         completer.setModel(model)
+        completer.setCaseSensitivity(Qt.CaseInsensitive)
         self.edit.setCompleter(completer)
 
+        # OK/Cancel buttons
         self.button_box = bb = BB(BB.Ok | BB.Cancel, Qt.Horizontal, self)
         bb.button(BB.Ok).setIcon(new_icon('done'))
         bb.button(BB.Cancel).setIcon(new_icon('undo'))
@@ -37,15 +47,59 @@ class LabelDialog(QDialog):
         layout.addWidget(bb, alignment=Qt.AlignmentFlag.AlignLeft)
         layout.addWidget(self.edit)
 
-        if list_item is not None and len(list_item) > 0:
+        # Add search/filter and list widget if there are predefined classes
+        if self.list_item:
+            # Search/filter field
+            self.filter_edit = QLineEdit()
+            self.filter_edit.setPlaceholderText("Search labels...")
+            self.filter_edit.setClearButtonEnabled(True)
+            self.filter_edit.textChanged.connect(self._filter_list)
+
+            # Label for filter
+            filter_layout = QHBoxLayout()
+            filter_label = QLabel("Filter:")
+            filter_label.setStyleSheet("color: #666;")
+            filter_layout.addWidget(filter_label)
+            filter_layout.addWidget(self.filter_edit)
+            layout.addLayout(filter_layout)
+
+            # List widget for predefined classes
             self.list_widget = QListWidget(self)
-            for item in list_item:
+            for item in self.list_item:
                 self.list_widget.addItem(item)
             self.list_widget.itemClicked.connect(self.list_item_click)
             self.list_widget.itemDoubleClicked.connect(self.list_item_double_click)
             layout.addWidget(self.list_widget)
 
+            # Count label
+            self.count_label = QLabel(f"{len(self.list_item)} labels")
+            self.count_label.setStyleSheet("color: #888; font-size: 11px;")
+            layout.addWidget(self.count_label)
+
         self.setLayout(layout)
+
+    def _filter_list(self, text):
+        """Filter the list widget based on search text."""
+        if not hasattr(self, 'list_widget'):
+            return
+
+        filter_text = text.lower()
+        visible_count = 0
+
+        for i in range(self.list_widget.count()):
+            item = self.list_widget.item(i)
+            item_text = item.text().lower()
+            matches = filter_text in item_text
+            item.setHidden(not matches)
+            if matches:
+                visible_count += 1
+
+        # Update count label
+        if hasattr(self, 'count_label'):
+            if filter_text:
+                self.count_label.setText(f"{visible_count} of {len(self.list_item)} labels")
+            else:
+                self.count_label.setText(f"{len(self.list_item)} labels")
 
     def validate(self):
         if trimmed(self.edit.text()):
@@ -63,6 +117,11 @@ class LabelDialog(QDialog):
         self.edit.setText(text)
         self.edit.setSelection(0, len(text))
         self.edit.setFocus(Qt.PopupFocusReason)
+
+        # Clear filter when opening
+        if hasattr(self, 'filter_edit'):
+            self.filter_edit.clear()
+
         if move:
             cursor_pos = QCursor.pos()
 

--- a/tests/test_label_dialog.py
+++ b/tests/test_label_dialog.py
@@ -1,0 +1,120 @@
+# tests/test_label_dialog.py
+"""Tests for LabelDialog search/filter functionality (Issue #10)."""
+import os
+import sys
+import unittest
+
+# Set offscreen platform for headless testing
+if 'QT_QPA_PLATFORM' not in os.environ:
+    os.environ['QT_QPA_PLATFORM'] = 'offscreen'
+
+dir_name = os.path.abspath(os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(dir_name, '..'))
+
+from PyQt5.QtWidgets import QApplication
+from libs.labelDialog import LabelDialog
+
+
+class TestLabelDialogFilter(unittest.TestCase):
+    """Tests for label dialog search/filter feature."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create app once for all tests."""
+        cls.app = QApplication.instance() or QApplication([])
+        cls.labels = ['person', 'car', 'bicycle', 'dog', 'cat', 'person_sitting']
+
+    def test_dialog_with_labels_has_filter(self):
+        """Test that dialog with labels has filter widget."""
+        dialog = LabelDialog(list_item=self.labels)
+        self.assertTrue(hasattr(dialog, 'filter_edit'))
+        self.assertTrue(hasattr(dialog, 'list_widget'))
+        self.assertTrue(hasattr(dialog, 'count_label'))
+
+    def test_dialog_without_labels_no_filter(self):
+        """Test that dialog without labels has no filter widget."""
+        dialog = LabelDialog(list_item=[])
+        self.assertFalse(hasattr(dialog, 'filter_edit'))
+
+    def test_filter_hides_non_matching_items(self):
+        """Test that filter hides items not matching search text."""
+        dialog = LabelDialog(list_item=self.labels)
+
+        # Filter by 'car'
+        dialog._filter_list('car')
+
+        visible_count = 0
+        for i in range(dialog.list_widget.count()):
+            item = dialog.list_widget.item(i)
+            if not item.isHidden():
+                visible_count += 1
+                self.assertIn('car', item.text().lower())
+
+        self.assertEqual(visible_count, 1)  # Only 'car' should be visible
+
+    def test_filter_is_case_insensitive(self):
+        """Test that filter matching is case insensitive."""
+        dialog = LabelDialog(list_item=self.labels)
+
+        # Filter with uppercase
+        dialog._filter_list('CAR')
+
+        visible_items = []
+        for i in range(dialog.list_widget.count()):
+            item = dialog.list_widget.item(i)
+            if not item.isHidden():
+                visible_items.append(item.text())
+
+        self.assertIn('car', visible_items)
+
+    def test_filter_partial_match(self):
+        """Test that filter matches partial text."""
+        dialog = LabelDialog(list_item=self.labels)
+
+        # Filter by 'per' should match 'person' and 'person_sitting'
+        dialog._filter_list('per')
+
+        visible_items = []
+        for i in range(dialog.list_widget.count()):
+            item = dialog.list_widget.item(i)
+            if not item.isHidden():
+                visible_items.append(item.text())
+
+        self.assertEqual(len(visible_items), 2)
+        self.assertIn('person', visible_items)
+        self.assertIn('person_sitting', visible_items)
+
+    def test_empty_filter_shows_all(self):
+        """Test that empty filter shows all items."""
+        dialog = LabelDialog(list_item=self.labels)
+
+        # First filter
+        dialog._filter_list('car')
+        # Then clear
+        dialog._filter_list('')
+
+        visible_count = 0
+        for i in range(dialog.list_widget.count()):
+            if not dialog.list_widget.item(i).isHidden():
+                visible_count += 1
+
+        self.assertEqual(visible_count, len(self.labels))
+
+    def test_count_label_updates(self):
+        """Test that count label updates on filter."""
+        dialog = LabelDialog(list_item=self.labels)
+
+        # Initial count
+        self.assertEqual(dialog.count_label.text(), f"{len(self.labels)} labels")
+
+        # After filter
+        dialog._filter_list('per')
+        self.assertIn('2 of', dialog.count_label.text())
+
+        # After clearing
+        dialog._filter_list('')
+        self.assertEqual(dialog.count_label.text(), f"{len(self.labels)} labels")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add search field to label dialog with real-time filtering
- Filter is case-insensitive for better UX
- Shows count label ("X of Y labels") when filtering
- Clear button to reset filter

## Changes
- `libs/labelDialog.py`: Added filter_edit field, _filter_list method, and count_label
- `tests/test_label_dialog.py`: New test file with 7 comprehensive tests

## Test plan
- [x] All existing tests pass
- [x] New label dialog filter tests pass (7 tests)
- [ ] Manual testing: Open app, create annotation, verify filter works

Closes #10