### PR TITLE
Fix SonarCloud S1845: Remove unused fit_window attribute

### DIFF
--- a/labelImgPlusPlus.py
+++ b/labelImgPlusPlus.py
@@ -612,7 +612,6 @@ class MainWindow(QMainWindow, WindowMixin):
         self.line_color = None
         self.fill_color = None
         self.zoom_level = 100
-        self.fit_window = False
         # Add Chris
         self.difficult = False
 


### PR DESCRIPTION
## Summary
Remove unused `self.fit_window` attribute that was causing SonarCloud rule S1845 violation (methods and field names should not differ only by capitalization).

## Changes
- Remove `self.fit_window = False` from `labelImgPlusPlus.py` line 615
- This attribute was defined but never used anywhere in the codebase

## SonarCloud Rule
S1845: The instance attribute `fit_window` conflicts with class constant `FIT_WINDOW` (differ only by case).