### PR TITLE
Remove dead code across codebase

### DIFF
--- a/labelImgPlusPlus.py
+++ b/labelImgPlusPlus.py
@@ -2420,22 +2420,6 @@ class MainWindow(QMainWindow, WindowMixin):
                 self.status("Auto-saved to %s" % os.path.basename(save_path))
 
 
-def inverted(color):
-    return QColor(*[255 - v for v in color.getRgb()])
-
-
-def read(filename, default=None):
-    try:
-        reader = QImageReader(filename)
-        reader.setAutoTransform(True)
-        image = reader.read()
-        if image.isNull():
-            return default
-        return image
-    except (IOError, OSError):
-        return default
-
-
 def get_main_app(argv=None):
     """
     Standard boilerplate Qt application code.

--- a/libs/canvas.py
+++ b/libs/canvas.py
@@ -7,8 +7,6 @@ except ImportError:
     from PyQt4.QtGui import *
     from PyQt4.QtCore import *
 
-# from PyQt4.QtOpenGL import *
-
 from libs.shape import Shape
 from libs.utils import distance
 
@@ -17,8 +15,6 @@ CURSOR_POINT = Qt.PointingHandCursor
 CURSOR_DRAW = Qt.CrossCursor
 CURSOR_MOVE = Qt.ClosedHandCursor
 CURSOR_GRAB = Qt.OpenHandCursor
-
-# class Canvas(QGLWidget):
 
 
 class Canvas(QWidget):
@@ -609,9 +605,6 @@ class Canvas(QWidget):
         self.update()
 
     def close_enough(self, p1, p2):
-        # d = distance(p1 - p2)
-        # m = (p1-p2).manhattanLength()
-        # print "d %.2f, m %d, %.2f" % (d, m, d - m)
         return distance(p1 - p2) < self.epsilon
 
     # These two, along with a call to adjustSize are required for the
@@ -667,27 +660,22 @@ class Canvas(QWidget):
             self.move_one_pixel('Down')
 
     def move_one_pixel(self, direction):
-        # print(self.selectedShape.points)
         if direction == 'Left' and not self.move_out_of_bound(QPointF(-1.0, 0)):
-            # print("move Left one pixel")
             self.selected_shape.points[0] += QPointF(-1.0, 0)
             self.selected_shape.points[1] += QPointF(-1.0, 0)
             self.selected_shape.points[2] += QPointF(-1.0, 0)
             self.selected_shape.points[3] += QPointF(-1.0, 0)
         elif direction == 'Right' and not self.move_out_of_bound(QPointF(1.0, 0)):
-            # print("move Right one pixel")
             self.selected_shape.points[0] += QPointF(1.0, 0)
             self.selected_shape.points[1] += QPointF(1.0, 0)
             self.selected_shape.points[2] += QPointF(1.0, 0)
             self.selected_shape.points[3] += QPointF(1.0, 0)
         elif direction == 'Up' and not self.move_out_of_bound(QPointF(0, -1.0)):
-            # print("move Up one pixel")
             self.selected_shape.points[0] += QPointF(0, -1.0)
             self.selected_shape.points[1] += QPointF(0, -1.0)
             self.selected_shape.points[2] += QPointF(0, -1.0)
             self.selected_shape.points[3] += QPointF(0, -1.0)
         elif direction == 'Down' and not self.move_out_of_bound(QPointF(0, 1.0)):
-            # print("move Down one pixel")
             self.selected_shape.points[0] += QPointF(0, 1.0)
             self.selected_shape.points[1] += QPointF(0, 1.0)
             self.selected_shape.points[2] += QPointF(0, 1.0)

--- a/libs/commands.py
+++ b/libs/commands.py
@@ -5,7 +5,6 @@ This module provides undoable command classes for annotation actions.
 """
 
 from abc import ABC, abstractmethod
-from copy import deepcopy
 
 try:
     from PyQt5.QtCore import QPointF

--- a/libs/labelFile.py
+++ b/libs/labelFile.py
@@ -114,35 +114,6 @@ class LabelFile(object):
     def toggle_verify(self):
         self.verified = not self.verified
 
-    ''' ttf is disable
-    def load(self, filename):
-        import json
-        with open(filename, 'rb') as f:
-                data = json.load(f)
-                imagePath = data['imagePath']
-                imageData = b64decode(data['imageData'])
-                lineColor = data['lineColor']
-                fillColor = data['fillColor']
-                shapes = ((s['label'], s['points'], s['line_color'], s['fill_color'])\
-                        for s in data['shapes'])
-                # Only replace data after everything is loaded.
-                self.shapes = shapes
-                self.imagePath = imagePath
-                self.imageData = imageData
-                self.lineColor = lineColor
-                self.fillColor = fillColor
-
-    def save(self, filename, shapes, imagePath, imageData, lineColor=None, fillColor=None):
-        import json
-        with open(filename, 'wb') as f:
-                json.dump(dict(
-                    shapes=shapes,
-                    lineColor=lineColor, fillColor=fillColor,
-                    imagePath=imagePath,
-                    imageData=b64encode(imageData)),
-                    f, ensure_ascii=True, indent=2)
-    '''
-
     @staticmethod
     def is_label_file(filename):
         file_suffix = os.path.splitext(filename)[1].lower()

--- a/libs/pascal_voc_io.py
+++ b/libs/pascal_voc_io.py
@@ -30,9 +30,6 @@ class PascalVocWriter:
         rough_string = ElementTree.tostring(elem, 'utf8')
         root = etree.fromstring(rough_string)
         return etree.tostring(root, pretty_print=True, encoding=ENCODE_METHOD).replace("  ".encode(), "\t".encode())
-        # minidom does not support UTF-8
-        # reparsed = minidom.parseString(rough_string)
-        # return reparsed.toprettyxml(indent="\t", encoding=ENCODE_METHOD)
 
     def gen_xml(self):
         """

--- a/libs/yolo_io.py
+++ b/libs/yolo_io.py
@@ -83,8 +83,6 @@ class YoloReader:
         else:
             self.class_list_path = class_list_path
 
-        # print (file_path, self.class_list_path)
-
         # Load classes with proper error handling
         self.classes = []
         try:
@@ -97,8 +95,6 @@ class YoloReader:
             )
         except IOError as e:
             raise IOError(f"Error reading classes.txt: {e}")
-
-        # print (self.classes)
 
         img_size = [image.height(), image.width(),
                     1 if image.isGrayscale() else 3]


### PR DESCRIPTION
## Summary
Remove 65 lines of dead code across 6 files to improve code maintainability.

## Changes
| File | Removed |
|------|---------|
| `labelImgPlusPlus.py` | Unused `inverted()` and `read()` functions |
| `libs/commands.py` | Unused `deepcopy` import |
| `libs/labelFile.py` | Commented-out ttf save/load block |
| `libs/canvas.py` | Legacy commented imports and debug prints |
| `libs/yolo_io.py` | Commented debug prints |
| `libs/pascal_voc_io.py` | Commented minidom code |

## Test plan
- [x] All 263 tests pass