### PR TITLE
Add annotation statistics dashboard (Issue #19)

### DIFF
--- a/libs/statsWidget.py
+++ b/libs/statsWidget.py
@@ -1,0 +1,185 @@
+# libs/statsWidget.py
+"""Statistics widget for displaying annotation statistics."""
+
+try:
+    from PyQt5.QtGui import *
+    from PyQt5.QtCore import *
+    from PyQt5.QtWidgets import *
+except ImportError:
+    from PyQt4.QtGui import *
+    from PyQt4.QtCore import *
+
+
+class StatsWidget(QWidget):
+    """Widget displaying annotation statistics for the dataset."""
+
+    def __init__(self, parent=None):
+        super(StatsWidget, self).__init__(parent)
+        self._setup_ui()
+        self._label_counts = {}
+        self._dataset_stats = {
+            'total': 0,
+            'annotated': 0,
+            'verified': 0
+        }
+        self._current_image_stats = {
+            'annotations': 0,
+            'labels': []
+        }
+
+    def _setup_ui(self):
+        """Set up the user interface."""
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(8, 8, 8, 8)
+        layout.setSpacing(12)
+
+        # Dataset Statistics Section
+        dataset_group = QGroupBox("Dataset Statistics")
+        dataset_layout = QVBoxLayout(dataset_group)
+        dataset_layout.setSpacing(4)
+
+        self.total_images_label = QLabel("Images: 0")
+        self.annotated_label = QLabel("Annotated: 0 (0%)")
+        self.verified_label = QLabel("Verified: 0 (0%)")
+
+        self.progress_bar = QProgressBar()
+        self.progress_bar.setMinimum(0)
+        self.progress_bar.setMaximum(100)
+        self.progress_bar.setValue(0)
+        self.progress_bar.setTextVisible(True)
+        self.progress_bar.setFormat("Annotation Progress: %p%")
+
+        dataset_layout.addWidget(self.total_images_label)
+        dataset_layout.addWidget(self.annotated_label)
+        dataset_layout.addWidget(self.verified_label)
+        dataset_layout.addWidget(self.progress_bar)
+
+        layout.addWidget(dataset_group)
+
+        # Label Distribution Section
+        label_group = QGroupBox("Label Distribution")
+        label_layout = QVBoxLayout(label_group)
+
+        self.label_table = QTableWidget()
+        self.label_table.setColumnCount(2)
+        self.label_table.setHorizontalHeaderLabels(["Label", "Count"])
+        self.label_table.horizontalHeader().setStretchLastSection(True)
+        self.label_table.horizontalHeader().setSectionResizeMode(0, QHeaderView.Stretch)
+        self.label_table.verticalHeader().setVisible(False)
+        self.label_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.label_table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.label_table.setMaximumHeight(200)
+
+        label_layout.addWidget(self.label_table)
+
+        layout.addWidget(label_group)
+
+        # Current Image Section
+        current_group = QGroupBox("Current Image")
+        current_layout = QVBoxLayout(current_group)
+        current_layout.setSpacing(4)
+
+        self.current_annotations_label = QLabel("Annotations: 0")
+        self.current_labels_label = QLabel("Labels: -")
+        self.current_labels_label.setWordWrap(True)
+
+        current_layout.addWidget(self.current_annotations_label)
+        current_layout.addWidget(self.current_labels_label)
+
+        layout.addWidget(current_group)
+
+        # Refresh Button
+        self.refresh_btn = QPushButton("Refresh Statistics")
+        self.refresh_btn.setIcon(self.style().standardIcon(QStyle.SP_BrowserReload))
+        layout.addWidget(self.refresh_btn)
+
+        # Spacer
+        layout.addStretch()
+
+        self.setLayout(layout)
+
+    def update_dataset_stats(self, total, annotated, verified):
+        """Update dataset-level statistics.
+
+        Args:
+            total: Total number of images
+            annotated: Number of images with annotations
+            verified: Number of verified images
+        """
+        self._dataset_stats = {
+            'total': total,
+            'annotated': annotated,
+            'verified': verified
+        }
+
+        self.total_images_label.setText(f"Images: {total}")
+
+        if total > 0:
+            annotated_pct = (annotated / total) * 100
+            verified_pct = (verified / total) * 100
+            self.annotated_label.setText(f"Annotated: {annotated} ({annotated_pct:.0f}%)")
+            self.verified_label.setText(f"Verified: {verified} ({verified_pct:.0f}%)")
+            self.progress_bar.setValue(int(annotated_pct))
+        else:
+            self.annotated_label.setText("Annotated: 0 (0%)")
+            self.verified_label.setText("Verified: 0 (0%)")
+            self.progress_bar.setValue(0)
+
+    def update_label_distribution(self, label_counts):
+        """Update label distribution table.
+
+        Args:
+            label_counts: Dict mapping label names to counts
+        """
+        self._label_counts = label_counts
+
+        # Sort by count descending
+        sorted_labels = sorted(label_counts.items(), key=lambda x: x[1], reverse=True)
+
+        self.label_table.setRowCount(len(sorted_labels))
+
+        for row, (label, count) in enumerate(sorted_labels):
+            label_item = QTableWidgetItem(label)
+            count_item = QTableWidgetItem(str(count))
+            count_item.setTextAlignment(Qt.AlignRight | Qt.AlignVCenter)
+
+            self.label_table.setItem(row, 0, label_item)
+            self.label_table.setItem(row, 1, count_item)
+
+    def update_current_image_stats(self, annotations_count, labels):
+        """Update current image statistics.
+
+        Args:
+            annotations_count: Number of annotations in current image
+            labels: List of label names used in current image
+        """
+        self._current_image_stats = {
+            'annotations': annotations_count,
+            'labels': labels
+        }
+
+        self.current_annotations_label.setText(f"Annotations: {annotations_count}")
+
+        if labels:
+            unique_labels = sorted(set(labels))
+            self.current_labels_label.setText(f"Labels: {', '.join(unique_labels)}")
+        else:
+            self.current_labels_label.setText("Labels: -")
+
+    def clear_stats(self):
+        """Clear all statistics."""
+        self.update_dataset_stats(0, 0, 0)
+        self.update_label_distribution({})
+        self.update_current_image_stats(0, [])
+
+    def get_dataset_stats(self):
+        """Return current dataset statistics."""
+        return self._dataset_stats.copy()
+
+    def get_label_counts(self):
+        """Return current label counts."""
+        return self._label_counts.copy()
+
+    def get_current_image_stats(self):
+        """Return current image statistics."""
+        return self._current_image_stats.copy()

--- a/resources/strings/strings.properties
+++ b/resources/strings/strings.properties
@@ -116,3 +116,4 @@ galleryView=Gallery
 galleryMode=Gallery Mode
 galleryModeDetail=Toggle full-screen gallery view
 leftGallery=Gallery
+statistics=Statistics

--- a/tests/test_stats_widget.py
+++ b/tests/test_stats_widget.py
@@ -1,0 +1,207 @@
+# tests/test_stats_widget.py
+"""Tests for StatsWidget annotation statistics dashboard (Issue #19)."""
+import os
+import sys
+import unittest
+
+# Set offscreen platform for headless testing
+if 'QT_QPA_PLATFORM' not in os.environ:
+    os.environ['QT_QPA_PLATFORM'] = 'offscreen'
+
+dir_name = os.path.abspath(os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(dir_name, '..'))
+
+from PyQt5.QtWidgets import QApplication
+from libs.statsWidget import StatsWidget
+
+
+class TestStatsWidgetInit(unittest.TestCase):
+    """Tests for StatsWidget initialization."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create app once for all tests."""
+        cls.app = QApplication.instance() or QApplication([])
+
+    def test_widget_creates_successfully(self):
+        """Test that StatsWidget can be created."""
+        widget = StatsWidget()
+        self.assertIsNotNone(widget)
+
+    def test_has_required_labels(self):
+        """Test that widget has required UI elements."""
+        widget = StatsWidget()
+        self.assertIsNotNone(widget.total_images_label)
+        self.assertIsNotNone(widget.annotated_label)
+        self.assertIsNotNone(widget.verified_label)
+        self.assertIsNotNone(widget.progress_bar)
+
+    def test_has_label_table(self):
+        """Test that widget has label distribution table."""
+        widget = StatsWidget()
+        self.assertIsNotNone(widget.label_table)
+        self.assertEqual(widget.label_table.columnCount(), 2)
+
+    def test_has_current_image_labels(self):
+        """Test that widget has current image stats labels."""
+        widget = StatsWidget()
+        self.assertIsNotNone(widget.current_annotations_label)
+        self.assertIsNotNone(widget.current_labels_label)
+
+    def test_has_refresh_button(self):
+        """Test that widget has refresh button."""
+        widget = StatsWidget()
+        self.assertIsNotNone(widget.refresh_btn)
+
+
+class TestStatsWidgetDatasetStats(unittest.TestCase):
+    """Tests for dataset statistics updates."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create app once for all tests."""
+        cls.app = QApplication.instance() or QApplication([])
+
+    def test_update_dataset_stats_zero(self):
+        """Test updating with zero images."""
+        widget = StatsWidget()
+        widget.update_dataset_stats(0, 0, 0)
+
+        self.assertIn('0', widget.total_images_label.text())
+        self.assertEqual(widget.progress_bar.value(), 0)
+
+    def test_update_dataset_stats_with_data(self):
+        """Test updating with actual data."""
+        widget = StatsWidget()
+        widget.update_dataset_stats(100, 80, 50)
+
+        self.assertIn('100', widget.total_images_label.text())
+        self.assertIn('80', widget.annotated_label.text())
+        self.assertIn('80%', widget.annotated_label.text())
+        self.assertIn('50', widget.verified_label.text())
+        self.assertIn('50%', widget.verified_label.text())
+        self.assertEqual(widget.progress_bar.value(), 80)
+
+    def test_get_dataset_stats(self):
+        """Test retrieving dataset stats."""
+        widget = StatsWidget()
+        widget.update_dataset_stats(150, 120, 90)
+
+        stats = widget.get_dataset_stats()
+        self.assertEqual(stats['total'], 150)
+        self.assertEqual(stats['annotated'], 120)
+        self.assertEqual(stats['verified'], 90)
+
+
+class TestStatsWidgetLabelDistribution(unittest.TestCase):
+    """Tests for label distribution updates."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create app once for all tests."""
+        cls.app = QApplication.instance() or QApplication([])
+
+    def test_update_label_distribution_empty(self):
+        """Test updating with no labels."""
+        widget = StatsWidget()
+        widget.update_label_distribution({})
+
+        self.assertEqual(widget.label_table.rowCount(), 0)
+
+    def test_update_label_distribution_with_data(self):
+        """Test updating with label data."""
+        widget = StatsWidget()
+        labels = {'person': 45, 'car': 30, 'dog': 15}
+        widget.update_label_distribution(labels)
+
+        self.assertEqual(widget.label_table.rowCount(), 3)
+
+    def test_label_distribution_sorted_by_count(self):
+        """Test that labels are sorted by count descending."""
+        widget = StatsWidget()
+        labels = {'dog': 10, 'person': 50, 'car': 25}
+        widget.update_label_distribution(labels)
+
+        # First row should be 'person' with highest count
+        first_label = widget.label_table.item(0, 0).text()
+        first_count = widget.label_table.item(0, 1).text()
+        self.assertEqual(first_label, 'person')
+        self.assertEqual(first_count, '50')
+
+    def test_get_label_counts(self):
+        """Test retrieving label counts."""
+        widget = StatsWidget()
+        labels = {'person': 45, 'car': 30}
+        widget.update_label_distribution(labels)
+
+        counts = widget.get_label_counts()
+        self.assertEqual(counts['person'], 45)
+        self.assertEqual(counts['car'], 30)
+
+
+class TestStatsWidgetCurrentImage(unittest.TestCase):
+    """Tests for current image statistics updates."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create app once for all tests."""
+        cls.app = QApplication.instance() or QApplication([])
+
+    def test_update_current_image_no_annotations(self):
+        """Test updating with no annotations."""
+        widget = StatsWidget()
+        widget.update_current_image_stats(0, [])
+
+        self.assertIn('0', widget.current_annotations_label.text())
+        self.assertIn('-', widget.current_labels_label.text())
+
+    def test_update_current_image_with_annotations(self):
+        """Test updating with annotations."""
+        widget = StatsWidget()
+        widget.update_current_image_stats(5, ['person', 'car', 'person', 'dog'])
+
+        self.assertIn('5', widget.current_annotations_label.text())
+        # Should show unique labels
+        self.assertIn('car', widget.current_labels_label.text())
+        self.assertIn('dog', widget.current_labels_label.text())
+        self.assertIn('person', widget.current_labels_label.text())
+
+    def test_get_current_image_stats(self):
+        """Test retrieving current image stats."""
+        widget = StatsWidget()
+        widget.update_current_image_stats(3, ['cat', 'dog'])
+
+        stats = widget.get_current_image_stats()
+        self.assertEqual(stats['annotations'], 3)
+        self.assertEqual(stats['labels'], ['cat', 'dog'])
+
+
+class TestStatsWidgetClear(unittest.TestCase):
+    """Tests for clearing statistics."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Create app once for all tests."""
+        cls.app = QApplication.instance() or QApplication([])
+
+    def test_clear_stats(self):
+        """Test clearing all statistics."""
+        widget = StatsWidget()
+
+        # Set some data first
+        widget.update_dataset_stats(100, 80, 50)
+        widget.update_label_distribution({'person': 45})
+        widget.update_current_image_stats(5, ['person'])
+
+        # Clear
+        widget.clear_stats()
+
+        # Verify cleared
+        stats = widget.get_dataset_stats()
+        self.assertEqual(stats['total'], 0)
+        self.assertEqual(widget.label_table.rowCount(), 0)
+        self.assertEqual(widget.get_current_image_stats()['annotations'], 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
Add a statistics dock widget showing annotation statistics for the dataset.

## Features
- **Dataset Statistics**: Total images, annotated count (%), verified count (%)
- **Progress Bar**: Visual annotation completion percentage
- **Label Distribution**: Table showing per-class annotation counts (sorted by count)
- **Current Image Stats**: Annotations count and labels used

## Changes
- `libs/statsWidget.py`: New statistics widget
- `labelImgPlusPlus.py`: Integration with dock, menu, and update hooks
- `resources/strings/strings.properties`: Added "statistics" string
- `tests/test_stats_widget.py`: 16 unit tests

## Keyboard Shortcut
- `Ctrl+Shift+T`: Toggle Statistics panel

## Test plan
- [x] All 279 tests pass
- [x] StatsWidget unit tests (16 tests)
- [ ] Manual testing: Load directory, verify stats update

Closes #19