### PR TITLE
Add resizable dock panels (Issue #11)

### DIFF
--- a/labelImgPlusPlus.py
+++ b/labelImgPlusPlus.py
@@ -250,11 +250,27 @@ class MainWindow(QMainWindow, WindowMixin):
         self.addDockWidget(Qt.RightDockWidgetArea, self.dock)
         self.addDockWidget(Qt.RightDockWidgetArea, self.file_dock)
         self.addDockWidget(Qt.RightDockWidgetArea, self.stats_dock)
-        self.file_dock.setFeatures(QDockWidget.DockWidgetFloatable)
-        self.stats_dock.setFeatures(QDockWidget.DockWidgetClosable | QDockWidget.DockWidgetFloatable)
 
+        # Configure dock features - all docks are movable for resizing
+        # DockWidgetMovable enables drag-to-rearrange and proper splitter resizing
+        dock_features_all = (QDockWidget.DockWidgetMovable |
+                             QDockWidget.DockWidgetFloatable |
+                             QDockWidget.DockWidgetClosable)
+        self.file_dock.setFeatures(QDockWidget.DockWidgetMovable | QDockWidget.DockWidgetFloatable)
+        self.stats_dock.setFeatures(dock_features_all)
+
+        # Set minimum sizes for better resize UX
+        self.dock.setMinimumHeight(100)
+        self.file_dock.setMinimumHeight(100)
+        self.stats_dock.setMinimumHeight(80)
+        self.dock.setMinimumWidth(200)
+        self.file_dock.setMinimumWidth(200)
+        self.stats_dock.setMinimumWidth(200)
+
+        # Features toggled by advanced mode (closable/floatable for labels dock)
         self.dock_features = QDockWidget.DockWidgetClosable | QDockWidget.DockWidgetFloatable
-        self.dock.setFeatures(self.dock.features() ^ self.dock_features)
+        # In beginner mode, labels dock is movable only (not closable/floatable)
+        self.dock.setFeatures(QDockWidget.DockWidgetMovable)
 
         # Actions
         action = partial(new_action, self)


### PR DESCRIPTION
## Summary

- Enabled `DockWidgetMovable` on all dock widgets for proper resizing
- Set minimum sizes (200px width, 80-100px height) for better UX
- Dock sizes persist automatically via existing `saveState`/`restoreState`

## Changes

The Qt `saveState`/`restoreState` mechanism already handles size persistence. This change enables the movable feature which allows users to:
- Drag dock borders to resize panels
- Rearrange dock panels by dragging title bars
- Sizes are saved automatically when closing and restored on startup

## Test plan

- [ ] Open application
- [ ] Drag the border between dock panels to resize them
- [ ] Resize panels to different sizes
- [ ] Close and reopen application
- [ ] Verify panel sizes are restored

Closes #11