### PR TITLE
chore: ignore coverage artifacts and local-only working dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,15 @@ CLAUDE.md
 .claude/
 labelImgPlusPlus.egg-info/
 *.bak
+
+# Test coverage artifacts
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/
+
+# Local-only working dirs — plans, specs and design notes never push to remote
+.superpowers/
+docs/plans/
+docs/specs/
+docs/superpowers/


### PR DESCRIPTION
## Summary

Adds `.gitignore` rules for files that should never be committed. This is the gap that let a `git add -A` accidentally stage 8,400+ lines of local-only content during PR #71 — these paths were untracked but unignored, so they showed up as stageable.

## Ignored

| Pattern | Why |
|---------|-----|
| `.coverage`, `.coverage.*`, `coverage.xml`, `htmlcov/` | Coverage artifacts from local and CI test runs |
| `.superpowers/` | Local tooling working state |
| `docs/plans/`, `docs/specs/`, `docs/superpowers/` | Plans, specs and design notes — per project convention these stay local and never push to remote |

## Not ignored

Reference documentation under `docs/` — `architecture.md`, `components/`, `features/`, `formats/`, `guides/`, `reference/`, `screenshots/`, `testing/` — stays tracked. Only the three working subdirs are ignored. Verified with `git check-ignore` that no currently-tracked file is affected.

After this change `git status` is clean with no stray untracked paths.