### PR TITLE
fix: critical + high-severity fixes from codebase review

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ qt5py3:
 	pyrcc5 -o libs/resources.py resources.qrc
 
 clean:
-	rm -rf ~/.labelImgSettings.pkl *.pyc dist labelImg.egg-info __pycache__ build
+	rm -rf ~/.labelImgSettings.json ~/.labelImgSettings.pkl *.pyc dist labelImg.egg-info __pycache__ build
 
 pip_upload:
 	python3 setup.py upload

--- a/README.rst
+++ b/README.rst
@@ -239,7 +239,7 @@ If you encounter issues, reset the settings:
 
 .. code:: shell
 
-    rm ~/.labelImgSettings.pkl
+    rm ~/.labelImgSettings.json
 
 Or use **Menu > File > Reset All**
 

--- a/labelImgPlusPlus.py
+++ b/labelImgPlusPlus.py
@@ -3876,11 +3876,19 @@ def get_main_app(argv=None):
     app.setStyleSheet(get_combined_style())  # Apply global stylesheet
     app.setApplicationName(__appname__)
     app.setWindowIcon(new_icon("app"))
-    # Tzutalin 201705+: Accept extra agruments to change predefined class file
+    # Tzutalin 201705+: Accept extra agruments to change predefined class file.
+    # Prefer the copy packaged inside the libs package (shipped in the wheel);
+    # fall back to the top-level data/ dir for source checkouts.
+    _here = os.path.dirname(__file__)
+    default_class_file = os.path.join(_here, "libs", "data",
+                                      "predefined_classes.txt")
+    if not os.path.exists(default_class_file):
+        default_class_file = os.path.join(_here, "data",
+                                          "predefined_classes.txt")
     argparser = argparse.ArgumentParser()
     argparser.add_argument("image_dir", nargs="?")
     argparser.add_argument("class_file",
-                           default=os.path.join(os.path.dirname(__file__), "data", "predefined_classes.txt"),
+                           default=default_class_file,
                            nargs="?")
     argparser.add_argument("save_dir", nargs="?")
     args = argparser.parse_args(argv[1:])

--- a/labelImgPlusPlus.py
+++ b/labelImgPlusPlus.py
@@ -2882,7 +2882,7 @@ class MainWindow(QMainWindow, WindowMixin):
         # and replace old_label with new_label
         # For now, just log - full implementation would update files
         print(f"Label fix requested: '{old_label}' → '{new_label}'")
-        self.status_bar.showMessage(
+        self.statusBar().showMessage(
             f"Label fix: '{old_label}' → '{new_label}' (reload to see changes)",
             5000
         )
@@ -3274,7 +3274,9 @@ class MainWindow(QMainWindow, WindowMixin):
         self.settings.reset()
         self.close()
         process = QProcess()
-        process.startDetached(os.path.abspath(__file__))
+        # Relaunch through the Python interpreter so the restart works for an
+        # installed (entry-point) package, not just a source checkout.
+        process.startDetached(sys.executable, [os.path.abspath(__file__)])
 
     def may_continue(self):
         if not self.dirty:

--- a/labelImgPlusPlus.py
+++ b/labelImgPlusPlus.py
@@ -2537,20 +2537,19 @@ class MainWindow(QMainWindow, WindowMixin):
 
         if unicode_file_path and os.path.exists(unicode_file_path):
             if LabelFile.is_label_file(unicode_file_path):
-                try:
-                    self.label_file = LabelFile(unicode_file_path)
-                except LabelFileError as e:
-                    self.error_message(u'Error opening file',
-                                       (u"<p><b>%s</b></p>"
-                                        u"<p>Make sure <i>%s</i> is a valid label file.")
-                                       % (e, unicode_file_path))
-                    self.status("Error reading %s" % unicode_file_path)
-                    
-                    return False
-                self.image_data = self.label_file.image_data
-                self.line_color = QColor(*self.label_file.lineColor)
-                self.fill_color = QColor(*self.label_file.fillColor)
-                self.canvas.verified = self.label_file.verified
+                # Annotation files cannot be opened directly: in this fork
+                # LabelFile is a write-only dispatcher with no reader and no
+                # embedded image, so there is nothing to display. Report a
+                # clear error rather than crashing. Open the corresponding
+                # image instead; its annotations load automatically.
+                self.error_message(
+                    u'Cannot open annotation file',
+                    (u"<p><b>%s</b> is an annotation file, not an image.</p>"
+                     u"<p>Open the image it describes instead - its "
+                     u"annotations will load automatically.</p>")
+                    % unicode_file_path)
+                self.status("Cannot open annotation file %s" % unicode_file_path)
+                return False
             else:
                 # Load image with memory-efficient downsampling for large images
                 self.label_file = None

--- a/labelImgPlusPlus.py
+++ b/labelImgPlusPlus.py
@@ -599,6 +599,7 @@ class MainWindow(QMainWindow, WindowMixin):
         self.canvas.polygonVerticesEdited.connect(
             self._on_polygon_vertices_edited)
         self.canvas.keypointsEdited.connect(self._on_keypoints_edited)
+        self.canvas.shapeMoveFinished.connect(self._on_shape_move_finished)
         self.canvas.selectionChanged.connect(self.shape_selection_changed)
         self.canvas.drawingPolygon.connect(self.toggle_drawing_sensitive)
 
@@ -1702,6 +1703,12 @@ class MainWindow(QMainWindow, WindowMixin):
         """Capture polygon vertex edits for undo support."""
         cmd = EditPolygonVerticesCommand(
             self, shape, old_points, list(shape.points))
+        self.undo_stack.push(cmd)
+        self.set_dirty()
+
+    def _on_shape_move_finished(self, shape, old_points):
+        """Capture whole-shape moves / rectangle resizes for undo support."""
+        cmd = MoveShapeCommand(self, shape, old_points, list(shape.points))
         self.undo_stack.push(cmd)
         self.set_dirty()
 

--- a/libs/core/settings.py
+++ b/libs/core/settings.py
@@ -1,13 +1,79 @@
+# libs/core/settings.py
+import json
 import os
-import pickle
+from enum import Enum
+
+from PyQt5.QtCore import QByteArray, QPoint, QSize
+from PyQt5.QtGui import QColor
+
+# Settings are persisted as JSON rather than pickle: pickle.load executes
+# arbitrary code embedded in the file, and ~/.labelImgSettings is a
+# user-writable path loaded at every startup (a local code-execution vector).
+# JSON cannot describe Qt value types, so the handful that we store are encoded
+# as tagged dicts and reconstructed on load.
+
+_TYPE_TAG = '__type__'
+
+
+def _enum_classes():
+    """Whitelist of enum classes allowed during decode.
+
+    Resolved lazily to avoid an import-time core->formats dependency and to
+    keep an untrusted settings file from naming arbitrary classes to import.
+    """
+    from libs.formats.labelFile import LabelFileFormat
+    return {'LabelFileFormat': LabelFileFormat}
+
+
+def _encode(obj):
+    """json.dump ``default`` hook: serialize the Qt/enum values we persist."""
+    if isinstance(obj, QSize):
+        return {_TYPE_TAG: 'QSize', 'w': obj.width(), 'h': obj.height()}
+    if isinstance(obj, QPoint):
+        return {_TYPE_TAG: 'QPoint', 'x': obj.x(), 'y': obj.y()}
+    if isinstance(obj, QColor):
+        return {_TYPE_TAG: 'QColor',
+                'rgba': [obj.red(), obj.green(), obj.blue(), obj.alpha()]}
+    if isinstance(obj, QByteArray):
+        return {_TYPE_TAG: 'QByteArray',
+                'b64': bytes(obj.toBase64()).decode('ascii')}
+    if isinstance(obj, Enum):
+        return {_TYPE_TAG: 'Enum', 'cls': type(obj).__name__, 'value': obj.value}
+    raise TypeError('Object of type %s is not JSON serializable'
+                    % type(obj).__name__)
+
+
+def _decode(dct):
+    """json.load ``object_hook``: rebuild tagged Qt/enum values."""
+    tag = dct.get(_TYPE_TAG)
+    if tag is None:
+        return dct
+    if tag == 'QSize':
+        return QSize(dct['w'], dct['h'])
+    if tag == 'QPoint':
+        return QPoint(dct['x'], dct['y'])
+    if tag == 'QColor':
+        r, g, b, a = dct['rgba']
+        return QColor(r, g, b, a)
+    if tag == 'QByteArray':
+        return QByteArray.fromBase64(dct['b64'].encode('ascii'))
+    if tag == 'Enum':
+        cls = _enum_classes().get(dct.get('cls'))
+        if cls is not None:
+            try:
+                return cls(dct['value'])
+            except ValueError:
+                return None
+        return dct.get('value')
+    return dct
 
 
 class Settings(object):
     def __init__(self):
-        # Be default, the home will be in the same folder as labelImg
+        # By default, the home will be in the same folder as labelImg
         home = os.path.expanduser("~")
         self.data = {}
-        self.path = os.path.join(home, '.labelImgSettings.pkl')
+        self.path = os.path.join(home, '.labelImgSettings.json')
 
     def __setitem__(self, key, value):
         self.data[key] = value
@@ -22,29 +88,32 @@ class Settings(object):
 
     def save(self):
         if self.path:
-            with open(self.path, 'wb') as f:
-                pickle.dump(self.data, f, pickle.HIGHEST_PROTOCOL)
+            with open(self.path, 'w', encoding='utf-8') as f:
+                json.dump(self.data, f, default=_encode, ensure_ascii=False)
                 return True
         return False
 
     def load(self):
         try:
             if os.path.exists(self.path):
-                with open(self.path, 'rb') as f:
-                    self.data = pickle.load(f)
+                with open(self.path, 'r', encoding='utf-8') as f:
+                    self.data = json.load(f, object_hook=_decode)
                     return True
-        except (pickle.UnpicklingError, EOFError, AttributeError) as e:
-            print(f'Settings file corrupted, using defaults: {e}')
+        except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as e:
+            # Covers a corrupt JSON file as well as a legacy pickle file left
+            # over from older versions (its binary bytes are not valid UTF-8
+            # JSON, so it is rejected here and never deserialized/executed).
+            print(f'Settings file corrupted or legacy, using defaults: {e}')
             self.data = {}
-        except IOError as e:
+        except OSError as e:
             print(f'Could not read settings file: {e}')
         except Exception as e:
             print(f'Unexpected error loading settings: {e}')
         return False
 
     def reset(self):
-        if os.path.exists(self.path):
+        if self.path and os.path.exists(self.path):
             os.remove(self.path)
-            print('Remove setting pkl file ${0}'.format(self.path))
+            print('Removed settings file {0}'.format(self.path))
         self.data = {}
-        self.path = None
+        # Keep self.path so settings can still be persisted after a reset.

--- a/libs/core/shape.py
+++ b/libs/core/shape.py
@@ -301,8 +301,8 @@ class Shape(object):
         self._highlight_index = None
 
     def copy(self):
-        shape = Shape("%s" % self.label, shape_type=self.shape_type)
-        shape.points = [p for p in self.points]
+        shape = Shape(self.label, shape_type=self.shape_type)
+        shape.points = [QPointF(p.x(), p.y()) for p in self.points]
         shape.fill = self.fill
         shape.selected = self.selected
         shape._closed = self._closed

--- a/libs/data/predefined_classes.txt
+++ b/libs/data/predefined_classes.txt
@@ -1,0 +1,15 @@
+dog
+person
+cat
+tv
+car
+meatballs
+marinara sauce
+tomato soup
+chicken noodle soup
+french onion soup
+chicken breast
+ribs
+pulled pork
+hamburger
+cavity

--- a/libs/formats/coco_io.py
+++ b/libs/formats/coco_io.py
@@ -164,23 +164,29 @@ class COCOReader:
         target_image_id = None
         if target_filename:
             for img in images:
-                if img['file_name'] == target_filename:
-                    target_image_id = img['id']
+                if img.get('file_name') == target_filename:
+                    target_image_id = img.get('id')
                     break
         if target_image_id is None and images:
-            target_image_id = images[0]['id']
+            target_image_id = images[0].get('id')
 
         for ann in data.get('annotations', []):
             if ann.get('image_id') != target_image_id:
                 continue
 
-            label = cat_map.get(ann['category_id'], 'unknown')
+            # Untrusted file: skip annotations missing required fields rather
+            # than raising KeyError/IndexError/ValueError to the caller.
+            cat_id = ann.get('category_id')
+            if cat_id is None:
+                continue
+            label = cat_map.get(cat_id, 'unknown')
             difficult = bool(ann.get('difficult', 0))
 
-            # Parse keypoints if present.
+            # Parse keypoints if present. COCO keypoints are a flat list of
+            # (x, y, v) triples; a length not divisible by 3 is malformed.
             kp_data = None
-            if 'keypoints' in ann and ann['keypoints']:
-                flat = ann['keypoints']
+            flat = ann.get('keypoints')
+            if flat and len(flat) % 3 == 0:
                 kp_data = []
                 for i in range(0, len(flat), 3):
                     x, y, v = flat[i], flat[i + 1], flat[i + 2]
@@ -189,14 +195,18 @@ class COCOReader:
                     else:
                         kp_data.append((x, y, int(v)))
 
-            if 'segmentation' in ann and ann['segmentation']:
-                seg = ann['segmentation'][0]
-                points = [(seg[i], seg[i + 1]) for i in range(0, len(seg), 2)]
+            segmentation = ann.get('segmentation')
+            if segmentation:
+                seg = segmentation[0]
+                points = [(seg[i], seg[i + 1])
+                          for i in range(0, len(seg) - 1, 2)]
                 self.shapes.append(
                     (label, points, None, None, difficult, 'polygon', None))
             else:
-                bbox = ann['bbox']  # [x, y, w, h]
-                x, y, w, h = bbox
+                bbox = ann.get('bbox')  # [x, y, w, h]
+                if not bbox or len(bbox) < 4:
+                    continue
+                x, y, w, h = bbox[0], bbox[1], bbox[2], bbox[3]
                 points = [(x, y), (x + w, y), (x + w, y + h), (x, y + h)]
                 self.shapes.append(
                     (label, points, None, None, difficult, 'rectangle', kp_data))

--- a/libs/formats/create_ml_io.py
+++ b/libs/formats/create_ml_io.py
@@ -95,16 +95,29 @@ class CreateMLReader:
         with open(self.json_path, "r") as file:
             input_data = file.read()
 
-        # Returns a list
         output_list = json.loads(input_data)
 
-        if output_list:
+        # A CreateML file is a JSON array of image objects; anything else is
+        # malformed. Fail with a clear error instead of an opaque TypeError.
+        if not isinstance(output_list, list):
+            raise ValueError("CreateML annotation file must be a JSON array")
+
+        if output_list and isinstance(output_list[0], dict):
             self.verified = output_list[0].get("verified", False)
 
         for image in output_list:
-            if image["image"] == self.filename:
-                for shape in image["annotations"]:
-                    self.add_shape(shape["label"], shape["coordinates"])
+            if not isinstance(image, dict):
+                continue
+            if image.get("image") == self.filename:
+                for shape in image.get("annotations", []):
+                    label = shape.get("label")
+                    coords = shape.get("coordinates")
+                    if label is None or not isinstance(coords, dict):
+                        continue
+                    if not all(k in coords
+                               for k in ("x", "y", "width", "height")):
+                        continue
+                    self.add_shape(label, coords)
 
     def add_shape(self, label, bnd_box):
         x_min = bnd_box["x"] - (bnd_box["width"] / 2)

--- a/libs/formats/labelFile.py
+++ b/libs/formats/labelFile.py
@@ -210,13 +210,14 @@ class LabelFile(object):
             x_max = max(x, x_max)
             y_max = max(y, y_max)
 
-        # Martin Kersner, 2015/11/12
-        # 0-valued coordinates of BB caused an error while
-        # training faster-rcnn object detector.
-        if x_min < 1:
-            x_min = 1
+        # Clamp off-image (negative) origins to 0; edge-anchored boxes at the
+        # top-left pixel are legitimate and must be preserved. round() instead
+        # of int() keeps sub-pixel coordinates from drifting toward the origin
+        # on every save.
+        if x_min < 0:
+            x_min = 0
 
-        if y_min < 1:
-            y_min = 1
+        if y_min < 0:
+            y_min = 0
 
-        return int(x_min), int(y_min), int(x_max), int(y_max)
+        return round(x_min), round(y_min), round(x_max), round(y_max)

--- a/libs/formats/pascal_voc_io.py
+++ b/libs/formats/pascal_voc_io.py
@@ -182,7 +182,16 @@ class PascalVocReader:
 
     def parse_xml(self):
         assert self.file_path.endswith(XML_EXT), "Unsupported file format"
-        parser = etree.XMLParser(encoding=ENCODE_METHOD)
+        # Harden against entity-expansion DoS (billion-laughs) and external
+        # entity / network access (XXE). Annotation files travel with shared
+        # datasets and are untrusted input.
+        parser = etree.XMLParser(
+            encoding=ENCODE_METHOD,
+            resolve_entities=False,
+            no_network=True,
+            load_dtd=False,
+            huge_tree=False,
+        )
         xml_tree = ElementTree.parse(self.file_path, parser=parser).getroot()
         filename = xml_tree.find('filename').text
         try:

--- a/libs/formats/yolo_seg_io.py
+++ b/libs/formats/yolo_seg_io.py
@@ -79,8 +79,14 @@ class YOLOSegReader:
         else:
             self.class_list_path = class_list_path
 
-        with open(self.class_list_path, 'r') as f:
-            self.classes = f.read().strip('\n').split('\n')
+        try:
+            with open(self.class_list_path, 'r') as f:
+                self.classes = f.read().strip('\n').split('\n')
+        except FileNotFoundError:
+            raise FileNotFoundError(
+                f"classes.txt not found at: {self.class_list_path}\n"
+                "YOLO segmentation format requires a classes.txt file in the "
+                "same directory as annotations.")
 
         self.img_size = [image.height(), image.width(),
                          1 if image.isGrayscale() else 3]
@@ -103,7 +109,10 @@ class YOLOSegReader:
                 if len(parts) < 7:  # class + min 3 points (6 coords)
                     continue
 
-                class_idx = int(parts[0])
+                try:
+                    class_idx = int(parts[0])
+                except ValueError:
+                    continue  # malformed class index token
                 if class_idx < 0 or class_idx >= len(self.classes):
                     continue
 
@@ -112,11 +121,14 @@ class YOLOSegReader:
                 if len(coords) % 2 != 0:
                     continue
 
-                points = []
-                for i in range(0, len(coords), 2):
-                    x = round(float(coords[i]) * w)
-                    y = round(float(coords[i + 1]) * h)
-                    points.append((x, y))
+                try:
+                    points = []
+                    for i in range(0, len(coords), 2):
+                        x = round(float(coords[i]) * w)
+                        y = round(float(coords[i + 1]) * h)
+                        points.append((x, y))
+                except ValueError:
+                    continue  # malformed coordinate token
 
                 # Detect axis-aligned rectangles
                 if len(points) == 4:

--- a/libs/tools/dataset_splitter.py
+++ b/libs/tools/dataset_splitter.py
@@ -64,6 +64,11 @@ def split_dataset(image_list, ratios, seed=42, stratified=False,
     Returns:
         Dict with keys 'train', 'val', 'test', each a list of image paths.
     """
+    total = sum(ratios.get(k, 0) for k in ('train', 'val', 'test'))
+    if abs(total - 1.0) > 1e-6:
+        raise ValueError(
+            f"Split ratios must sum to 1.0 (got {total:.3f})")
+
     rng = random.Random(seed)
 
     if stratified:
@@ -100,8 +105,35 @@ def split_dataset(image_list, ratios, seed=42, stratified=False,
     }
 
 
+def _find_classes_file(save_dir, splits):
+    """Locate a classes.txt for YOLO splits (save_dir first, then image dirs)."""
+    candidates = []
+    if save_dir:
+        candidates.append(os.path.join(save_dir, 'classes.txt'))
+    for images in splits.values():
+        for img in images:
+            candidates.append(os.path.join(os.path.dirname(img), 'classes.txt'))
+    for path in candidates:
+        if os.path.isfile(path):
+            return path
+    return None
+
+
+def _place_file(src, dest, copy):
+    """Copy or symlink src->dest. Caller guarantees dest does not yet exist."""
+    if copy:
+        shutil.copy2(src, dest)
+    else:
+        os.symlink(os.path.abspath(src), dest)
+
+
 def execute_split(splits, output_dir, save_dir=None, copy=True):
     """Copy or symlink files into train/val/test directories.
+
+    Existing destination files are never overwritten (recorded under
+    ``skipped``), per-file failures are collected (under ``errors``) instead of
+    aborting the whole split, and a YOLO ``classes.txt`` is copied into each
+    split so the integer labels remain decodable.
 
     Args:
         splits: Dict from split_dataset().
@@ -110,38 +142,62 @@ def execute_split(splits, output_dir, save_dir=None, copy=True):
         copy: If True, copy files. If False, create symlinks.
 
     Returns:
-        Path to the generated manifest file.
+        Path to the generated manifest file (always written, even on failures).
     """
     manifest = {
         'created': datetime.now().isoformat(),
         'files': {},
+        'skipped': [],
+        'errors': [],
     }
+    classes_src = _find_classes_file(save_dir, splits)
 
-    for split_name, images in splits.items():
-        split_dir = os.path.join(output_dir, split_name)
-        os.makedirs(split_dir, exist_ok=True)
-        manifest['files'][split_name] = []
+    try:
+        for split_name, images in splits.items():
+            split_dir = os.path.join(output_dir, split_name)
+            os.makedirs(split_dir, exist_ok=True)
+            manifest['files'][split_name] = []
+            wrote_yolo = False
 
-        for img_path in images:
-            basename = os.path.basename(img_path)
-            dest = os.path.join(split_dir, basename)
+            for img_path in images:
+                dest = os.path.join(split_dir, os.path.basename(img_path))
+                if os.path.lexists(dest):
+                    manifest['skipped'].append(dest)  # never clobber
+                    continue
+                try:
+                    _place_file(img_path, dest, copy)
+                except OSError as e:
+                    manifest['errors'].append(
+                        {'file': img_path, 'error': str(e)})
+                    continue
 
-            if copy:
-                shutil.copy2(img_path, dest)
-            else:
-                os.symlink(os.path.abspath(img_path), dest)
+                manifest['files'][split_name].append(os.path.basename(img_path))
 
-            manifest['files'][split_name].append(basename)
+                ann = find_annotation_file(img_path, save_dir)
+                if ann:
+                    ann_dest = os.path.join(split_dir, os.path.basename(ann))
+                    if not os.path.lexists(ann_dest):
+                        try:
+                            _place_file(ann, ann_dest, copy)
+                        except OSError as e:
+                            manifest['errors'].append(
+                                {'file': ann, 'error': str(e)})
+                    if ann.endswith('.txt'):
+                        wrote_yolo = True
 
-            ann = find_annotation_file(img_path, save_dir)
-            if ann:
-                ann_dest = os.path.join(split_dir, os.path.basename(ann))
-                if copy:
-                    shutil.copy2(ann, ann_dest)
-                else:
-                    os.symlink(os.path.abspath(ann), ann_dest)
+            # YOLO labels are useless without their class map.
+            if wrote_yolo and classes_src:
+                classes_dest = os.path.join(split_dir, 'classes.txt')
+                if not os.path.lexists(classes_dest):
+                    try:
+                        shutil.copy2(classes_src, classes_dest)
+                    except OSError as e:
+                        manifest['errors'].append(
+                            {'file': classes_src, 'error': str(e)})
+    finally:
+        manifest_path = os.path.join(output_dir, 'split_manifest.json')
+        os.makedirs(output_dir, exist_ok=True)
+        with open(manifest_path, 'w') as f:
+            json.dump(manifest, f, indent=2)
 
-    manifest_path = os.path.join(output_dir, 'split_manifest.json')
-    with open(manifest_path, 'w') as f:
-        json.dump(manifest, f, indent=2)
     return manifest_path

--- a/libs/utils/utils.py
+++ b/libs/utils/utils.py
@@ -134,12 +134,12 @@ def generate_color_by_text(text):
 
 
 def have_qstring():
-    """p3/qt5 get rid of QString wrapper as py3 has native unicode str type"""
-    return not (sys.version_info.major >= 3 or QT_VERSION_STR.startswith('5.'))
+    """py3/qt5 have no QString wrapper; py3 has a native unicode str type."""
+    return False
 
 
 def util_qt_strlistclass():
-    return QStringList if have_qstring() else list
+    return list
 
 
 def natural_sort(list, key=lambda s:s):

--- a/libs/widgets/canvas.py
+++ b/libs/widgets/canvas.py
@@ -70,6 +70,10 @@ class Canvas(QWidget):
     # Emitted on keypoint placement / mutation with the pre-mutation
     # keypoints list (may be None) for undo support.
     keypointsEdited = pyqtSignal(object, object)        # (shape, old_keypoints)
+    # Emitted on mouse release after a non-polygon shape (rectangle) was moved
+    # or resized, with the pre-drag points list, so MainWindow can push a
+    # MoveShapeCommand. Polygon edits use polygonVerticesEdited instead.
+    shapeMoveFinished = pyqtSignal(object, object)      # (shape, old_points)
 
     CREATE, EDIT, CREATE_POLYGON, KEYPOINT_MODE = list(range(4))
 
@@ -138,6 +142,10 @@ class Canvas(QWidget):
         # vertex drag, so we can emit polygonVerticesEdited on release
         # if the drag actually changed any vertex position.
         self._polygon_drag_old_points = None
+
+        # Same idea for non-polygon (rectangle) shapes moved or resized by
+        # drag, emitted as shapeMoveFinished on release for undo support.
+        self._move_shape_old_points = None
 
     def set_drawing_color(self, qcolor):
         self.drawing_line_color = qcolor
@@ -464,6 +472,16 @@ class Canvas(QWidget):
                 and self.selected_shape.shape_type == ShapeType.POLYGON):
             self._polygon_drag_old_points = list(self.selected_shape.points)
 
+        # Snapshot non-polygon (rectangle) points before a potential body
+        # move or corner resize. Emitted as shapeMoveFinished on release if
+        # the drag actually changed the geometry.
+        self._move_shape_old_points = None
+        if (ev.button() == Qt.LeftButton
+                and self.selected_shape
+                and self.selected_shape.shape_type != ShapeType.POLYGON):
+            self._move_shape_old_points = [
+                QPointF(p.x(), p.y()) for p in self.selected_shape.points]
+
         # Keypoint placement
         if self.mode == self.KEYPOINT_MODE and self._keypoint_shape:
             kp_count = self._keypoint_count()
@@ -562,6 +580,7 @@ class Canvas(QWidget):
                     self.finalise()
             self._freehand_points = []
             self._polygon_drag_old_points = None
+            self._move_shape_old_points = None
             return
 
         # If a polygon was selected on press and any vertex moved during
@@ -580,8 +599,26 @@ class Canvas(QWidget):
             )
             if moved:
                 self._emit_polygon_edit(self.selected_shape, old_pts)
+
+        # Same for a non-polygon (rectangle) shape moved or resized during the
+        # drag: emit shapeMoveFinished so MainWindow can push a MoveShapeCommand.
+        if (ev.button() == Qt.LeftButton
+                and self._move_shape_old_points is not None
+                and self.selected_shape
+                and self.selected_shape.shape_type != ShapeType.POLYGON):
+            new_pts = self.selected_shape.points
+            old_pts = self._move_shape_old_points
+            moved = (
+                len(new_pts) != len(old_pts)
+                or any((a.x(), a.y()) != (b.x(), b.y())
+                       for a, b in zip(old_pts, new_pts))
+            )
+            if moved:
+                self.shapeMoveFinished.emit(self.selected_shape, old_pts)
+
         if ev.button() == Qt.LeftButton:
             self._polygon_drag_old_points = None
+            self._move_shape_old_points = None
 
         if ev.button() == Qt.RightButton:
             # Check if right-clicking a polygon vertex

--- a/libs/widgets/splitDialog.py
+++ b/libs/widgets/splitDialog.py
@@ -95,6 +95,9 @@ class SplitDialog(QDialog):
 
         self.setLayout(layout)
 
+        # Establish the initial enabled/label state now that run_btn exists.
+        self._sync_ratios()
+
     def _create_ratio_row(self, layout, label, default):
         """Create a labeled spin box row for a split ratio.
 
@@ -125,7 +128,14 @@ class SplitDialog(QDialog):
         self.test_spin.setValue(max(0, test))
         self.test_spin.blockSignals(False)
         total = train + val + max(0, test)
-        self.total_label.setText(f'Total: {total}%')
+        # Only train+val > 100 can push the total off 100%.
+        valid = (total == 100) and self._image_count > 0
+        if total != 100:
+            self.total_label.setText(f'Total: {total}% (must equal 100%)')
+        else:
+            self.total_label.setText(f'Total: {total}%')
+        if hasattr(self, 'run_btn'):
+            self.run_btn.setEnabled(valid)
         self._update_preview()
 
     def _update_preview(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = {file = "LICENSE"}
 authors = [
     {name = "Abhik Sarkar", email = "abhiksark@gmail.com"}
 ]
-requires-python = ">=3.6"
+requires-python = ">=3.8"
 keywords = ["labelImg", "labelimgpp", "labelimgplusplus", "annotation", "deeplearning", "image-annotation", "bounding-box", "gallery"]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -19,12 +19,11 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Scientific/Engineering :: Image Recognition",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,11 @@ def pytest_sessionfinish(session, exitstatus):
 
     for widget in list(app.topLevelWidgets()):
         try:
+            # A dirty MainWindow pops a modal "discard changes?" dialog from
+            # closeEvent, which blocks/segfaults under offscreen teardown.
+            # Tests are not real edit sessions, so suppress the prompt.
+            if hasattr(widget, 'dirty'):
+                widget.dirty = False
             widget.close()
             widget.deleteLater()
         except Exception:

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Tests for Settings class with proper isolation (uses temp files)."""
+import json
 import os
 import sys
 import tempfile
@@ -165,6 +166,87 @@ class TestSettingsEdgeCases(unittest.TestCase):
         nested = new_settings.get('nested')
         self.assertEqual(nested['level1']['level2']['list'], [1, 2, 3])
         self.assertEqual(nested['level1']['level2']['dict']['a'], 'b')
+
+
+class TestSettingsJsonMigration(unittest.TestCase):
+    """Settings must persist as JSON, never via pickle (arbitrary-code-exec)."""
+
+    def setUp(self):
+        self.temp_file = tempfile.NamedTemporaryFile(delete=False, suffix='.json')
+        self.temp_file.close()
+        self.settings = Settings()
+        self.settings.path = self.temp_file.name
+
+    def tearDown(self):
+        if os.path.exists(self.temp_file.name):
+            os.remove(self.temp_file.name)
+
+    def test_saved_file_is_valid_json(self):
+        """The on-disk settings file must be JSON text, not a pickle blob."""
+        self.settings['key'] = 'value'
+        self.settings['n'] = 7
+        self.settings.save()
+
+        with open(self.temp_file.name, 'r', encoding='utf-8') as f:
+            data = json.load(f)  # raises if the file is a pickle
+        self.assertEqual(data['key'], 'value')
+        self.assertEqual(data['n'], 7)
+
+    def test_load_does_not_execute_pickle_payload(self):
+        """A malicious legacy pickle must NOT execute code when load() runs."""
+        import pickle
+        sentinel = tempfile.mktemp(prefix='labelimg_pwned_')
+
+        class Exploit:
+            def __reduce__(self):
+                return (os.system, ('touch %s' % sentinel,))
+
+        with open(self.temp_file.name, 'wb') as f:
+            pickle.dump(Exploit(), f)
+
+        try:
+            self.settings.load()  # must not run the payload
+            self.assertFalse(
+                os.path.exists(sentinel),
+                'pickle payload executed - settings.load() is unsafe')
+        finally:
+            if os.path.exists(sentinel):
+                os.remove(sentinel)
+
+    def test_qt_types_roundtrip(self):
+        """QSize/QPoint/QColor/QByteArray/enum must survive a save/load cycle."""
+        from PyQt5.QtCore import QByteArray, QPoint, QSize
+        from PyQt5.QtGui import QColor
+        from libs.formats.labelFile import LabelFileFormat
+
+        self.settings['size'] = QSize(640, 480)
+        self.settings['pos'] = QPoint(12, 34)
+        self.settings['color'] = QColor(10, 20, 30, 200)
+        self.settings['state'] = QByteArray(b'\x00\x01\x02\xff')
+        self.settings['fmt'] = LabelFileFormat.YOLO
+        self.settings.save()
+
+        loaded = Settings()
+        loaded.path = self.temp_file.name
+        self.assertTrue(loaded.load())
+
+        self.assertEqual(loaded.get('size'), QSize(640, 480))
+        self.assertEqual(loaded.get('pos'), QPoint(12, 34))
+        self.assertEqual(loaded.get('color'), QColor(10, 20, 30, 200))
+        self.assertEqual(loaded.get('state'), QByteArray(b'\x00\x01\x02\xff'))
+        self.assertEqual(loaded.get('fmt'), LabelFileFormat.YOLO)
+
+    def test_reset_keeps_path_so_persistence_survives(self):
+        """reset() must not null the path (which would disable all saving)."""
+        self.settings['k'] = 'v'
+        self.settings.save()
+        self.settings.reset()
+
+        self.assertEqual(self.settings.data, {})
+        self.assertIsNotNone(self.settings.path)
+        # Persistence still works after reset.
+        self.settings['k2'] = 'v2'
+        self.assertTrue(self.settings.save())
 
 
 if __name__ == '__main__':

--- a/tests/core/test_shape.py
+++ b/tests/core/test_shape.py
@@ -303,6 +303,29 @@ class TestShapeCopy(unittest.TestCase):
         self.assertEqual(shape.label, 'original')
         self.assertEqual(shape[0].x(), 0)
 
+    def test_copy_points_are_distinct_objects(self):
+        """Copied points must not alias the originals (in-place mutation safe)."""
+        shape = Shape(label='original')
+        shape.add_point(QPointF(0, 0))
+        shape.add_point(QPointF(100, 100))
+
+        copied = shape.copy()
+        # Mutate a point of the copy IN PLACE.
+        copied[0].setX(999)
+
+        # The original's point must be unaffected.
+        self.assertEqual(shape[0].x(), 0)
+        self.assertIsNot(copied.points[0], shape.points[0])
+
+    def test_copy_of_unlabeled_shape_preserves_none_label(self):
+        """copy() of a label-less shape must keep label None, not the string 'None'."""
+        shape = Shape()  # label defaults to None
+        shape.add_point(QPointF(0, 0))
+
+        copied = shape.copy()
+
+        self.assertIsNone(copied.label)
+
     def test_copy_preserves_difficult(self):
         """Test that copy preserves difficult flag."""
         shape = Shape(difficult=True)

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -16,7 +16,8 @@ from PyQt5.QtCore import QPointF
 
 from libs.utils.utils import (
     Struct, new_action, new_icon, add_actions, format_shortcut,
-    generate_color_by_text, natural_sort, distance, trimmed
+    generate_color_by_text, natural_sort, distance, trimmed,
+    have_qstring, util_qt_strlistclass
 )
 
 # Create QApplication for tests
@@ -315,6 +316,16 @@ class TestAddActions(unittest.TestCase):
 
         # Menu should be added
         self.assertGreaterEqual(len(menubar.actions()), 1)
+
+
+class TestLegacyQtShims(unittest.TestCase):
+    """The py2/Qt4 compatibility shims must not reference undefined names."""
+
+    def test_have_qstring_is_false_on_py3(self):
+        self.assertIs(have_qstring(), False)
+
+    def test_util_qt_strlistclass_is_list(self):
+        self.assertIs(util_qt_strlistclass(), list)
 
 
 if __name__ == '__main__':

--- a/tests/formats/test_coco_io.py
+++ b/tests/formats/test_coco_io.py
@@ -91,6 +91,54 @@ class TestCOCOReader(unittest.TestCase):
         self.assertEqual(label, 'cat')
         self.assertEqual(shape_type, 'rectangle')
 
+    def _read(self, data, target='test.jpg'):
+        path = os.path.join(self.tmp_dir, 'annotations.json')
+        with open(path, 'w') as f:
+            json.dump(data, f)
+        return COCOReader(path, target)
+
+    def test_missing_category_id_does_not_crash(self):
+        """An annotation without category_id must be skipped, not KeyError."""
+        data = {
+            'images': [{'id': 1, 'file_name': 'test.jpg'}],
+            'annotations': [{'id': 1, 'image_id': 1, 'bbox': [1, 2, 3, 4]}],
+            'categories': [{'id': 1, 'name': 'cat'}],
+        }
+        reader = self._read(data)  # must not raise
+        self.assertEqual(reader.get_shapes(), [])
+
+    def test_malformed_bbox_does_not_crash(self):
+        """A bbox of the wrong arity must be skipped, not ValueError."""
+        data = {
+            'images': [{'id': 1, 'file_name': 'test.jpg'}],
+            'annotations': [{'id': 1, 'image_id': 1, 'category_id': 1,
+                             'bbox': [10, 20, 30]}],
+            'categories': [{'id': 1, 'name': 'cat'}],
+        }
+        reader = self._read(data)
+        self.assertEqual(reader.get_shapes(), [])
+
+    def test_keypoints_not_multiple_of_three_does_not_crash(self):
+        """A keypoints list whose length isn't a multiple of 3 must not IndexError."""
+        data = {
+            'images': [{'id': 1, 'file_name': 'test.jpg'}],
+            'annotations': [{'id': 1, 'image_id': 1, 'category_id': 1,
+                             'bbox': [10, 20, 30, 40], 'keypoints': [1, 2, 2, 3, 4]}],
+            'categories': [{'id': 1, 'name': 'cat'}],
+        }
+        reader = self._read(data)  # must not raise
+        self.assertEqual(len(reader.get_shapes()), 1)
+
+    def test_missing_file_name_does_not_crash(self):
+        """An image entry without file_name must not KeyError during matching."""
+        data = {
+            'images': [{'id': 1}],
+            'annotations': [],
+            'categories': [],
+        }
+        reader = self._read(data)  # must not raise
+        self.assertEqual(reader.get_shapes(), [])
+
     def test_read_polygon(self):
         data = {
             'images': [{'id': 1, 'file_name': 'test.jpg', 'width': 640, 'height': 480}],

--- a/tests/formats/test_io.py
+++ b/tests/formats/test_io.py
@@ -200,6 +200,44 @@ class TestPascalVocEdgeCases(unittest.TestCase):
         with self.assertRaises((ValueError, AttributeError, Exception)):
             PascalVocReader(xml_path)
 
+    def test_xml_entity_expansion_is_not_resolved(self):
+        """A malicious annotation must not trigger XML entity expansion (billion-laughs DoS).
+
+        The entity is placed in an object's <name>; a hardened parser must not
+        expand it (label stays small/empty rather than ballooning).
+        """
+        xml_path = os.path.join(self.temp_dir, 'bomb.xml')
+        with open(xml_path, 'w') as f:
+            f.write('''<?xml version="1.0"?>
+<!DOCTYPE annotation [
+  <!ENTITY a "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA">
+  <!ENTITY b "&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;">
+  <!ENTITY c "&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;">
+  <!ENTITY d "&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;">
+]>
+<annotation>
+    <filename>bomb.jpg</filename>
+    <size><width>100</width><height>100</height><depth>3</depth></size>
+    <object>
+        <name>&d;</name>
+        <bndbox><xmin>1</xmin><ymin>1</ymin><xmax>9</xmax><ymax>9</ymax></bndbox>
+    </object>
+</annotation>''')
+
+        # Either the parser refuses the DTD/entity (raises) or it reads the
+        # file without expanding the entity. Both are acceptable; an expanded
+        # 50k-char label is NOT.
+        try:
+            reader = PascalVocReader(xml_path)
+        except (ValueError, Exception):
+            return  # refusing the malicious DTD is a valid hardened outcome
+
+        for shape in reader.get_shapes():
+            label = shape[0] or ''
+            self.assertLess(
+                len(label), 1000,
+                'XML entity was expanded — parser is vulnerable to entity-expansion DoS')
+
     def test_read_nonexistent_file_raises_error(self):
         """Test reading non-existent XML file raises FileNotFoundError."""
         with self.assertRaises(FileNotFoundError):

--- a/tests/formats/test_io.py
+++ b/tests/formats/test_io.py
@@ -329,6 +329,28 @@ class TestCreateMLEdgeCases(unittest.TestCase):
         with self.assertRaises(FileNotFoundError):
             CreateMLReader('/nonexistent/path/file.json', 'folder/test.jpg')
 
+    def test_non_list_json_raises_value_error(self):
+        """A CreateML file must be a JSON array; a top-level object is a clean
+        ValueError, not an opaque 'string indices must be integers' TypeError."""
+        json_path = os.path.join(self.temp_dir, 'object.json')
+        with open(json_path, 'w') as f:
+            json.dump({'image': 'test.jpg', 'annotations': []}, f)
+
+        with self.assertRaises(ValueError):
+            CreateMLReader(json_path, 'folder/test.jpg')
+
+    def test_annotation_missing_keys_is_skipped(self):
+        """Annotations missing label/coordinates must be skipped, not KeyError."""
+        json_path = os.path.join(self.temp_dir, 'partial.json')
+        with open(json_path, 'w') as f:
+            json.dump([{'image': 'test.jpg', 'annotations': [
+                {'label': 'cat'},                       # no coordinates
+                {'coordinates': {'x': 1, 'y': 2, 'width': 3, 'height': 4}},  # no label
+            ]}], f)
+
+        reader = CreateMLReader(json_path, 'folder/test.jpg')  # must not raise
+        self.assertEqual(reader.get_shapes(), [])
+
     def test_write_with_no_shapes(self):
         """Test writing with empty shapes list."""
         json_path = os.path.join(self.temp_dir, 'no_shapes.json')

--- a/tests/formats/test_label_file.py
+++ b/tests/formats/test_label_file.py
@@ -43,22 +43,28 @@ class TestConvertPointsToBndBox(unittest.TestCase):
         self.assertIsInstance(result[2], int)
         self.assertIsInstance(result[3], int)
 
-    def test_zero_coordinate_clamped_to_one(self):
-        """Test that coordinates < 1 are clamped to 1."""
+    def test_subpixel_coordinates_are_rounded(self):
+        """Sub-pixel coordinates must round, not truncate toward zero."""
+        points = [(10.9, 20.4), (30.6, 20.4), (30.6, 40.8), (10.9, 40.8)]
+        result = LabelFile.convert_points_to_bnd_box(points)
+
+        self.assertEqual(result, (11, 20, 31, 41))
+
+    def test_zero_coordinate_preserved(self):
+        """An edge-anchored box at (0, 0) must be preserved, not shifted to 1."""
         points = [(0, 0), (50, 0), (50, 50), (0, 50)]
         result = LabelFile.convert_points_to_bnd_box(points)
 
-        # x_min and y_min should be clamped to 1
-        self.assertEqual(result[0], 1)  # x_min
-        self.assertEqual(result[1], 1)  # y_min
+        self.assertEqual(result[0], 0)  # x_min
+        self.assertEqual(result[1], 0)  # y_min
 
-    def test_negative_coordinate_clamped_to_one(self):
-        """Test that negative coordinates are clamped to 1."""
+    def test_negative_coordinate_clamped_to_zero(self):
+        """Negative coordinates clamp to 0 (off-image), not to 1."""
         points = [(-5, -10), (50, -10), (50, 50), (-5, 50)]
         result = LabelFile.convert_points_to_bnd_box(points)
 
-        self.assertEqual(result[0], 1)  # x_min clamped from -5
-        self.assertEqual(result[1], 1)  # y_min clamped from -10
+        self.assertEqual(result[0], 0)  # x_min clamped from -5
+        self.assertEqual(result[1], 0)  # y_min clamped from -10
 
     def test_single_point_box(self):
         """Test degenerate case of single point repeated."""

--- a/tests/formats/test_yolo_seg_io.py
+++ b/tests/formats/test_yolo_seg_io.py
@@ -74,6 +74,32 @@ class TestYOLOSegReader(unittest.TestCase):
         self.assertEqual(shape_type, 'rectangle')
         self.assertEqual(len(points), 4)
 
+    def test_missing_classes_file_raises_friendly_error(self):
+        """A missing classes.txt must raise FileNotFoundError mentioning it,
+        mirroring the plain YOLO reader (recoverable, not an opaque crash)."""
+        txt_path = os.path.join(self.tmp_dir, 'noclasses.txt')
+        with open(txt_path, 'w') as f:
+            f.write('0 0.1 0.1 0.9 0.1 0.9 0.9 0.1 0.9\n')
+        missing = os.path.join(self.tmp_dir, 'classes.txt')  # not created
+
+        with self.assertRaises(FileNotFoundError) as ctx:
+            YOLOSegReader(txt_path, self.image, missing)
+        self.assertIn('classes.txt', str(ctx.exception))
+
+    def test_malformed_tokens_are_skipped(self):
+        """Non-numeric class index or coordinates must skip the line, not crash."""
+        txt_path = os.path.join(self.tmp_dir, 'test.txt')
+        classes_path = os.path.join(self.tmp_dir, 'classes.txt')
+        with open(classes_path, 'w') as f:
+            f.write('cat\n')
+        with open(txt_path, 'w') as f:
+            f.write('x 0.1 0.1 0.9 0.1 0.9 0.9\n')          # bad class index
+            f.write('0 0.1 zz 0.9 0.1 0.9 0.9\n')           # bad coordinate
+            f.write('0 0.100 0.100 0.900 0.100 0.900 0.900 0.100 0.900\n')  # valid
+
+        reader = YOLOSegReader(txt_path, self.image, classes_path)  # must not raise
+        self.assertEqual(len(reader.get_shapes()), 1)
+
     def test_read_non_axis_aligned_quadrilateral(self):
         """4-point non-axis-aligned shapes remain polygons."""
         txt_path = os.path.join(self.tmp_dir, 'test.txt')

--- a/tests/integration/test_main_window.py
+++ b/tests/integration/test_main_window.py
@@ -89,6 +89,14 @@ class TestMainWindowFileOperations(unittest.TestCase):
         self.assertNotEqual(self.win.file_path, annot_path)
         mock_error.assert_called_once()
 
+    def test_default_predefined_classes_file_is_packaged(self):
+        """The default class list must ship inside the libs package so it is
+        present in the installed wheel (not just the source checkout)."""
+        import libs
+        packaged = os.path.join(os.path.dirname(libs.__file__),
+                                'data', 'predefined_classes.txt')
+        self.assertTrue(os.path.isfile(packaged))
+
     def test_apply_label_fix_does_not_crash(self):
         """_apply_label_fix must use statusBar(), not a missing status_bar attr.
 

--- a/tests/integration/test_main_window.py
+++ b/tests/integration/test_main_window.py
@@ -65,6 +65,30 @@ class TestMainWindowFileOperations(unittest.TestCase):
         # Should not crash, file_path should be unchanged or empty
         self.assertNotEqual(self.win.file_path, fake_path)
 
+    def test_load_file_on_annotation_file_does_not_crash(self):
+        """Opening an annotation file (suffix == LabelFile.suffix) must fail
+        gracefully, not crash.
+
+        Regression: the is_label_file branch in load_file referenced
+        LabelFile.lineColor (which does not exist) and left `image` unbound,
+        raising AttributeError/UnboundLocalError instead of reporting a clean
+        error.
+        """
+        from unittest.mock import patch
+        from libs.formats.labelFile import LabelFile
+        annot_path = os.path.join(self.temp_dir, 'annotation' + LabelFile.suffix)
+        with open(annot_path, 'w') as f:
+            f.write('<annotation><filename>x.jpg</filename></annotation>')
+
+        # error_message shows a modal QMessageBox; stub it so the test does
+        # not block, while still exercising the real load_file branch.
+        with patch.object(self.win, 'error_message') as mock_error:
+            result = self.win.load_file(annot_path)
+
+        self.assertFalse(result)
+        self.assertNotEqual(self.win.file_path, annot_path)
+        mock_error.assert_called_once()
+
     def test_load_predefined_classes_none_does_not_raise(self):
         """load_predefined_classes(None) must no-op, not raise TypeError.
 

--- a/tests/integration/test_main_window.py
+++ b/tests/integration/test_main_window.py
@@ -517,6 +517,41 @@ class TestMainWindowPolygonKeypointUndo(unittest.TestCase):
         self.win.undo_stack.undo()
         self.assertIsNone(shape.keypoints)
 
+    def test_rectangle_move_pushes_undoable_command(self):
+        """shapeMoveFinished -> pushes MoveShapeCommand, and undo restores the
+        rectangle's original position.
+
+        Regression: MoveShapeCommand was implemented, exported, imported and
+        unit-tested, but never wired into the app. Whole-shape (and rectangle
+        vertex) drags emitted shapeMoved -> set_dirty only, bypassing the undo
+        stack, so Ctrl+Z could not revert a moved box.
+        """
+        from libs.core.commands import MoveShapeCommand
+
+        shape = Shape(label='car')
+        shape.add_point(QPointF(10, 10))
+        shape.add_point(QPointF(50, 50))
+        shape.close()
+        self.win.canvas.shapes.append(shape)
+        self.win.add_label(shape)
+        self.win.canvas.selected_shape = shape
+
+        old = [QPointF(p.x(), p.y()) for p in shape.points]
+
+        # Simulate a completed body drag: the canvas moved the points, then
+        # reports the finished move on mouse release.
+        shape.move_by(QPointF(20, 0))
+        self.win.canvas.shapeMoveFinished.emit(shape, old)
+
+        self.assertTrue(self.win.undo_stack.can_undo())
+        self.assertIsInstance(self.win.undo_stack._undo_stack[-1], MoveShapeCommand)
+        self.assertEqual(shape.points[0].x(), 30)
+
+        self.win.undo_stack.undo()
+
+        self.assertEqual(shape.points[0].x(), 10)
+        self.assertEqual(shape.points[1].x(), 50)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/integration/test_main_window.py
+++ b/tests/integration/test_main_window.py
@@ -89,6 +89,32 @@ class TestMainWindowFileOperations(unittest.TestCase):
         self.assertNotEqual(self.win.file_path, annot_path)
         mock_error.assert_called_once()
 
+    def test_apply_label_fix_does_not_crash(self):
+        """_apply_label_fix must use statusBar(), not a missing status_bar attr.
+
+        Regression: it called self.status_bar.showMessage (no such attribute),
+        so the label-consistency fix path always raised AttributeError.
+        """
+        self.win.dir_name = self.temp_dir
+        self.win._apply_label_fix('old', 'new')  # must not raise
+
+    def test_reset_all_relaunches_with_python_interpreter(self):
+        """reset_all must relaunch through sys.executable, not exec the .py.
+
+        Regression: startDetached(os.path.abspath(__file__)) does not restart
+        an installed (entry-point) package.
+        """
+        from unittest.mock import patch
+        with patch.object(self.win, 'close'), \
+                patch.object(self.win.settings, 'reset'), \
+                patch('labelImgPlusPlus.QProcess') as mock_proc:
+            instance = mock_proc.return_value
+            self.win.reset_all()
+
+        instance.startDetached.assert_called_once()
+        args = instance.startDetached.call_args[0]
+        self.assertEqual(args[0], sys.executable)
+
     def test_load_predefined_classes_none_does_not_raise(self):
         """load_predefined_classes(None) must no-op, not raise TypeError.
 

--- a/tests/tools/test_dataset_splitter.py
+++ b/tests/tools/test_dataset_splitter.py
@@ -1,0 +1,104 @@
+# tests/tools/test_dataset_splitter.py
+"""Tests for dataset splitting and its data-safety guarantees."""
+
+import json
+import os
+import sys
+import tempfile
+import shutil
+import unittest
+
+dir_name = os.path.abspath(os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(dir_name, '..', '..'))
+
+from libs.tools.dataset_splitter import execute_split, split_dataset
+
+
+def _touch(path, content='x'):
+    with open(path, 'w') as f:
+        f.write(content)
+
+
+class TestExecuteSplitDataSafety(unittest.TestCase):
+
+    def setUp(self):
+        self.src = tempfile.mkdtemp()
+        self.out = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.src, ignore_errors=True)
+        shutil.rmtree(self.out, ignore_errors=True)
+
+    def _yolo_image(self, name):
+        img = os.path.join(self.src, name + '.jpg')
+        _touch(img)
+        _touch(os.path.join(self.src, name + '.txt'), '0 0.5 0.5 0.2 0.2\n')
+        return img
+
+    def test_classes_txt_copied_for_yolo_splits(self):
+        """classes.txt must be copied into each split dir so YOLO labels decode."""
+        imgs = [self._yolo_image('a'), self._yolo_image('b')]
+        _touch(os.path.join(self.src, 'classes.txt'), 'cat\ndog\n')
+        splits = {'train': [imgs[0]], 'val': [imgs[1]], 'test': []}
+
+        execute_split(splits, self.out, save_dir=self.src, copy=True)
+
+        self.assertTrue(os.path.isfile(os.path.join(self.out, 'train', 'classes.txt')))
+        self.assertTrue(os.path.isfile(os.path.join(self.out, 'val', 'classes.txt')))
+
+    def test_existing_destination_not_overwritten(self):
+        """A pre-existing destination file must not be clobbered."""
+        img = self._yolo_image('a')
+        os.makedirs(os.path.join(self.out, 'train'))
+        existing = os.path.join(self.out, 'train', 'a.jpg')
+        _touch(existing, 'ORIGINAL')
+
+        execute_split({'train': [img], 'val': [], 'test': []},
+                      self.out, save_dir=self.src, copy=True)
+
+        with open(existing) as f:
+            self.assertEqual(f.read(), 'ORIGINAL')  # untouched
+
+    def test_symlink_to_existing_destination_does_not_crash(self):
+        """Symlink mode with an existing destination must not raise FileExistsError."""
+        img = self._yolo_image('a')
+        os.makedirs(os.path.join(self.out, 'train'))
+        _touch(os.path.join(self.out, 'train', 'a.jpg'), 'ORIGINAL')
+
+        # Must not raise.
+        execute_split({'train': [img], 'val': [], 'test': []},
+                      self.out, save_dir=self.src, copy=False)
+
+    def test_partial_failure_is_recorded_not_raised(self):
+        """A missing source file must be recorded, not crash the whole split."""
+        good = self._yolo_image('good')
+        missing = os.path.join(self.src, 'gone.jpg')  # never created
+
+        manifest_path = execute_split(
+            {'train': [missing, good], 'val': [], 'test': []},
+            self.out, save_dir=self.src, copy=True)
+
+        self.assertTrue(os.path.isfile(manifest_path))
+        with open(manifest_path) as f:
+            manifest = json.load(f)
+        self.assertTrue(manifest.get('errors'))  # the missing file is recorded
+        # The good file still made it through.
+        self.assertTrue(os.path.isfile(os.path.join(self.out, 'train', 'good.jpg')))
+
+
+class TestSplitRatios(unittest.TestCase):
+
+    def test_rejects_ratios_that_do_not_sum_to_one(self):
+        """split_dataset must reject ratios that don't sum to 1.0."""
+        with self.assertRaises(ValueError):
+            split_dataset(['a.jpg', 'b.jpg'],
+                          {'train': 0.8, 'val': 0.8, 'test': 0.0})
+
+    def test_accepts_valid_ratios(self):
+        out = split_dataset(['a', 'b', 'c', 'd'],
+                            {'train': 0.5, 'val': 0.25, 'test': 0.25})
+        self.assertEqual(sum(len(v) for v in out.values()), 4)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/widgets/test_dialogs.py
+++ b/tests/widgets/test_dialogs.py
@@ -229,5 +229,33 @@ class TestLabelDialogCompleter(unittest.TestCase):
         self.assertEqual(model.rowCount(), 0)
 
 
+class TestSplitDialogValidation(unittest.TestCase):
+    """The split dialog must not accept ratios that don't sum to 100%."""
+
+    def test_run_disabled_when_ratios_exceed_100(self):
+        from libs.widgets.splitDialog import SplitDialog
+        dialog = SplitDialog(image_count=10)
+
+        dialog.train_spin.setValue(80)
+        dialog.val_spin.setValue(80)  # train+val = 160 -> invalid
+
+        self.assertFalse(dialog.run_btn.isEnabled())
+
+    def test_run_enabled_when_ratios_sum_to_100(self):
+        from libs.widgets.splitDialog import SplitDialog
+        dialog = SplitDialog(image_count=10)
+
+        dialog.train_spin.setValue(70)
+        dialog.val_spin.setValue(20)  # test auto -> 10, total 100
+
+        self.assertTrue(dialog.run_btn.isEnabled())
+
+    def test_run_disabled_when_no_images(self):
+        from libs.widgets.splitDialog import SplitDialog
+        dialog = SplitDialog(image_count=0)
+
+        self.assertFalse(dialog.run_btn.isEnabled())
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes from a detailed codebase review: all **5 Critical** items plus **7 High-severity** items. Each fix is test-first (red→green); the suite went from 471 → **503 passing** with no regressions. 12 atomic commits.

## Critical

- **Settings: pickle → JSON** (`libs/core/settings.py`) — `pickle.load` of `~/.labelImgSettings` ran arbitrary code at every startup (local code-execution vector). Now JSON with a small codec for the Qt value types + `LabelFileFormat`; a legacy `.pkl` is never deserialized. Also stopped `reset()` from nulling the path (which silently disabled all persistence).
- **VOC XML entity-expansion DoS** (`pascal_voc_io.py`) — hardened the lxml parser (`resolve_entities=False`, `no_network=True`, `load_dtd=False`, `huge_tree=False`). A tiny crafted `.xml` previously expanded to gigabytes.
- **`load_file` crash on annotation files** — the `is_label_file` branch referenced non-existent `LabelFile.lineColor`/`.fillColor` and left `image` unbound. Now reports a clear error.
- **Moving a box wasn't undoable** — `MoveShapeCommand` was implemented, exported, imported and unit-tested but never wired. Body-drags/rectangle resizes now push it (Ctrl+Z works).
- **`Shape.copy()` aliasing** — shallow-copied `QPointF` objects (silent corruption) and turned a `None` label into `"None"`. Now deep-copies points and preserves `None`.

## High

- **Format reader hardening** (COCO/YOLO-seg/CreateML) — malformed/untrusted files no longer raise raw `KeyError`/`IndexError`/`ValueError`/`TypeError`; missing `classes.txt` gives the same recoverable error as the plain YOLO reader.
- **`dataset_splitter` data-safety** — never overwrites existing files, collects per-file failures instead of aborting, always writes the manifest, copies `classes.txt` into YOLO splits, and symlink mode no longer crashes on an existing destination.
- **Split-ratio validation** — `split_dataset()` rejects ratios not summing to 1.0; the dialog disables Run unless ratios total 100% and at least one image exists (was silently producing an empty test set).
- **VOC coordinate data loss** — origin clamp `≥1`→`≥0` (preserves edge-anchored boxes) and `round()` instead of `int()` (stops sub-pixel drift toward the origin). *Note: changes the documented faster-rcnn `(0,0)→(1,1)` workaround — intentional, agreed with maintainer.*
- **Label-fix crash + Reset All relaunch** — `_apply_label_fix` used a non-existent `self.status_bar`; `reset_all` relaunched the `.py` directly instead of via `sys.executable` (broken for installed packages).
- **Dead py2/Qt4 shims** — `have_qstring`/`util_qt_strlistclass` referenced undefined names; collapsed to their py3 results.
- **Packaging** — `data/predefined_classes.txt` was never shipped in the wheel (lived outside any package); now ships as `libs/data/predefined_classes.txt` (verified in the built wheel) with a runtime fallback. `requires-python` set to `>=3.8`; classifiers aligned (drop 3.6/3.7, add 3.12).

## Test infra

- Session teardown clears the dirty flag before closing widgets so a modal "discard changes?" dialog no longer blocks/segfaults offscreen subset runs.

## Verification

`QT_QPA_PLATFORM=offscreen pytest tests/` → **503 passed, 0 failed**. The packaging fix was verified by building the wheel and confirming the data file is present.

## Out of scope (follow-ups)

VOC polygon sub-pixel truncation, the quadruplicated annotation-probe refactor, and the Medium theme-consistency / paintEvent-perf items from the review.
