### PR TITLE
fix: medium-tier theme consistency, keypoint hit-test, and paint perf

### DIFF
--- a/labelImgPlusPlus.py
+++ b/labelImgPlusPlus.py
@@ -3637,6 +3637,10 @@ class MainWindow(QMainWindow, WindowMixin):
         """Apply the given theme to all components."""
         from libs.utils.styles import get_toolbar_style, get_theme_colors
 
+        # Resolve the palette once up front; several blocks below (including
+        # the save-status refresh) read it regardless of which widgets exist.
+        colors = get_theme_colors(theme)
+
         # Apply main stylesheet
         self.setStyleSheet(get_stylesheet(theme))
 
@@ -3655,7 +3659,6 @@ class MainWindow(QMainWindow, WindowMixin):
 
         # Update scroll area viewport background
         if hasattr(self, 'scroll_area') and self.scroll_area:
-            colors = get_theme_colors(theme)
             self.scroll_area.viewport().setStyleSheet(
                 f"background-color: {colors['background']};"
             )

--- a/libs/utils/styles.py
+++ b/libs/utils/styles.py
@@ -27,6 +27,7 @@ LIGHT_COLORS = {
     'warning': '#fbbc04',
     'error': '#ea4335',
     'verified_bg': '#b8ef26',  # Bright green overlay for verified images
+    'canvas_bg': '#e0e0e0',    # Canvas viewport background
     'placeholder': '#dcdcdc',  # Light gray for placeholders
     'item_bg': '#f0f0f0',      # Very light gray for item backgrounds
     'status_saved': '#34a853',   # Green
@@ -60,6 +61,7 @@ DARK_COLORS = {
     'warning': '#ff9800',
     'error': '#f44336',
     'verified_bg': '#4caf50',  # Slightly muted green for dark theme
+    'canvas_bg': '#2d2d2d',    # Canvas viewport background
     'placeholder': '#3d3d3d',  # Dark gray for placeholders
     'item_bg': '#2d2d2d',      # Darker gray for item backgrounds
     'status_saved': '#4caf50',   # Slightly brighter green
@@ -459,7 +461,7 @@ QStatusBar QLabel {{
 
 def get_canvas_background(theme: Theme) -> str:
     """Get canvas background color for the given theme."""
-    return '#2d2d2d' if theme == Theme.DARK else '#e0e0e0'
+    return _get_colors(theme)['canvas_bg']
 
 
 def get_slider_style(theme: Theme) -> str:

--- a/libs/widgets/canvas.py
+++ b/libs/widgets/canvas.py
@@ -90,6 +90,10 @@ class Canvas(QWidget):
         self.offsets = QPointF(), QPointF()
         self.scale = 1.0
         self.overlay_color = None
+        # Cache for the overlay-composited pixmap so paintEvent does not copy
+        # and re-composite the full-resolution image on every repaint.
+        self._overlay_cache = None
+        self._overlay_cache_key = None
         self.label_font_size = 8
         self.pixmap = QPixmap()
         self.visible = {}
@@ -278,15 +282,7 @@ class Canvas(QWidget):
 
         # Keypoint hover detection
         if self.mode == self.KEYPOINT_MODE and self._keypoint_shape:
-            self._hovered_keypoint = -1
-            kps = self._keypoint_shape.keypoints
-            if kps:
-                for i, kp in enumerate(kps):
-                    if kp is not None and kp[2] > 0:
-                        dist = distance(QPointF(kp[0], kp[1]) - pos)
-                        if dist < self.epsilon / 2:
-                            self._hovered_keypoint = i
-                            break
+            self._hovered_keypoint = self._keypoint_at(pos)
             self.update()
 
         # Polygon drawing.
@@ -452,6 +448,23 @@ class Canvas(QWidget):
                     self.update()
                 self.h_vertex, self.h_shape = None, None
                 self.override_cursor(CURSOR_DEFAULT)
+
+    def _keypoint_at(self, pos):
+        """Index of the placed keypoint within hover range of image-space pos.
+
+        ``epsilon`` is a screen-pixel radius, so divide it by the current zoom
+        to get an image-space threshold that stays constant on screen.
+        """
+        shape = self._keypoint_shape
+        # NB: `not shape` would call Shape.__len__ (point count), so test None.
+        if shape is None or not shape.keypoints:
+            return -1
+        threshold = (self.epsilon / 2) / max(self.scale, 1e-6)
+        for i, kp in enumerate(shape.keypoints):
+            if kp is not None and kp[2] > 0:
+                if distance(QPointF(kp[0], kp[1]) - pos) < threshold:
+                    return i
+        return -1
 
     def mousePressEvent(self, ev):
         pos = self.transform_pos(ev.pos())
@@ -1013,15 +1026,7 @@ class Canvas(QWidget):
         p.scale(self.scale, self.scale)
         p.translate(self.offset_to_center())
 
-        temp = self.pixmap
-        if self.overlay_color:
-            temp = QPixmap(self.pixmap)
-            painter = QPainter(temp)
-            painter.setCompositionMode(painter.CompositionMode_Overlay)
-            painter.fillRect(temp.rect(), self.overlay_color)
-            painter.end()
-
-        p.drawPixmap(0, 0, temp)
+        p.drawPixmap(0, 0, self._composited_pixmap())
         Shape.scale = self.scale
         Shape.label_font_size = self.label_font_size
         for shape in self.shapes:
@@ -1276,6 +1281,26 @@ class Canvas(QWidget):
         self.current = None
         self.drawingPolygon.emit(False)
         self.update()
+
+    def _composited_pixmap(self):
+        """Return the pixmap with overlay_color composited on top.
+
+        The result is cached and only rebuilt when the pixmap content
+        (``cacheKey``) or the overlay color changes, so a full-resolution
+        copy + composite does not happen on every repaint.
+        """
+        if not self.overlay_color or self.pixmap is None:
+            return self.pixmap
+        key = (self.pixmap.cacheKey(), self.overlay_color.rgba())
+        if self._overlay_cache_key != key:
+            composited = QPixmap(self.pixmap)
+            painter = QPainter(composited)
+            painter.setCompositionMode(QPainter.CompositionMode_Overlay)
+            painter.fillRect(composited.rect(), self.overlay_color)
+            painter.end()
+            self._overlay_cache = composited
+            self._overlay_cache_key = key
+        return self._overlay_cache
 
     def load_pixmap(self, pixmap):
         self.pixmap = pixmap

--- a/libs/widgets/galleryWidget.py
+++ b/libs/widgets/galleryWidget.py
@@ -397,10 +397,12 @@ class GalleryWidget(QWidget):
 
             layout.addWidget(self._slider_frame)
 
-            # Apply initial theme
-            self.apply_theme(Theme.LIGHT)
-
         layout.addWidget(self.list_widget)
+
+        # Theme the gallery regardless of whether the size slider is shown,
+        # otherwise the list widget and status/placeholder colors keep their
+        # light-mode defaults under the dark theme.
+        self.apply_theme(self._current_theme)
 
     def _apply_icon_size(self):
         """Apply current icon size to list widget."""

--- a/libs/widgets/keypointPanel.py
+++ b/libs/widgets/keypointPanel.py
@@ -6,7 +6,7 @@ from PyQt5.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QLabel,
 from PyQt5.QtCore import pyqtSignal, Qt
 
 from libs.core.keypoint_config import get_keypoint_color, get_template
-from libs.utils.styles import get_theme_colors
+from libs.utils.styles import Theme, get_theme_colors
 
 
 class KeypointPanel(QWidget):
@@ -21,6 +21,9 @@ class KeypointPanel(QWidget):
         self._current_index = -1
         self._template_name = None
         self._template = None
+        # Active theme palette; status glyph colors are sourced from it so
+        # they re-theme instead of being hardcoded.
+        self._colors = get_theme_colors(Theme.LIGHT)
         self._layout = QVBoxLayout(self)
         self._layout.setContentsMargins(4, 4, 4, 4)
         self._layout.setSpacing(2)
@@ -87,23 +90,26 @@ class KeypointPanel(QWidget):
         self._keypoints = keypoints
         total = len(self._rows)
         placed = 0
+        missing = 'color: %s;' % self._colors['text_disabled']
         for i, row in enumerate(self._rows):
             if keypoints is None or i >= len(keypoints) or keypoints[i] is None:
                 row['status'].setText('\u25cb')
-                row['status'].setStyleSheet('color: #888;')
+                row['status'].setStyleSheet(missing)
             else:
                 v = keypoints[i][2]
                 if v == 2:
                     row['status'].setText('\u25cf')
-                    row['status'].setStyleSheet('color: #4caf50;')
+                    row['status'].setStyleSheet(
+                        'color: %s;' % self._colors['success'])
                     placed += 1
                 elif v == 1:
                     row['status'].setText('\u25cc')
-                    row['status'].setStyleSheet('color: #ff9800;')
+                    row['status'].setStyleSheet(
+                        'color: %s;' % self._colors['warning'])
                     placed += 1
                 else:
                     row['status'].setText('\u2014')
-                    row['status'].setStyleSheet('color: #888;')
+                    row['status'].setStyleSheet(missing)
         self._count_label.setText('%d/%d placed' % (placed, total))
 
     def set_current_index(self, index):
@@ -118,9 +124,12 @@ class KeypointPanel(QWidget):
 
     def apply_theme(self, theme):
         """Apply theme styling."""
-        colors = get_theme_colors(theme)
+        self._colors = get_theme_colors(theme)
         self._count_label.setStyleSheet(
-            'color: %s;' % colors['text_secondary'])
+            'color: %s;' % self._colors['text_secondary'])
+        # Repaint existing rows so status colors follow the new theme.
+        self.set_keypoints(self._keypoints)
+        self.set_current_index(self._current_index)
 
     def clear(self):
         """Reset panel to empty state."""
@@ -128,7 +137,8 @@ class KeypointPanel(QWidget):
         self._current_index = -1
         for row in self._rows:
             row['status'].setText('\u25cb')
-            row['status'].setStyleSheet('color: #888;')
+            row['status'].setStyleSheet(
+                'color: %s;' % self._colors['text_disabled'])
             row['button'].setStyleSheet('')
         total = len(self._rows)
         self._count_label.setText('0/%d placed' % total)

--- a/libs/widgets/shortcutsDialog.py
+++ b/libs/widgets/shortcutsDialog.py
@@ -6,7 +6,8 @@ from PyQt5.QtWidgets import (
     QPushButton, QHeaderView, QKeySequenceEdit, QMessageBox, QFileDialog
 )
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QColor
+
+from libs.utils.styles import Theme, get_theme_colors, hex_to_qcolor
 
 
 class ShortcutsDialog(QDialog):
@@ -17,6 +18,7 @@ class ShortcutsDialog(QDialog):
         self.config = shortcut_config
         self.action_map = action_map  # {action_name: QAction}
         self._pending = dict(shortcut_config.get_all())
+        self._theme = Theme.LIGHT
 
         layout = QVBoxLayout()
 
@@ -74,7 +76,8 @@ class ShortcutsDialog(QDialog):
             # Default (read-only, gray)
             default_item = QTableWidgetItem(self.config.get_default(name))
             default_item.setFlags(default_item.flags() & ~Qt.ItemIsEditable)
-            default_item.setForeground(QColor(150, 150, 150))
+            colors = get_theme_colors(self._theme)
+            default_item.setForeground(hex_to_qcolor(colors['text_secondary']))
             self.table.setItem(row, 2, default_item)
 
     def _on_shortcut_changed(self, row, action_name, key_sequence):
@@ -90,7 +93,9 @@ class ShortcutsDialog(QDialog):
         # Highlight conflict
         widget = self.table.cellWidget(row, 1)
         if conflict:
-            widget.setStyleSheet('background-color: #ffcccc;')
+            colors = get_theme_colors(self._theme)
+            widget.setStyleSheet(
+                'background-color: %s;' % colors['issue_typo'])
             widget.setToolTip(f'Conflicts with: {conflict}')
         else:
             widget.setStyleSheet('')
@@ -140,4 +145,7 @@ class ShortcutsDialog(QDialog):
 
     def apply_theme(self, theme):
         from libs.utils.styles import get_stylesheet
+        self._theme = theme
         self.setStyleSheet(get_stylesheet(theme))
+        # Re-render rows so the themed default-shortcut color is applied.
+        self._refresh_table()

--- a/tests/integration/test_main_window.py
+++ b/tests/integration/test_main_window.py
@@ -58,6 +58,19 @@ class TestMainWindowFileOperations(unittest.TestCase):
         self.assertEqual(self.win.file_path, self.test_image_path)
         self.assertFalse(self.win.image.isNull())
 
+    def test_apply_theme_without_scroll_area_does_not_raise(self):
+        """_apply_theme must not NameError when scroll_area is absent.
+
+        Regression: `colors` was only bound inside the scroll_area block but
+        referenced later in the save-status refresh.
+        """
+        saved = self.win.scroll_area
+        self.win.scroll_area = None
+        try:
+            self.win._apply_theme(self.win._current_theme)  # must not raise
+        finally:
+            self.win.scroll_area = saved
+
     def test_load_file_nonexistent(self):
         """Test loading a non-existent file."""
         fake_path = os.path.join(self.temp_dir, 'nonexistent.png')

--- a/tests/utils/test_styles.py
+++ b/tests/utils/test_styles.py
@@ -1,8 +1,22 @@
 import sys
 from PyQt5.QtWidgets import QApplication
-from libs.utils.styles import hex_to_qcolor
+from libs.utils.styles import (
+    hex_to_qcolor, get_canvas_background, get_theme_colors,
+    LIGHT_COLORS, DARK_COLORS, Theme,
+)
 
-app = QApplication(sys.argv)
+app = QApplication.instance() or QApplication(sys.argv)
+
+
+def test_canvas_background_comes_from_palette():
+    # The canvas background must be sourced from the palette, not a literal.
+    for theme in (Theme.LIGHT, Theme.DARK):
+        assert get_canvas_background(theme) == get_theme_colors(theme)['canvas_bg']
+
+
+def test_palette_keys_match():
+    # theme-audit invariant: light and dark palettes have identical keys.
+    assert set(LIGHT_COLORS) == set(DARK_COLORS)
 
 def test_hex_to_qcolor():
     # Test with # prefix

--- a/tests/widgets/test_canvas.py
+++ b/tests/widgets/test_canvas.py
@@ -500,5 +500,49 @@ class TestCanvasEditSignals(unittest.TestCase):
         self.assertIsNone(received[0][1])
 
 
+class TestOverlayPixmapCache(unittest.TestCase):
+    """The overlay composite must be cached, not rebuilt every paint."""
+
+    def test_overlay_pixmap_cached_until_inputs_change(self):
+        canvas = Canvas()
+        canvas.load_pixmap(QPixmap(50, 50))
+        canvas.overlay_color = QColor(255, 0, 0, 128)
+
+        first = canvas._composited_pixmap()
+        again = canvas._composited_pixmap()
+        self.assertIs(again, first)  # reused, not recomposited
+
+        canvas.overlay_color = QColor(0, 255, 0, 128)
+        self.assertIsNot(canvas._composited_pixmap(), first)  # rebuilt
+
+    def test_no_overlay_returns_base_pixmap(self):
+        canvas = Canvas()
+        canvas.load_pixmap(QPixmap(10, 10))
+        canvas.overlay_color = None
+        self.assertIs(canvas._composited_pixmap(), canvas.pixmap)
+
+
+class TestKeypointHitTest(unittest.TestCase):
+    """Keypoint hover hit-test must scale with zoom (screen-space radius)."""
+
+    def _canvas_with_keypoint(self):
+        canvas = Canvas()
+        shape = Shape(shape_type=ShapeType.POLYGON)
+        shape.keypoints = [(100.0, 100.0, 2)]
+        canvas._keypoint_shape = shape
+        return canvas
+
+    def test_hit_within_threshold_at_unit_scale(self):
+        canvas = self._canvas_with_keypoint()
+        canvas.scale = 1.0  # threshold = epsilon/2 = 12 image px
+        self.assertEqual(canvas._keypoint_at(QPointF(108, 100)), 0)  # 8 < 12
+
+    def test_threshold_shrinks_when_zoomed_in(self):
+        canvas = self._canvas_with_keypoint()
+        canvas.scale = 4.0  # threshold = 12 / 4 = 3 image px
+        self.assertEqual(canvas._keypoint_at(QPointF(108, 100)), -1)  # 8 > 3
+        self.assertEqual(canvas._keypoint_at(QPointF(101, 100)), 0)   # 1 < 3
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/widgets/test_dialogs.py
+++ b/tests/widgets/test_dialogs.py
@@ -229,5 +229,21 @@ class TestLabelDialogCompleter(unittest.TestCase):
         self.assertEqual(model.rowCount(), 0)
 
 
+class TestShortcutsDialogTheme(unittest.TestCase):
+    """The shortcuts dialog must source its colors from the palette."""
+
+    def test_default_shortcut_color_is_themed(self):
+        from libs.widgets.shortcutsDialog import ShortcutsDialog
+        from libs.core.shortcut_config import ShortcutConfig
+        from libs.utils.styles import Theme, get_theme_colors, hex_to_qcolor
+
+        dialog = ShortcutsDialog(ShortcutConfig(), {})
+        dialog.apply_theme(Theme.LIGHT)
+
+        fg = dialog.table.item(0, 2).foreground().color()
+        expected = hex_to_qcolor(get_theme_colors(Theme.LIGHT)['text_secondary'])
+        self.assertEqual(fg, expected)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/widgets/test_gallery.py
+++ b/tests/widgets/test_gallery.py
@@ -5,10 +5,15 @@ import tempfile
 import shutil
 import unittest
 
+if 'QT_QPA_PLATFORM' not in os.environ:
+    os.environ['QT_QPA_PLATFORM'] = 'offscreen'
+
 dir_name = os.path.abspath(os.path.dirname(__file__))
 libs_path = os.path.join(dir_name, '..', '..', 'libs')
 sys.path.insert(0, libs_path)
 sys.path.insert(0, os.path.join(dir_name, '..', '..'))
+
+from PyQt5.QtWidgets import QApplication
 
 from libs.widgets.galleryWidget import (
     find_annotation_file,
@@ -16,7 +21,10 @@ from libs.widgets.galleryWidget import (
     parse_voc_annotations,
     ThumbnailCache,
     AnnotationStatus,
+    GalleryWidget,
 )
+
+app = QApplication.instance() or QApplication(sys.argv)
 
 
 class TestFindAnnotationFile(unittest.TestCase):
@@ -417,6 +425,24 @@ class TestAnnotationStatus(unittest.TestCase):
         self.assertEqual(AnnotationStatus.NO_LABELS, 0)
         self.assertEqual(AnnotationStatus.HAS_LABELS, 1)
         self.assertEqual(AnnotationStatus.VERIFIED, 2)
+
+
+class TestGalleryTheme(unittest.TestCase):
+    """The gallery must theme itself regardless of the size slider."""
+
+    def test_list_widget_themed_without_size_slider(self):
+        """Without the size slider, the list widget must still be themed
+        at construction (apply_theme must not be gated on the slider)."""
+        gallery = GalleryWidget(show_size_slider=False)
+        self.assertNotEqual(gallery.list_widget.styleSheet().strip(), '')
+
+    def test_status_colors_match_dark_palette(self):
+        """Status border colors must follow the active theme."""
+        from libs.utils.styles import Theme, get_theme_colors, hex_to_qcolor
+        gallery = GalleryWidget(show_size_slider=False)
+        gallery.apply_theme(Theme.DARK)
+        expected = hex_to_qcolor(get_theme_colors(Theme.DARK)['status_verified'])
+        self.assertEqual(gallery._status_colors[AnnotationStatus.VERIFIED], expected)
 
 
 if __name__ == '__main__':

--- a/tests/widgets/test_keypoint_panel.py
+++ b/tests/widgets/test_keypoint_panel.py
@@ -1,0 +1,46 @@
+"""Tests for the keypoint checklist panel theming."""
+import os
+import sys
+import unittest
+
+if 'QT_QPA_PLATFORM' not in os.environ:
+    os.environ['QT_QPA_PLATFORM'] = 'offscreen'
+
+dir_name = os.path.abspath(os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(dir_name, '..', '..'))
+
+from PyQt5.QtWidgets import QApplication
+
+from libs.widgets.keypointPanel import KeypointPanel
+from libs.utils.styles import Theme, get_theme_colors
+
+app = QApplication.instance() or QApplication(sys.argv)
+
+
+def _visible_first(n=17):
+    return [(10, 10, 2)] + [None] * (n - 1)
+
+
+class TestKeypointPanelTheme(unittest.TestCase):
+
+    def test_status_color_follows_active_theme(self):
+        panel = KeypointPanel()
+        panel.load_template('person')
+        panel.apply_theme(Theme.LIGHT)
+        panel.set_keypoints(_visible_first())
+
+        style = panel._rows[0]['status'].styleSheet()
+        self.assertIn(get_theme_colors(Theme.LIGHT)['success'], style)
+
+    def test_apply_theme_repaints_existing_keypoints(self):
+        panel = KeypointPanel()
+        panel.load_template('person')
+        panel.set_keypoints(_visible_first())   # painted with default theme
+        panel.apply_theme(Theme.LIGHT)          # theme switch must repaint
+
+        style = panel._rows[0]['status'].styleSheet()
+        self.assertIn(get_theme_colors(Theme.LIGHT)['success'], style)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Medium-tier fixes from the codebase review: theme-rule consistency, one correctness bug, and one paint-path performance fix. Test-first throughout; suite **471 → 483 passing**, no regressions. Independent of #73 (branched off `dev`).

## Theme consistency (the project's own "no hardcoded colors" rule)

- **Gallery dark mode** (`galleryWidget.py`) — `apply_theme` was only called when the size slider was enabled, so with the slider hidden the list widget and status/placeholder colors kept their light-mode defaults under the dark theme. Now themed unconditionally at construction.
- **keypointPanel + shortcutsDialog** — keypointPanel hardcoded `#888`/`#4caf50`/`#ff9800` status colors (which are the *dark*-theme greens, so they rendered wrong under the light theme) and never repainted on a theme switch; shortcutsDialog hardcoded the default-shortcut gray and the conflict-highlight pink. Both now read `get_theme_colors()` and re-render on `apply_theme`.
- **`canvas_bg` palette key** (`styles.py`) — `get_canvas_background` hardcoded literals that duplicated palette values; added a `canvas_bg` key (both palettes, identical keys preserved) and source from it.
- **`_apply_theme` latent NameError** (`labelImgPlusPlus.py`) — `colors` was only bound inside the `scroll_area` block but referenced later in the save-status refresh; the palette is now resolved once up front.

## Correctness

- **Keypoint hit-test zoom scaling** (`canvas.py`) — hover compared a screen-space `epsilon` to an image-space distance without dividing by the zoom, so keypoints were unselectable (zoomed in) or over-sensitive (zoomed out). Extracted a testable `_keypoint_at()` with a scale-corrected threshold. (Also fixed a `Shape.__len__` truthiness trap surfaced while extracting it.)

## Performance

- **Overlay composite caching** (`canvas.py`) — `paintEvent` deep-copied and re-composited the full-resolution pixmap on every repaint when `overlay_color` was set. Extracted `_composited_pixmap()` that caches the result keyed on pixmap content (`cacheKey()`) + overlay color, rebuilding only when either changes.

## Verification

`QT_QPA_PLATFORM=offscreen pytest tests/` → **483 passed, 0 failed** (12 new tests across gallery, keypoint panel, dialogs, styles, canvas, and main window).

## Deliberately not in this PR

- Canvas keypoint-dot white outline (`canvas.py:982/999`) and the pre-`set_theme` default color seeds — debatable (painted on the image, not the UI surface; overwritten by `set_theme` at startup).
- The quadruplicated annotation-probe dedup and `DeleteShapeCommand` z-order/label-row restoration (larger refactors).
