### PR TITLE
refactor: unify annotation status/label probe (fixes gallery vs stats disagreement)

### DIFF
--- a/labelImgPlusPlus.py
+++ b/labelImgPlusPlus.py
@@ -72,6 +72,7 @@ from libs.formats.yolo_io import YoloReader, TXT_EXT
 from libs.formats.create_ml_io import CreateMLReader, JSON_EXT
 from libs.formats.coco_io import COCOReader
 from libs.formats.yolo_seg_io import YOLOSegReader
+from libs.formats.annotation_probe import probe as probe_annotation
 
 # Utils
 from libs.utils.constants import (
@@ -119,6 +120,16 @@ class WindowMixin(object):
             add_actions(toolbar, actions)
         self.addToolBar(Qt.LeftToolBarArea, toolbar)
         return toolbar
+
+
+def _probe_status(image_path, save_dir):
+    """Map the shared annotation probe to an AnnotationStatus enum value."""
+    info = probe_annotation(image_path, save_dir)
+    if info.verified:
+        return AnnotationStatus.VERIFIED
+    if info.has_labels:
+        return AnnotationStatus.HAS_LABELS
+    return AnnotationStatus.NO_LABELS
 
 
 class StatisticsWorkerSignals(QObject):
@@ -191,109 +202,11 @@ class StatisticsWorker(QRunnable):
 
     def _compute_status(self, image_path):
         """Thread-safe annotation status check (no shared state)."""
-        basename = os.path.splitext(os.path.basename(image_path))[0]
-        ann_dir = self.save_dir if self.save_dir else os.path.dirname(image_path)
-
-        xml_path = os.path.join(ann_dir, basename + XML_EXT)
-        txt_path = os.path.join(ann_dir, basename + TXT_EXT)
-
-        # Check labels/ sibling folder (standard YOLO structure)
-        if not os.path.isfile(txt_path):
-            img_dir = os.path.dirname(image_path)
-            parent_dir = os.path.dirname(img_dir)
-            labels_dir = os.path.join(parent_dir, 'labels')
-            alt_txt_path = os.path.join(labels_dir, basename + TXT_EXT)
-            if os.path.isfile(alt_txt_path):
-                txt_path = alt_txt_path
-
-        json_path = os.path.join(ann_dir, 'annotations.json')
-
-        has_labels = False
-        verified = False
-
-        if os.path.isfile(xml_path):
-            has_labels = True
-            try:
-                reader = PascalVocReader(xml_path)
-                verified = reader.verified
-            except Exception:
-                pass
-        elif os.path.isfile(txt_path):
-            has_labels = os.path.getsize(txt_path) > 0
-        elif os.path.isfile(json_path):
-            try:
-                import json
-                with open(json_path, 'r') as f:
-                    data = json.load(f)
-                    for item in data:
-                        if item.get('image') == os.path.basename(image_path):
-                            has_labels = len(item.get('annotations', [])) > 0
-                            verified = item.get('verified', False)
-                            break
-            except Exception:
-                pass
-
-        if verified:
-            return AnnotationStatus.VERIFIED
-        elif has_labels:
-            return AnnotationStatus.HAS_LABELS
-        return AnnotationStatus.NO_LABELS
+        return _probe_status(image_path, self.save_dir)
 
     def _compute_labels(self, img_path):
         """Thread-safe label extraction (no shared state)."""
-        labels = []
-        base_path = os.path.splitext(img_path)[0]
-        basename = os.path.basename(base_path)
-        ann_dir = self.save_dir if self.save_dir else os.path.dirname(img_path)
-
-        xml_path = os.path.join(ann_dir, basename + XML_EXT)
-        if os.path.exists(xml_path):
-            try:
-                reader = PascalVocReader(xml_path)
-                shapes = reader.get_shapes()
-                labels = [shape[0] for shape in shapes]
-            except Exception:
-                pass
-            return labels
-
-        txt_path = base_path + TXT_EXT
-        if not os.path.exists(txt_path):
-            img_dir = os.path.dirname(img_path)
-            parent_dir = os.path.dirname(img_dir)
-            labels_dir = os.path.join(parent_dir, 'labels')
-            alt_txt_path = os.path.join(labels_dir, basename + TXT_EXT)
-            if os.path.exists(alt_txt_path):
-                txt_path = alt_txt_path
-
-        if os.path.exists(txt_path):
-            try:
-                txt_dir = os.path.dirname(txt_path)
-                classes_path = os.path.join(txt_dir, 'classes.txt')
-                if not os.path.exists(classes_path):
-                    parent_dir = os.path.dirname(txt_dir)
-                    classes_path = os.path.join(parent_dir, 'classes.txt')
-                if os.path.exists(classes_path):
-                    from libs.formats.yolo_io import YoloReader
-
-                    class MockImage:
-                        def __init__(self, w, h):
-                            self._width, self._height = w, h
-                        def width(self):
-                            return self._width
-                        def height(self):
-                            return self._height
-
-                    img_reader = QImageReader(img_path)
-                    size = img_reader.size()
-                    if size.isValid():
-                        mock_img = MockImage(size.width(), size.height())
-                        reader = YoloReader(txt_path, mock_img, classes_path)
-                        shapes = reader.get_shapes()
-                        labels = [shape[0] for shape in shapes]
-            except Exception:
-                pass
-
-        return labels
+        return probe_annotation(img_path, self.save_dir, want_labels=True).labels
 
 
 class StatusRefreshWorkerSignals(QObject):
@@ -352,53 +265,7 @@ class StatusRefreshWorker(QRunnable):
 
     def _compute_status(self, image_path):
         """Thread-safe annotation status check (no shared state)."""
-        basename = os.path.splitext(os.path.basename(image_path))[0]
-        ann_dir = self.save_dir if self.save_dir else os.path.dirname(image_path)
-
-        xml_path = os.path.join(ann_dir, basename + XML_EXT)
-        txt_path = os.path.join(ann_dir, basename + TXT_EXT)
-
-        # Check labels/ sibling folder (standard YOLO structure)
-        if not os.path.isfile(txt_path):
-            img_dir = os.path.dirname(image_path)
-            parent_dir = os.path.dirname(img_dir)
-            labels_dir = os.path.join(parent_dir, 'labels')
-            alt_txt_path = os.path.join(labels_dir, basename + TXT_EXT)
-            if os.path.isfile(alt_txt_path):
-                txt_path = alt_txt_path
-
-        json_path = os.path.join(ann_dir, 'annotations.json')
-
-        has_labels = False
-        verified = False
-
-        if os.path.isfile(xml_path):
-            has_labels = True
-            try:
-                reader = PascalVocReader(xml_path)
-                verified = reader.verified
-            except Exception:
-                pass
-        elif os.path.isfile(txt_path):
-            has_labels = os.path.getsize(txt_path) > 0
-        elif os.path.isfile(json_path):
-            try:
-                import json
-                with open(json_path, 'r') as f:
-                    data = json.load(f)
-                    for item in data:
-                        if item.get('image') == os.path.basename(image_path):
-                            has_labels = len(item.get('annotations', [])) > 0
-                            verified = item.get('verified', False)
-                            break
-            except Exception:
-                pass
-
-        if verified:
-            return AnnotationStatus.VERIFIED
-        elif has_labels:
-            return AnnotationStatus.HAS_LABELS
-        return AnnotationStatus.NO_LABELS
+        return _probe_status(image_path, self.save_dir)
 
 
 class MainWindow(QMainWindow, WindowMixin):
@@ -1862,61 +1729,7 @@ class MainWindow(QMainWindow, WindowMixin):
         if use_cache and image_path in self._annotation_status_cache:
             return self._annotation_status_cache[image_path]
 
-        basename = os.path.splitext(os.path.basename(image_path))[0]
-
-        # Determine annotation directory
-        if self.default_save_dir is not None:
-            ann_dir = self.default_save_dir
-        else:
-            ann_dir = os.path.dirname(image_path)
-
-        # Check for annotation files
-        xml_path = os.path.join(ann_dir, basename + XML_EXT)
-        txt_path = os.path.join(ann_dir, basename + TXT_EXT)
-        # Also check labels/ sibling folder (standard YOLO structure)
-        if not os.path.isfile(txt_path):
-            img_dir = os.path.dirname(image_path)
-            parent_dir = os.path.dirname(img_dir)
-            labels_dir = os.path.join(parent_dir, 'labels')
-            alt_txt_path = os.path.join(labels_dir, basename + TXT_EXT)
-            if os.path.isfile(alt_txt_path):
-                txt_path = alt_txt_path
-        json_path = os.path.join(ann_dir, 'annotations.json')
-
-        has_labels = False
-        verified = False
-
-        # Check PASCAL VOC
-        if os.path.isfile(xml_path):
-            has_labels = True
-            try:
-                reader = PascalVocReader(xml_path)
-                verified = reader.verified
-            except Exception:
-                pass
-        # Check YOLO
-        elif os.path.isfile(txt_path):
-            has_labels = os.path.getsize(txt_path) > 0
-        # Check CreateML
-        elif os.path.isfile(json_path):
-            try:
-                import json
-                with open(json_path, 'r') as f:
-                    data = json.load(f)
-                    for item in data:
-                        if item.get('image') == os.path.basename(image_path):
-                            has_labels = len(item.get('annotations', [])) > 0
-                            verified = item.get('verified', False)
-                            break
-            except Exception:
-                pass
-
-        if verified:
-            status = AnnotationStatus.VERIFIED
-        elif has_labels:
-            status = AnnotationStatus.HAS_LABELS
-        else:
-            status = AnnotationStatus.NO_LABELS
+        status = _probe_status(image_path, self.default_save_dir)
 
         # Cache the result
         self._annotation_status_cache[image_path] = status
@@ -3785,78 +3598,8 @@ class MainWindow(QMainWindow, WindowMixin):
 
     def _get_labels_for_image(self, img_path):
         """Get list of labels for an image from its annotation file."""
-        labels = []
-        base_path = os.path.splitext(img_path)[0]
-
-        # Try XML (PASCAL VOC)
-        xml_path = base_path + XML_EXT
-        if os.path.exists(xml_path):
-            try:
-                reader = PascalVocReader(xml_path)
-                shapes = reader.get_shapes()
-                labels = [shape[0] for shape in shapes]
-            except Exception:
-                pass
-            return labels
-
-        # Try TXT (YOLO) - needs classes.txt
-        txt_path = base_path + TXT_EXT
-        if not os.path.exists(txt_path):
-            # Check for labels/ sibling folder (standard YOLO structure)
-            img_dir = os.path.dirname(img_path)
-            parent_dir = os.path.dirname(img_dir)
-            labels_dir = os.path.join(parent_dir, 'labels')
-            txt_filename = os.path.basename(base_path) + TXT_EXT
-            alt_txt_path = os.path.join(labels_dir, txt_filename)
-            if os.path.exists(alt_txt_path):
-                txt_path = alt_txt_path
-
-        if os.path.exists(txt_path):
-            try:
-                # Find classes.txt - check same dir, then parent dirs
-                txt_dir = os.path.dirname(txt_path)
-                classes_path = os.path.join(txt_dir, 'classes.txt')
-                if not os.path.exists(classes_path):
-                    # Check parent directory (standard YOLO structure)
-                    parent_dir = os.path.dirname(txt_dir)
-                    classes_path = os.path.join(parent_dir, 'classes.txt')
-                if not os.path.exists(classes_path):
-                    return labels  # Can't read without classes.txt
-
-                # Use QImageReader to get dimensions without loading full image
-                img_reader = QImageReader(img_path)
-                size = img_reader.size()
-                if size.isValid():
-                    # Create minimal mock image with just dimensions for YoloReader
-                    class MockImage:
-                        def __init__(self, w, h):
-                            self._w, self._h = w, h
-                        def width(self):
-                            return self._w
-                        def height(self):
-                            return self._h
-                        def isGrayscale(self):
-                            return False
-
-                    mock_img = MockImage(size.width(), size.height())
-                    reader = YoloReader(txt_path, mock_img, classes_path)
-                    shapes = reader.get_shapes()
-                    labels = [shape[0] for shape in shapes]
-            except Exception:
-                pass
-            return labels
-
-        # Try JSON (CreateML)
-        json_path = base_path + JSON_EXT
-        if os.path.exists(json_path):
-            try:
-                reader = CreateMLReader(json_path, img_path)
-                shapes = reader.get_shapes()
-                labels = [shape[0] for shape in shapes]
-            except Exception:
-                pass
-
-        return labels
+        return probe_annotation(
+            img_path, self.default_save_dir, want_labels=True).labels
 
 
 def get_main_app(argv=None):

--- a/libs/formats/annotation_probe.py
+++ b/libs/formats/annotation_probe.py
@@ -1,0 +1,197 @@
+# libs/formats/annotation_probe.py
+"""Single source of truth for resolving an image's annotation file and
+reading its status and labels.
+
+This logic was previously duplicated across the statistics worker, the
+status-refresh worker, and two MainWindow methods, and the copies had drifted:
+the status checks only looked at ``annotations.json`` while label extraction
+only looked at a per-image ``<base>.json``, so the gallery and the statistics
+view could disagree about whether an image was annotated. This module unifies
+the resolution so every caller agrees.
+
+Resolution order (first match wins), searched in both ``save_dir`` and the
+image's own directory:
+
+    PASCAL VOC  <base>.xml
+    YOLO        <base>.txt   (also a ``labels/`` sibling folder)
+    JSON        <base>.json  then  annotations.json
+                (auto-detected as COCO or CreateML by structure)
+"""
+import json
+import os
+
+from libs.formats.create_ml_io import CreateMLReader, JSON_EXT
+from libs.formats.coco_io import COCOReader
+from libs.formats.pascal_voc_io import PascalVocReader, XML_EXT
+from libs.formats.yolo_io import YoloReader
+
+try:
+    from PyQt5.QtGui import QImageReader
+except ImportError:  # pragma: no cover - legacy Qt4 fallback
+    from PyQt4.QtGui import QImageReader
+
+TXT_EXT = '.txt'
+COCO_JSON_NAME = 'annotations.json'
+
+
+class _MockImage:
+    """Minimal image stand-in exposing the dimensions ``YoloReader`` needs."""
+
+    def __init__(self, width, height, grayscale=False):
+        self._w, self._h, self._gray = width, height, grayscale
+
+    def width(self):
+        return self._w
+
+    def height(self):
+        return self._h
+
+    def isGrayscale(self):
+        return self._gray
+
+
+class AnnotationInfo:
+    """Result of probing an image for its annotation."""
+
+    def __init__(self, path=None, fmt=None, has_labels=False,
+                 verified=False, labels=None):
+        self.path = path           # annotation file path, or None
+        self.fmt = fmt             # 'voc' | 'yolo' | 'createml' | 'coco' | None
+        self.has_labels = has_labels
+        self.verified = verified
+        self.labels = labels if labels is not None else []
+
+
+def _search_dirs(image_path, save_dir):
+    dirs = []
+    if save_dir:
+        dirs.append(save_dir)
+    img_dir = os.path.dirname(image_path)
+    if img_dir and img_dir not in dirs:
+        dirs.append(img_dir)
+    return dirs
+
+
+def _first_existing(dirs, name):
+    for d in dirs:
+        path = os.path.join(d, name)
+        if os.path.isfile(path):
+            return path
+    return None
+
+
+def _resolve(image_path, save_dir):
+    """Return (path, fmt) for the first matching annotation, or (None, None)."""
+    basename = os.path.splitext(os.path.basename(image_path))[0]
+    dirs = _search_dirs(image_path, save_dir)
+
+    xml = _first_existing(dirs, basename + XML_EXT)
+    if xml:
+        return xml, 'voc'
+
+    txt = _first_existing(dirs, basename + TXT_EXT)
+    if not txt:
+        # Standard YOLO layout: <parent-of-image-dir>/labels/<base>.txt
+        img_dir = os.path.dirname(image_path)
+        sibling = os.path.join(os.path.dirname(img_dir), 'labels',
+                               basename + TXT_EXT)
+        if os.path.isfile(sibling):
+            txt = sibling
+    if txt:
+        return txt, 'yolo'
+
+    base_json = _first_existing(dirs, basename + JSON_EXT)
+    if base_json:
+        return base_json, 'json'
+
+    coco_json = _first_existing(dirs, COCO_JSON_NAME)
+    if coco_json:
+        return coco_json, 'json'
+
+    return None, None
+
+
+def _yolo_classes_path(txt_path):
+    """Find classes.txt next to the annotations, then one directory up."""
+    txt_dir = os.path.dirname(txt_path)
+    candidate = os.path.join(txt_dir, 'classes.txt')
+    if os.path.isfile(candidate):
+        return candidate
+    candidate = os.path.join(os.path.dirname(txt_dir), 'classes.txt')
+    if os.path.isfile(candidate):
+        return candidate
+    return None
+
+
+def _read_yolo_labels(image_path, txt_path):
+    classes_path = _yolo_classes_path(txt_path)
+    if not classes_path:
+        return []
+    reader = QImageReader(image_path)
+    size = reader.size()
+    if not size.isValid():
+        return []
+    mock = _MockImage(size.width(), size.height())
+    shapes = YoloReader(txt_path, mock, classes_path).get_shapes()
+    return [shape[0] for shape in shapes]
+
+
+def _is_coco(data):
+    return (isinstance(data, dict)
+            and 'annotations' in data and 'images' in data)
+
+
+def _read_json(path, image_path):
+    """Return (fmt, has_labels, verified, labels) for a CreateML or COCO file."""
+    with open(path, 'r') as f:
+        data = json.load(f)
+
+    if _is_coco(data):
+        shapes = COCOReader(path, os.path.basename(image_path)).get_shapes()
+        labels = [shape[0] for shape in shapes]
+        return 'coco', bool(labels), False, labels  # COCO has no verified flag
+
+    # CreateML: a list of image objects, possibly sharing one file.
+    reader = CreateMLReader(path, image_path)
+    shapes = reader.get_shapes()
+    labels = [shape[0] for shape in shapes]
+    return 'createml', bool(labels), bool(reader.verified), labels
+
+
+def probe(image_path, save_dir=None, want_labels=False):
+    """Resolve and read an image's annotation.
+
+    Args:
+        image_path: Path to the image file.
+        save_dir: Optional directory annotations are saved to.
+        want_labels: When True, read label names (a full read for YOLO);
+            when False, labels may be left empty for cheaper status-only scans.
+
+    Returns:
+        An :class:`AnnotationInfo`.
+    """
+    path, fmt = _resolve(image_path, save_dir)
+    info = AnnotationInfo(path=path, fmt=fmt)
+    if not path:
+        return info
+
+    try:
+        if fmt == 'voc':
+            reader = PascalVocReader(path)
+            shapes = reader.get_shapes()
+            info.labels = [shape[0] for shape in shapes]
+            info.has_labels = len(shapes) > 0
+            info.verified = reader.verified
+        elif fmt == 'yolo':
+            info.has_labels = os.path.getsize(path) > 0
+            if want_labels and info.has_labels:
+                info.labels = _read_yolo_labels(image_path, path)
+        else:  # 'json' - CreateML or COCO, auto-detected
+            info.fmt, info.has_labels, info.verified, info.labels = \
+                _read_json(path, image_path)
+    except Exception:
+        # Malformed annotation: report "no labels" rather than crashing the
+        # caller (gallery scan, stats worker). Format-level readers already
+        # surface hard errors when a file is opened explicitly.
+        pass
+    return info

--- a/tests/formats/test_annotation_probe.py
+++ b/tests/formats/test_annotation_probe.py
@@ -1,0 +1,143 @@
+# tests/formats/test_annotation_probe.py
+"""Tests for the unified annotation probe (status + label resolution)."""
+import json
+import os
+import sys
+import tempfile
+import shutil
+import unittest
+
+if 'QT_QPA_PLATFORM' not in os.environ:
+    os.environ['QT_QPA_PLATFORM'] = 'offscreen'
+
+dir_name = os.path.abspath(os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(dir_name, '..', '..'))
+
+from PyQt5.QtGui import QImage
+from PyQt5.QtWidgets import QApplication
+
+from libs.formats.annotation_probe import probe
+from libs.formats.pascal_voc_io import PascalVocWriter
+
+app = QApplication.instance() or QApplication(sys.argv)
+
+
+class TestAnnotationProbe(unittest.TestCase):
+
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.d, ignore_errors=True)
+
+    def _image(self, name='img.png', w=100, h=80, where=None):
+        path = os.path.join(where or self.d, name)
+        img = QImage(w, h, QImage.Format_RGB32)
+        img.fill(0xFFFFFF)
+        img.save(path)
+        return path
+
+    # ---- VOC ----
+    def test_voc_status_and_labels(self):
+        img = self._image('a.png')
+        w = PascalVocWriter('f', 'a.png', (80, 100, 3))
+        w.add_bnd_box(10, 10, 50, 50, 'cat', difficult=0)
+        w.save(os.path.join(self.d, 'a.xml'))
+
+        info = probe(img, save_dir=self.d, want_labels=True)
+        self.assertEqual(info.fmt, 'voc')
+        self.assertTrue(info.has_labels)
+        self.assertIn('cat', info.labels)
+
+    def test_voc_verified_flag(self):
+        img = self._image('v.png')
+        w = PascalVocWriter('f', 'v.png', (80, 100, 3))
+        w.verified = True
+        w.add_bnd_box(1, 1, 9, 9, 'dog', difficult=0)
+        w.save(os.path.join(self.d, 'v.xml'))
+
+        self.assertTrue(probe(img, save_dir=self.d).verified)
+
+    # ---- YOLO ----
+    def test_yolo_status_and_labels(self):
+        img = self._image('y.png')
+        with open(os.path.join(self.d, 'y.txt'), 'w') as f:
+            f.write('0 0.5 0.5 0.2 0.2\n')
+        with open(os.path.join(self.d, 'classes.txt'), 'w') as f:
+            f.write('person\ncar\n')
+
+        info = probe(img, save_dir=self.d, want_labels=True)
+        self.assertEqual(info.fmt, 'yolo')
+        self.assertTrue(info.has_labels)
+        self.assertIn('person', info.labels)
+
+    def test_yolo_labels_sibling_folder(self):
+        # images/ and labels/ sibling structure
+        images_dir = os.path.join(self.d, 'images')
+        labels_dir = os.path.join(self.d, 'labels')
+        os.makedirs(images_dir)
+        os.makedirs(labels_dir)
+        img = self._image('s.png', where=images_dir)
+        with open(os.path.join(labels_dir, 's.txt'), 'w') as f:
+            f.write('1 0.5 0.5 0.2 0.2\n')
+        with open(os.path.join(self.d, 'classes.txt'), 'w') as f:
+            f.write('person\ncar\n')
+
+        info = probe(img, want_labels=True)  # no save_dir
+        self.assertEqual(info.fmt, 'yolo')
+        self.assertIn('car', info.labels)
+
+    # ---- CreateML per-image <base>.json ----
+    def test_createml_base_json_status_and_labels(self):
+        """Cross-view fix: a CreateML <base>.json must report HAS_LABELS for
+        the status probe AND surface its labels (previously they disagreed)."""
+        img = self._image('c.png')
+        with open(os.path.join(self.d, 'c.json'), 'w') as f:
+            json.dump([{'image': 'c.png', 'verified': False, 'annotations': [
+                {'label': 'cat',
+                 'coordinates': {'x': 40, 'y': 30, 'width': 20, 'height': 20}}]}], f)
+
+        info = probe(img, save_dir=self.d, want_labels=True)
+        self.assertTrue(info.has_labels)        # status agrees ...
+        self.assertIn('cat', info.labels)       # ... and labels are read
+
+    # ---- COCO shared annotations.json ----
+    def test_coco_annotations_json(self):
+        img = self._image('k.png')
+        coco = {
+            'images': [{'id': 1, 'file_name': 'k.png', 'width': 100, 'height': 80}],
+            'annotations': [{'id': 1, 'image_id': 1, 'category_id': 1,
+                             'bbox': [10, 10, 30, 30]}],
+            'categories': [{'id': 1, 'name': 'boat'}],
+        }
+        with open(os.path.join(self.d, 'annotations.json'), 'w') as f:
+            json.dump(coco, f)
+
+        info = probe(img, save_dir=self.d, want_labels=True)
+        self.assertTrue(info.has_labels)
+        self.assertIn('boat', info.labels)
+
+    # ---- resolution / precedence ----
+    def test_no_annotation(self):
+        img = self._image('none.png')
+        info = probe(img, save_dir=self.d, want_labels=True)
+        self.assertFalse(info.has_labels)
+        self.assertEqual(info.labels, [])
+        self.assertIsNone(info.fmt)
+
+    def test_searches_image_dir_when_not_in_save_dir(self):
+        # annotation lives next to the image, save_dir points elsewhere
+        other = tempfile.mkdtemp()
+        try:
+            img = self._image('x.png')
+            w = PascalVocWriter('f', 'x.png', (80, 100, 3))
+            w.add_bnd_box(1, 1, 9, 9, 'cat', difficult=0)
+            w.save(os.path.join(self.d, 'x.xml'))
+            info = probe(img, save_dir=other, want_labels=True)  # not in `other`
+            self.assertIn('cat', info.labels)
+        finally:
+            shutil.rmtree(other, ignore_errors=True)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Extracts the quadruplicated annotation status/label logic into one tested module and **fixes the gallery-vs-stats disagreement** flagged in the review. Net: −274 lines from the 3,900-line entry point, +197 in a focused, tested module. Suite **515 → 523 passing**.

## The bug

The status check and the label extraction had drifted apart:
- **Status** (statistics worker, status-refresh worker, `_get_annotation_status`) only looked at `annotations.json` — and parsed it as a *CreateML list*, so a real **COCO** `annotations.json` read as empty.
- **Labels** (`_get_labels_for_image`) only looked at a per-image `<base>.json`, while the stats worker's `_compute_labels` had **no JSON branch at all**.

Result: an image labeled in CreateML (`<base>.json`) showed "no labels" in the gallery but its label in stats; a COCO image did the reverse. A private `MockImage` was also redefined in each copy.

## The fix

New `libs/formats/annotation_probe.probe(image_path, save_dir, want_labels=False)` → `AnnotationInfo(path, fmt, has_labels, verified, labels)`. It resolves the annotation across **both** `save_dir` and the image's own directory, in priority order:

```
VOC   <base>.xml
YOLO  <base>.txt   (+ labels/ sibling folder)
JSON  <base>.json  then  annotations.json   (auto-detected COCO vs CreateML)
```

All five call sites now delegate to it, so status and labels always agree. YOLO label reads stay lazy (`want_labels`) to keep the gallery status scan cheap.

## Tests

8 new probe tests (VOC/YOLO/labels-sibling/CreateML/COCO/precedence/empty), including a direct regression test for the CreateML cross-view agreement. `QT_QPA_PLATFORM=offscreen pytest tests/` → **523 passed, 0 failed**.

## Notes

- Behavior change (intentional, the point of the fix): status now detects per-image CreateML `<base>.json` and real COCO `annotations.json`, and label extraction now finds COCO. VOC `has_labels` is now content-based (an empty `.xml` reads as no-labels rather than annotated) — more correct and consistent with label extraction.
- The two remaining `MockImage` definitions are in the save path (building `image_shape` for writers), a separate concern left as-is.
- `galleryWidget.find_annotation_file` / `dataset_splitter.find_annotation_file` are a separate duplicated resolver (review #14) — not touched here.
