### PR TITLE
ci: run the test workflow on dev (was only watching develop)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,11 +2,11 @@ name: CI
 
 on:
   push:
-    branches: [master, main, develop]
+    branches: [master, main, dev]
     tags:
       - 'v*'
   pull_request:
-    branches: [master, main, develop]
+    branches: [master, main, dev]
 
 jobs:
   test:
@@ -23,6 +23,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: requirements/requirements-linux-python3.txt
 
       - name: Install system dependencies
         run: |


### PR DESCRIPTION
## Summary

Fixes a CI configuration bug: the test workflow never ran on `dev`.

`ci.yaml` triggered on push/PR to `master`, `main`, and **`develop`** — but this repo's integration branch is **`dev`** (per CLAUDE.md; `develop` is a stale name nothing uses). The result: every PR into `dev` merged without the pytest matrix (Python 3.8–3.12) ever running in CI. The recent PRs were only verified locally for this reason.

## Changes

- Point both `push` and `pull_request` triggers at `dev` (replacing `develop`).
- Enable `actions/setup-python` pip caching (keyed on `requirements/requirements-linux-python3.txt`) to speed up the 5-version matrix.

YAML validated locally with `yaml.safe_load`.

## Deliberately not bundled (follow-ups)

- **Gating `ruff`/lint job** — would immediately fail on the existing codebase; needs a separate cleanup pass first.
- **Replacing the `grep "passed"` pass-gate with the raw exit code** — the gate is currently load-bearing: the suite is known to segfault at *interpreter shutdown* (exit 139) on GitHub runners even when every test passes, and the grep tolerates that. Removing it safely needs the shutdown race fixed first.
- **Wheel-content assertion** for `predefined_classes.txt` at release time (the source-layout guard already added in the packaging PR covers the common case).
