### PR TITLE
fix(undo): restore label-list order on delete; fix label-edit crash + combo refresh

### DIFF
--- a/labelImgPlusPlus.py
+++ b/labelImgPlusPlus.py
@@ -2067,7 +2067,7 @@ class MainWindow(QMainWindow, WindowMixin):
         else:
             self.keypoint_panel.hide()
 
-    def add_label(self, shape):
+    def add_label(self, shape, row=None):
         shape.paint_label = self.display_label_option.isChecked()
         item = HashableQListWidgetItem(shape.label)
         item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
@@ -2077,15 +2077,21 @@ class MainWindow(QMainWindow, WindowMixin):
         self.shapes_to_items[shape] = item
         # Route to the appropriate label list based on shape type
         target_list = self._label_list_for_shape(shape)
-        target_list.addItem(item)
+        # Restore at a specific row (undo of a delete) when given, else append.
+        if row is not None and row >= 0:
+            target_list.insertItem(row, item)
+        else:
+            target_list.addItem(item)
         self._update_tab_counts()
         for action in self.actions.onShapesPresent:
             action.setEnabled(True)
         self.update_combo_box()
 
     def remove_label(self, shape):
+        """Remove a shape's label-list item. Returns the row it occupied
+        (or None) so a caller can restore the exact ordering on undo."""
         if shape is None:
-            return
+            return None
         item = self.shapes_to_items[shape]
         # Remove from whichever list contains the item
         target_list = self._label_list_for_shape(shape)
@@ -2096,6 +2102,7 @@ class MainWindow(QMainWindow, WindowMixin):
         del self.shapes_to_items[shape]
         del self.items_to_shapes[item]
         self.update_combo_box()
+        return row
 
     def load_labels(self, shapes):
         s = []

--- a/libs/core/commands.py
+++ b/libs/core/commands.py
@@ -84,12 +84,14 @@ class DeleteShapeCommand(Command):
         self.main_window = main_window
         self.shape = shape  # Keep reference to original shape
         self.index = index
+        self._list_row = None  # label-list row, captured on execute
 
     def execute(self):
         """Remove the shape from canvas and label list."""
         if self.shape in self.main_window.canvas.shapes:
             self.main_window.canvas.shapes.remove(self.shape)
-        self.main_window.remove_label(self.shape)
+        # Capture the label-list row so undo can restore the exact ordering.
+        self._list_row = self.main_window.remove_label(self.shape)
         if self.main_window.canvas.selected_shape == self.shape:
             self.main_window.canvas.selected_shape = None
         self.main_window.canvas.update()
@@ -100,7 +102,7 @@ class DeleteShapeCommand(Command):
             self.main_window.canvas.shapes.insert(self.index, self.shape)
         else:
             self.main_window.canvas.shapes.append(self.shape)
-        self.main_window.add_label(self.shape)
+        self.main_window.add_label(self.shape, row=self._list_row)
         self.main_window.canvas.update()
 
     @property
@@ -168,12 +170,14 @@ class EditLabelCommand(Command):
         """Apply new label."""
         self.shape.label = self.new_label
         self._update_list_item()
+        self.main_window.update_combo_box()
         self.main_window.canvas.update()
 
     def undo(self):
         """Restore old label."""
         self.shape.label = self.old_label
         self._update_list_item()
+        self.main_window.update_combo_box()
         self.main_window.canvas.update()
 
     def _update_list_item(self):
@@ -181,7 +185,7 @@ class EditLabelCommand(Command):
         if self.shape in self.main_window.shapes_to_items:
             item = self.main_window.shapes_to_items[self.shape]
             item.setText(self.shape.label)
-            from libs.hashableQListWidgetItem import generate_color_by_text
+            from libs.utils.utils import generate_color_by_text
             item.setBackground(generate_color_by_text(self.shape.label))
 
     @property

--- a/tests/core/test_commands.py
+++ b/tests/core/test_commands.py
@@ -52,6 +52,9 @@ class MockMainWindow:
             def addItem(self, item):
                 self.items.append(item)
 
+            def insertItem(self, row, item):
+                self.items.insert(row, item)
+
             def takeItem(self, idx):
                 return self.items.pop(idx)
 
@@ -60,15 +63,18 @@ class MockMainWindow:
 
         self.label_list = MockLabelList()
 
-    def add_label(self, shape):
+    def add_label(self, shape, row=None):
         item = shape.label
         self.items_to_shapes[item] = shape
         self.shapes_to_items[shape] = item
-        self.label_list.addItem(item)
+        if row is not None and row >= 0:
+            self.label_list.insertItem(row, item)
+        else:
+            self.label_list.addItem(item)
 
     def remove_label(self, shape):
         if shape is None:
-            return
+            return None
         if shape in self.shapes_to_items:
             item = self.shapes_to_items[shape]
             idx = self.label_list.row(item)
@@ -76,6 +82,8 @@ class MockMainWindow:
                 self.label_list.takeItem(idx)
             del self.shapes_to_items[shape]
             del self.items_to_shapes[item]
+            return idx
+        return None
 
     def update_combo_box(self):
         pass

--- a/tests/integration/test_main_window.py
+++ b/tests/integration/test_main_window.py
@@ -600,5 +600,71 @@ class TestMainWindowPolygonKeypointUndo(unittest.TestCase):
         self.assertEqual(shape.points[1].x(), 50)
 
 
+class TestUndoStateConsistency(unittest.TestCase):
+    """Undo must restore label-list ordering and combo-box contents."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.app, cls.win = get_main_app()
+        cls.temp_dir = tempfile.mkdtemp()
+        cls.img = os.path.join(cls.temp_dir, 'i.png')
+        im = QImage(100, 100, QImage.Format_RGB32)
+        im.fill(0xFFFFFF)
+        im.save(cls.img)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.temp_dir, ignore_errors=True)
+
+    def setUp(self):
+        self.win.reset_state()
+        self.win.load_file(self.img)
+        self.win.undo_stack.clear()
+
+    def _rect(self, label):
+        s = Shape(label=label)
+        s.add_point(QPointF(10, 10))
+        s.add_point(QPointF(50, 50))
+        s.close()
+        return s
+
+    def _combo_items(self):
+        cb = self.win.combo_box.cb
+        return [cb.itemText(i) for i in range(cb.count())]
+
+    def test_delete_undo_restores_label_list_row(self):
+        """Deleting a non-last shape then undoing must put its list item back
+        at the same row, not append it to the bottom."""
+        from libs.core.commands import DeleteShapeCommand
+        a, b, c = self._rect('a'), self._rect('b'), self._rect('c')
+        for s in (a, b, c):
+            self.win.canvas.shapes.append(s)
+            self.win.add_label(s)
+        self.assertEqual(self.win.rect_label_list.row(self.win.shapes_to_items[b]), 1)
+
+        cmd = DeleteShapeCommand(self.win, b, self.win.canvas.shapes.index(b))
+        cmd.execute()
+        self.win.undo_stack.push(cmd)
+        self.win.undo_stack.undo()
+
+        self.assertEqual(self.win.rect_label_list.row(self.win.shapes_to_items[b]), 1)
+
+    def test_edit_label_updates_combo_box(self):
+        """Editing a label (and undoing) must refresh the label combo box."""
+        from libs.core.commands import EditLabelCommand
+        s = self._rect('cat')
+        self.win.canvas.shapes.append(s)
+        self.win.add_label(s)
+        self.assertIn('cat', self._combo_items())
+
+        cmd = EditLabelCommand(self.win, s, 'cat', 'dog')
+        cmd.execute()
+        self.win.undo_stack.push(cmd)
+        self.assertIn('dog', self._combo_items())
+
+        self.win.undo_stack.undo()
+        self.assertIn('cat', self._combo_items())
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes three undo/label-state defects, including a latent crash. Suite **515 → 517 passing** (2 new tests).

## Fixes

1. **Editing a label crashed** — `EditLabelCommand._update_list_item` imported `generate_color_by_text` from `libs.hashableQListWidgetItem`, which doesn't exist, so any label edit raised `ModuleNotFoundError`. Now imported from `libs.utils.utils`.
2. **Label edit didn't refresh the combo box** — the label filter dropdown kept the old label and missed the new one. `execute` and `undo` now call `update_combo_box()`.
3. **Delete→undo lost label-list ordering** — `add_label` always appended, so undoing the deletion of a non-last shape put its list item at the bottom while the canvas restored the correct z-order, desyncing the two. `remove_label` now returns the row it removed, `add_label` accepts an optional `row` to insert at, and `DeleteShapeCommand` captures the row on delete and restores it on undo.

## Tests

New `TestUndoStateConsistency` (delete→undo row restoration; label-edit combo refresh + undo). The `MockMainWindow` in `test_commands.py` was updated for the new `add_label(row=...)` / `remove_label` return contract. `QT_QPA_PLATFORM=offscreen pytest tests/` → **517 passed, 0 failed**.
