### PR TITLE
fix(verify): surface batch-verify failures instead of swallowing them

### DIFF
--- a/labelImgPlusPlus.py
+++ b/labelImgPlusPlus.py
@@ -2784,7 +2784,38 @@ class MainWindow(QMainWindow, WindowMixin):
             return
 
         verify = dialog.verify_mode
+        count, failures = self._apply_batch_verify(verify)
+
+        action_label = 'Verified' if verify else 'Unverified'
+        self.statusBar().showMessage(
+            f'{action_label} {count} images', 3000)
+        if failures:
+            # Surface the files we could not update instead of silently
+            # dropping them from the reported count.
+            sample = '\n'.join(
+                '- %s: %s' % (os.path.basename(p), reason)
+                for p, reason in failures[:10])
+            if len(failures) > 10:
+                sample += '\n... and %d more' % (len(failures) - 10)
+            self.error_message(
+                f'{action_label} with errors',
+                (f'<p>{action_label} {count} image(s); {len(failures)} could '
+                 f'not be updated:</p><pre>{sample}</pre>'))
+        if self.file_path:
+            self.load_file(self.file_path)
+
+    def _apply_batch_verify(self, verify):
+        """Set/clear the PASCAL VOC ``verified`` flag across annotated images.
+
+        Returns:
+            (count, failures) where ``count`` is the number of images updated
+            and ``failures`` is a list of (image_path, reason) for images that
+            could not be updated - corrupt/unreadable XML, or a non-VOC
+            annotation whose format has no verified flag.
+        """
+        import xml.etree.ElementTree as ET
         count = 0
+        failures = []
         for img_path in self.m_img_list:
             if not self._has_annotation(img_path):
                 continue
@@ -2793,26 +2824,21 @@ class MainWindow(QMainWindow, WindowMixin):
             xml_path = os.path.join(save_dir, basename + XML_EXT)
             if not os.path.isfile(xml_path):
                 xml_path = os.path.splitext(img_path)[0] + XML_EXT
-            if os.path.isfile(xml_path):
-                try:
-                    import xml.etree.ElementTree as ET
-                    tree = ET.parse(xml_path)
-                    root = tree.getroot()
-                    if verify:
-                        root.set('verified', 'yes')
-                    else:
-                        if 'verified' in root.attrib:
-                            del root.attrib['verified']
-                    tree.write(xml_path)
-                    count += 1
-                except Exception:
-                    pass
-
-        action_label = 'Verified' if verify else 'Unverified'
-        self.statusBar().showMessage(
-            f'{action_label} {count} images', 3000)
-        if self.file_path:
-            self.load_file(self.file_path)
+            if not os.path.isfile(xml_path):
+                failures.append((img_path, 'not a PASCAL VOC annotation'))
+                continue
+            try:
+                tree = ET.parse(xml_path)
+                root = tree.getroot()
+                if verify:
+                    root.set('verified', 'yes')
+                else:
+                    root.attrib.pop('verified', None)
+                tree.write(xml_path)
+                count += 1
+            except (ET.ParseError, OSError) as e:
+                failures.append((img_path, str(e)))
+        return count, failures
 
     def split_dataset(self):
         """Open dialog to split dataset into train/val/test sets."""

--- a/tests/integration/test_main_window.py
+++ b/tests/integration/test_main_window.py
@@ -666,5 +666,53 @@ class TestUndoStateConsistency(unittest.TestCase):
         self.assertIn('cat', self._combo_items())
 
 
+class TestBatchVerify(unittest.TestCase):
+    """Batch verify must report files it could not update, not swallow them."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.app, cls.win = get_main_app()
+
+    def setUp(self):
+        from libs.formats.pascal_voc_io import PascalVocWriter
+        self.win.reset_state()
+        self.d = tempfile.mkdtemp()
+        self.win.default_save_dir = self.d
+        imgs = []
+        for name in ('a', 'b'):
+            img = os.path.join(self.d, name + '.png')
+            im = QImage(50, 50, QImage.Format_RGB32)
+            im.fill(0xFFFFFF)
+            im.save(img)
+            w = PascalVocWriter('f', name + '.png', (50, 50, 3))
+            w.add_bnd_box(1, 1, 9, 9, 'cat', difficult=0)
+            w.save(os.path.join(self.d, name + '.xml'))
+            imgs.append(img)
+        # An annotated image whose XML is corrupt -> must surface as a failure.
+        cimg = os.path.join(self.d, 'c.png')
+        im = QImage(50, 50, QImage.Format_RGB32)
+        im.fill(0xFFFFFF)
+        im.save(cimg)
+        with open(os.path.join(self.d, 'c.xml'), 'w') as f:
+            f.write('<annotation><object> not closed')
+        imgs.append(cimg)
+        self.win.m_img_list = imgs
+
+    def tearDown(self):
+        shutil.rmtree(self.d, ignore_errors=True)
+
+    def test_reports_failures_instead_of_swallowing(self):
+        count, failures = self.win._apply_batch_verify(True)
+        self.assertEqual(count, 2)
+        self.assertEqual(len(failures), 1)
+        self.assertTrue(any('c.png' in f[0] for f in failures))
+
+    def test_actually_writes_verified_flag(self):
+        from libs.formats.pascal_voc_io import PascalVocReader
+        self.win._apply_batch_verify(True)
+        self.assertTrue(
+            PascalVocReader(os.path.join(self.d, 'a.xml')).verified)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

`batch_verify` wrapped its per-file work in `except Exception: pass` and reported only the success count, so any image whose XML was corrupt or unwritable silently disappeared from the result — the user saw "Verified N images" with no hint that some failed.

## Fix

- Extract a testable `_apply_batch_verify(verify) -> (count, failures)`.
- Narrow the catch to `(ET.ParseError, OSError)` (real I/O / parse errors), not a blanket `Exception`.
- Collect `(image_path, reason)` for every image that couldn't be updated — corrupt/unreadable XML, **and** annotated images that aren't PASCAL VOC (whose format has no `verified` flag, previously skipped invisibly).
- `batch_verify` now reports the failures (count + a sample of up to 10) via an error dialog after the status message.

## Tests

New `TestBatchVerify`: two valid XMLs + one corrupt → `count == 2`, the corrupt image is reported in `failures`, and a valid XML actually gets `verified='yes'` written. `QT_QPA_PLATFORM=offscreen pytest tests/` → **527 passed, 0 failed**.

Note: this is the first PR opened after the CI trigger fix (#76) landed on `dev`, so the pytest matrix (3.8–3.12) should run on it.
