### PR TITLE
fix(shortcuts): validate imported shortcut config instead of crashing

### DIFF
--- a/libs/core/shortcut_config.py
+++ b/libs/core/shortcut_config.py
@@ -94,10 +94,15 @@ class ShortcutConfig:
         return dict(self._shortcuts)
 
     def from_dict(self, data):
-        """Loads shortcuts from a dictionary, only updating known keys."""
+        """Load shortcuts from a dictionary, updating only known keys with
+        string values. Non-dict input and non-string values are ignored so a
+        corrupt config can never crash the load."""
+        if not isinstance(data, dict):
+            return
         for key in DEFAULT_SHORTCUTS:
-            if key in data:
-                self._shortcuts[key] = data[key]
+            value = data.get(key)
+            if isinstance(value, str):
+                self._shortcuts[key] = value
 
     def export_json(self, file_path):
         """Exports shortcuts to a JSON file."""
@@ -105,7 +110,17 @@ class ShortcutConfig:
             json.dump(self._shortcuts, f, indent=2)
 
     def import_json(self, file_path):
-        """Imports shortcuts from a JSON file."""
-        with open(file_path, 'r') as f:
-            data = json.load(f)
+        """Import shortcuts from a JSON file.
+
+        Raises:
+            ValueError: if the file cannot be read, is not valid JSON, or is
+                not a JSON object of shortcuts.
+        """
+        try:
+            with open(file_path, 'r') as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            raise ValueError(f"Could not read shortcuts file: {e}")
+        if not isinstance(data, dict):
+            raise ValueError("Shortcuts file must be a JSON object")
         self.from_dict(data)

--- a/libs/widgets/shortcutsDialog.py
+++ b/libs/widgets/shortcutsDialog.py
@@ -134,14 +134,19 @@ class ShortcutsDialog(QDialog):
     def _import(self):
         path, _ = QFileDialog.getOpenFileName(
             self, 'Import Shortcuts', '', 'JSON (*.json)')
-        if path:
+        if not path:
+            return
+        try:
             self.config.import_json(path)
-            self._pending = dict(self.config.get_all())
-            for name, act in self.action_map.items():
-                sc = self.config.get(name)
-                if sc:
-                    act.setShortcut(sc)
-            self._refresh_table()
+        except ValueError as e:
+            QMessageBox.warning(self, 'Import failed', str(e))
+            return
+        self._pending = dict(self.config.get_all())
+        for name, act in self.action_map.items():
+            sc = self.config.get(name)
+            if sc:
+                act.setShortcut(sc)
+        self._refresh_table()
 
     def apply_theme(self, theme):
         from libs.utils.styles import get_stylesheet

--- a/tests/core/test_shortcut_config.py
+++ b/tests/core/test_shortcut_config.py
@@ -1,0 +1,55 @@
+# tests/core/test_shortcut_config.py
+"""Tests for shortcut configuration import validation."""
+import os
+import sys
+import shutil
+import tempfile
+import unittest
+
+dir_name = os.path.abspath(os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(dir_name, '..', '..'))
+
+from libs.core.shortcut_config import ShortcutConfig, DEFAULT_SHORTCUTS
+
+
+class TestShortcutConfigImport(unittest.TestCase):
+
+    def setUp(self):
+        self.d = tempfile.mkdtemp()
+        self.cfg = ShortcutConfig()
+
+    def tearDown(self):
+        shutil.rmtree(self.d, ignore_errors=True)
+
+    def _write(self, content):
+        path = os.path.join(self.d, 's.json')
+        with open(path, 'w') as f:
+            f.write(content)
+        return path
+
+    def test_import_malformed_json_raises_valueerror(self):
+        with self.assertRaises(ValueError):
+            self.cfg.import_json(self._write('{ not valid json'))
+
+    def test_import_non_object_raises_valueerror(self):
+        # A bare JSON number must be rejected cleanly (was a raw TypeError).
+        with self.assertRaises(ValueError):
+            self.cfg.import_json(self._write('123'))
+
+    def test_from_dict_ignores_non_string_values(self):
+        self.cfg.from_dict({'open': 123, 'save': 'Ctrl+Shift+K'})
+        self.assertEqual(self.cfg.get('open'), DEFAULT_SHORTCUTS['open'])
+        self.assertEqual(self.cfg.get('save'), 'Ctrl+Shift+K')
+
+    def test_from_dict_tolerates_non_dict(self):
+        self.cfg.from_dict([1, 2, 3])   # must not raise
+        self.cfg.from_dict('garbage')   # must not raise
+        self.assertEqual(self.cfg.get('open'), DEFAULT_SHORTCUTS['open'])
+
+    def test_import_valid_applies(self):
+        self.cfg.import_json(self._write('{"save": "Ctrl+K"}'))
+        self.assertEqual(self.cfg.get('save'), 'Ctrl+K')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Hardens keyboard-shortcut import so a malformed config can't crash the app.

`import_json` let `json.load` errors escape, and `from_dict` assumed its input was a dict — so a malformed shortcuts file crashed the import (a bare JSON number raised `TypeError`; a corrupt file raised an unhandled decode error), and non-string values were applied verbatim.

## Fix

- `import_json` raises a clear `ValueError` for unreadable / invalid-JSON / non-object input (wrapping `OSError`/`JSONDecodeError`).
- `from_dict` ignores non-dict input and only applies **string** values for known keys — this also hardens the settings-load path (`from_dict(settings.get(SETTING_SHORTCUTS))`), so a corrupt persisted value can't crash startup.
- The shortcuts dialog's **Import** handler catches `ValueError` and shows a warning instead of letting it propagate.

## Tests

New `tests/core/test_shortcut_config.py`: malformed JSON, bare-number (non-object), non-string values, non-dict tolerance, and a valid import. `QT_QPA_PLATFORM=offscreen pytest tests/` → **530 passed, 0 failed**.
