### PR TITLE
fix(voc): round polygon coordinates instead of truncating

### DIFF
--- a/libs/formats/pascal_voc_io.py
+++ b/libs/formats/pascal_voc_io.py
@@ -87,8 +87,8 @@ class PascalVocWriter:
         x_max = max(p[0] for p in points)
         y_max = max(p[1] for p in points)
         entry = {
-            'xmin': int(x_min), 'ymin': int(y_min),
-            'xmax': int(x_max), 'ymax': int(y_max),
+            'xmin': round(x_min), 'ymin': round(y_min),
+            'xmax': round(x_max), 'ymax': round(y_max),
             'name': name, 'difficult': difficult,
             'polygon_points': points,
         }
@@ -125,9 +125,9 @@ class PascalVocWriter:
                 for px, py in each_object['polygon_points']:
                     pt = SubElement(polygon_elem, 'pt')
                     x_elem = SubElement(pt, 'x')
-                    x_elem.text = str(int(px))
+                    x_elem.text = str(round(px))
                     y_elem = SubElement(pt, 'y')
-                    y_elem.text = str(int(py))
+                    y_elem.text = str(round(py))
 
     def save(self, target_file=None):
         root = self.gen_xml()
@@ -168,8 +168,8 @@ class PascalVocReader:
         if polygon_elem is not None:
             points = []
             for pt in polygon_elem.findall('pt'):
-                x = int(float(pt.find('x').text))
-                y = int(float(pt.find('y').text))
+                x = round(float(pt.find('x').text))
+                y = round(float(pt.find('y').text))
                 points.append((x, y))
             self.shapes.append((label, points, None, None, difficult, 'polygon'))
         else:

--- a/tests/formats/test_io.py
+++ b/tests/formats/test_io.py
@@ -405,6 +405,19 @@ class TestPascalVocPolygon(unittest.TestCase):
         self.assertEqual(shape_type, 'polygon')
         self.assertEqual(len(pts), 3)
 
+    def test_polygon_subpixel_coords_round(self):
+        """Polygon vertices must round on write/read, not truncate to zero."""
+        writer = PascalVocWriter('folder', 'test.jpg', [480, 640, 3])
+        writer.add_polygon([(10.9, 20.4), (30.6, 20.4), (20.7, 40.8)],
+                           'tri', False)
+        out_path = os.path.join(self.tmp_dir, 'poly.xml')
+        writer.save(target_file=out_path)
+
+        reader = PascalVocReader(out_path)
+        _, pts, _, _, _, shape_type = reader.get_shapes()[0]
+        self.assertEqual(shape_type, 'polygon')
+        self.assertEqual(pts, [(11, 20), (31, 20), (21, 41)])
+
     def test_backward_compat_no_polygon(self):
         """Files without polygon element still load as rectangles."""
         writer = PascalVocWriter('folder', 'test.jpg', [480, 640, 3])


### PR DESCRIPTION
## Summary

Rounds VOC **polygon** coordinates instead of truncating them — the same fix already applied to the rectangle bbox path (#73 / H4).

Polygon vertices were written with `str(int(px))` and read with `int(float(...))`, and the polygon's derived bounding box used `int()`. Each save/load cycle therefore truncated sub-pixel coordinates toward the origin. Now `round()` is used on write, read, and the bbox.

## Tests

New `test_polygon_subpixel_coords_round`: a polygon with sub-pixel vertices round-trips to rounded integers (e.g. `10.9 → 11`, not `10`). `QT_QPA_PLATFORM=offscreen pytest tests/` → **526 passed, 0 failed**.
