### PR TITLE
refactor: extract annotation loading into annotation_loader module

### DIFF
--- a/labelImgPlusPlus.py
+++ b/labelImgPlusPlus.py
@@ -68,11 +68,10 @@ from libs.core.shortcut_config import ShortcutConfig
 # Formats
 from libs.formats.labelFile import LabelFile, LabelFileError, LabelFileFormat
 from libs.formats.pascal_voc_io import PascalVocReader, XML_EXT
-from libs.formats.yolo_io import YoloReader, TXT_EXT
-from libs.formats.create_ml_io import CreateMLReader, JSON_EXT
-from libs.formats.coco_io import COCOReader
-from libs.formats.yolo_seg_io import YOLOSegReader
+from libs.formats.yolo_io import TXT_EXT
+from libs.formats.create_ml_io import JSON_EXT
 from libs.formats.annotation_probe import probe as probe_annotation
+from libs.formats import annotation_loader
 
 # Utils
 from libs.utils.constants import (
@@ -3255,10 +3254,9 @@ class MainWindow(QMainWindow, WindowMixin):
 
         self.set_format(FORMAT_PASCALVOC)
 
-        t_voc_parse_reader = PascalVocReader(xml_path)
-        shapes = t_voc_parse_reader.get_shapes()
-        self.load_labels(shapes)
-        self.canvas.verified = t_voc_parse_reader.verified
+        loaded = annotation_loader.load_pascal_voc(xml_path)
+        self.load_labels(loaded.shapes)
+        self.canvas.verified = loaded.verified
 
     def load_yolo_txt_by_filename(self, txt_path):
         if self.file_path is None:
@@ -3267,28 +3265,14 @@ class MainWindow(QMainWindow, WindowMixin):
             return
 
         self.set_format(FORMAT_YOLO)
-        # Use original image size for YOLO coordinate conversion (Issue #31)
-        # YOLO stores normalized coords, so we need original dimensions
+        # YOLO stores normalized coords; convert against the original image
+        # size rather than the (possibly scaled) display image (Issue #31).
+        original_size = getattr(self, '_original_image_size', None)
         try:
-            if hasattr(self, '_original_image_size') and self._original_image_size is not None:
-                # Create a mock image object with original dimensions
-                class MockImage:
-                    def __init__(self, size, grayscale=False):
-                        self._size = size
-                        self._grayscale = grayscale
-                    def width(self):
-                        return self._size.width()
-                    def height(self):
-                        return self._size.height()
-                    def isGrayscale(self):
-                        return self._grayscale
-                mock_img = MockImage(self._original_image_size, self.image.isGrayscale())
-                t_yolo_parse_reader = YoloReader(txt_path, mock_img)
-            else:
-                t_yolo_parse_reader = YoloReader(txt_path, self.image)
-            shapes = t_yolo_parse_reader.get_shapes()
-            self.load_labels(shapes)
-            self.canvas.verified = t_yolo_parse_reader.verified
+            loaded = annotation_loader.load_yolo(
+                txt_path, self.image, original_size)
+            self.load_labels(loaded.shapes)
+            self.canvas.verified = loaded.verified
         except Exception as e:
             self.error_message('Annotation Error',
                 f'Error loading YOLO annotations for {os.path.basename(txt_path)}: {e}')
@@ -3300,8 +3284,7 @@ class MainWindow(QMainWindow, WindowMixin):
             return
 
         try:
-            create_ml_parse_reader = CreateMLReader(json_path, file_path)
-            shapes = create_ml_parse_reader.get_shapes()
+            loaded = annotation_loader.load_create_ml(json_path, file_path)
         except Exception as e:
             self.error_message(
                 'Annotation Error',
@@ -3310,8 +3293,8 @@ class MainWindow(QMainWindow, WindowMixin):
             return
 
         self.set_format(FORMAT_CREATEML)
-        self.load_labels(shapes)
-        self.canvas.verified = create_ml_parse_reader.verified
+        self.load_labels(loaded.shapes)
+        self.canvas.verified = loaded.verified
 
     def load_coco_json_by_filename(self, json_path, file_path):
         """Load annotations from a COCO JSON file for the given image.
@@ -3325,10 +3308,8 @@ class MainWindow(QMainWindow, WindowMixin):
         if not os.path.isfile(json_path):
             return
 
-        image_filename = os.path.basename(file_path)
         try:
-            reader = COCOReader(json_path, image_filename)
-            shapes = reader.get_shapes()
+            loaded = annotation_loader.load_coco(json_path, file_path)
         except Exception as e:
             self.error_message(
                 'Annotation Error',
@@ -3337,8 +3318,8 @@ class MainWindow(QMainWindow, WindowMixin):
             return
 
         self.set_format(FORMAT_COCO)
-        self.load_labels(shapes)
-        self.canvas.verified = reader.verified
+        self.load_labels(loaded.shapes)
+        self.canvas.verified = loaded.verified
 
     def load_yolo_seg_by_filename(self, txt_path):
         """Load annotations from a YOLO-seg text file.
@@ -3351,24 +3332,10 @@ class MainWindow(QMainWindow, WindowMixin):
         if not os.path.isfile(txt_path):
             return
 
+        original_size = getattr(self, '_original_image_size', None)
         try:
-            if hasattr(self, '_original_image_size') and self._original_image_size is not None:
-                class MockImage:
-                    def __init__(self, size, grayscale=False):
-                        self._size = size
-                        self._grayscale = grayscale
-                    def width(self):
-                        return self._size.width()
-                    def height(self):
-                        return self._size.height()
-                    def isGrayscale(self):
-                        return self._grayscale
-                mock_img = MockImage(self._original_image_size,
-                                     self.image.isGrayscale())
-                reader = YOLOSegReader(txt_path, mock_img)
-            else:
-                reader = YOLOSegReader(txt_path, self.image)
-            shapes = reader.get_shapes()
+            loaded = annotation_loader.load_yolo_seg(
+                txt_path, self.image, original_size)
         except Exception as e:
             self.error_message(
                 'Annotation Error',
@@ -3377,8 +3344,8 @@ class MainWindow(QMainWindow, WindowMixin):
             return
 
         self.set_format(FORMAT_YOLO_SEG)
-        self.load_labels(shapes)
-        self.canvas.verified = reader.verified
+        self.load_labels(loaded.shapes)
+        self.canvas.verified = loaded.verified
 
     def copy_previous_bounding_boxes(self):
         current_index = self._path_to_idx.get(self.file_path, 0)

--- a/libs/formats/annotation_loader.py
+++ b/libs/formats/annotation_loader.py
@@ -1,0 +1,87 @@
+# libs/formats/annotation_loader.py
+"""Format-agnostic annotation loading.
+
+Pulls the per-format reader glue out of ``MainWindow`` so it can be unit
+tested without a Qt main window. Each loader builds the appropriate reader
+and returns a :class:`LoadedAnnotation`; the caller is responsible for the UI
+side effects (selecting the format, populating the label list, propagating the
+``verified`` flag, and surfacing errors).
+
+The YOLO loaders accept an ``original_image_size`` so normalized coordinates
+convert against the source image's dimensions rather than a downscaled display
+image (Issue #31).
+"""
+import os
+from collections import namedtuple
+
+from libs.formats.pascal_voc_io import PascalVocReader
+from libs.formats.yolo_io import YoloReader
+from libs.formats.yolo_seg_io import YOLOSegReader
+from libs.formats.create_ml_io import CreateMLReader
+from libs.formats.coco_io import COCOReader
+
+LoadedAnnotation = namedtuple('LoadedAnnotation', ['shapes', 'verified'])
+
+
+class _ImageSizeAdapter:
+    """Minimal stand-in exposing the ``width``/``height``/``isGrayscale`` API
+    the YOLO readers expect, backed by an explicit (original) image size.
+
+    Lets normalized coordinates convert against the source dimensions even when
+    the live display image has been scaled.
+    """
+
+    def __init__(self, size, grayscale=False):
+        self._size = size
+        self._grayscale = grayscale
+
+    def width(self):
+        return self._size.width()
+
+    def height(self):
+        return self._size.height()
+
+    def isGrayscale(self):
+        return self._grayscale
+
+
+def _yolo_image(image, original_image_size):
+    """Return the image object the YOLO readers should measure against.
+
+    Prefers ``original_image_size`` (wrapped in an adapter) when available,
+    falling back to the live ``image``.
+    """
+    if original_image_size is not None:
+        grayscale = image.isGrayscale() if image is not None else False
+        return _ImageSizeAdapter(original_image_size, grayscale)
+    return image
+
+
+def load_pascal_voc(xml_path):
+    """Load a PASCAL VOC ``.xml`` annotation file."""
+    reader = PascalVocReader(xml_path)
+    return LoadedAnnotation(reader.get_shapes(), reader.verified)
+
+
+def load_yolo(txt_path, image, original_image_size=None):
+    """Load a YOLO ``.txt`` annotation file (needs a sibling ``classes.txt``)."""
+    reader = YoloReader(txt_path, _yolo_image(image, original_image_size))
+    return LoadedAnnotation(reader.get_shapes(), reader.verified)
+
+
+def load_yolo_seg(txt_path, image, original_image_size=None):
+    """Load a YOLO segmentation ``.txt`` annotation file."""
+    reader = YOLOSegReader(txt_path, _yolo_image(image, original_image_size))
+    return LoadedAnnotation(reader.get_shapes(), reader.verified)
+
+
+def load_create_ml(json_path, image_path):
+    """Load a CreateML ``.json`` annotation file for ``image_path``."""
+    reader = CreateMLReader(json_path, image_path)
+    return LoadedAnnotation(reader.get_shapes(), reader.verified)
+
+
+def load_coco(json_path, image_path):
+    """Load a COCO ``.json`` annotation file, matching by image basename."""
+    reader = COCOReader(json_path, os.path.basename(image_path))
+    return LoadedAnnotation(reader.get_shapes(), reader.verified)

--- a/tests/formats/test_annotation_loader.py
+++ b/tests/formats/test_annotation_loader.py
@@ -1,0 +1,177 @@
+# tests/formats/test_annotation_loader.py
+"""Tests for the format-agnostic annotation loader.
+
+The loader pulls the per-format reader glue out of MainWindow so it can be
+exercised without a Qt main window. Each loader returns a
+``LoadedAnnotation(shapes, verified)``; the YOLO loaders additionally honor an
+``original_image_size`` so normalized coordinates convert against the source
+image dimensions rather than a scaled display image.
+"""
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+dir_name = os.path.abspath(os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(dir_name, '..', '..'))
+
+if 'QT_QPA_PLATFORM' not in os.environ:
+    os.environ['QT_QPA_PLATFORM'] = 'offscreen'
+
+from PyQt5.QtCore import QSize
+from PyQt5.QtGui import QImage
+from PyQt5.QtWidgets import QApplication
+app = QApplication.instance() or QApplication(sys.argv)
+
+from libs.formats import annotation_loader
+from libs.formats.pascal_voc_io import PascalVocWriter
+
+
+class TestImageSizeAdapter(unittest.TestCase):
+    """The size adapter replaces the MockImage duplicated in MainWindow."""
+
+    def test_exposes_width_height_grayscale(self):
+        adapter = annotation_loader._ImageSizeAdapter(QSize(400, 200),
+                                                      grayscale=True)
+        self.assertEqual(adapter.width(), 400)
+        self.assertEqual(adapter.height(), 200)
+        self.assertTrue(adapter.isGrayscale())
+
+    def test_defaults_to_color(self):
+        adapter = annotation_loader._ImageSizeAdapter(QSize(10, 10))
+        self.assertFalse(adapter.isGrayscale())
+
+
+class TestLoadPascalVoc(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+
+    def _write_voc(self, verified):
+        writer = PascalVocWriter('folder', 'img.jpg', (200, 300, 3))
+        writer.verified = verified
+        writer.add_bnd_box(10, 20, 110, 120, 'cat', False)
+        path = os.path.join(self.tmp_dir, 'img.xml')
+        writer.save(target_file=path)
+        return path
+
+    def test_returns_shapes_and_unverified(self):
+        loaded = annotation_loader.load_pascal_voc(self._write_voc(False))
+        self.assertEqual(len(loaded.shapes), 1)
+        self.assertEqual(loaded.shapes[0][0], 'cat')
+        self.assertFalse(loaded.verified)
+
+    def test_propagates_verified_flag(self):
+        loaded = annotation_loader.load_pascal_voc(self._write_voc(True))
+        self.assertTrue(loaded.verified)
+
+
+class TestLoadYolo(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.txt_path = os.path.join(self.tmp_dir, 'img.txt')
+        with open(os.path.join(self.tmp_dir, 'classes.txt'), 'w') as f:
+            f.write('cat\n')
+        # center (0.5, 0.5), size (0.5, 0.5) -> box spans [0.25, 0.75] in both axes.
+        with open(self.txt_path, 'w') as f:
+            f.write('0 0.5 0.5 0.5 0.5\n')
+
+    def test_uses_original_image_size_over_display_image(self):
+        """Normalized coords must convert against original_image_size, not the
+        (possibly downscaled) display image — the dedup'd MockImage behavior."""
+        tiny_display = QImage(10, 10, QImage.Format_RGB32)
+        loaded = annotation_loader.load_yolo(
+            self.txt_path, tiny_display,
+            original_image_size=QSize(400, 200))  # width=400, height=200
+
+        self.assertEqual(len(loaded.shapes), 1)
+        label, points = loaded.shapes[0][0], loaded.shapes[0][1]
+        self.assertEqual(label, 'cat')
+        # x: round(400 * 0.25)=100 .. round(400 * 0.75)=300
+        # y: round(200 * 0.25)=50  .. round(200 * 0.75)=150
+        self.assertEqual(points[0], (100, 50))
+        self.assertEqual(points[2], (300, 150))
+
+    def test_falls_back_to_display_image_when_no_original_size(self):
+        img = QImage(200, 100, QImage.Format_RGB32)  # width=200, height=100
+        loaded = annotation_loader.load_yolo(self.txt_path, img,
+                                             original_image_size=None)
+        points = loaded.shapes[0][1]
+        # x: round(200*0.25)=50 .. round(200*0.75)=150
+        self.assertEqual(points[0], (50, 25))
+        self.assertEqual(points[2], (150, 75))
+
+
+class TestLoadYoloSeg(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.txt_path = os.path.join(self.tmp_dir, 'img.txt')
+        with open(os.path.join(self.tmp_dir, 'classes.txt'), 'w') as f:
+            f.write('cat\n')
+        # axis-aligned rectangle in normalized coords -> read back as rectangle
+        with open(self.txt_path, 'w') as f:
+            f.write('0 0.25 0.25 0.75 0.25 0.75 0.75 0.25 0.75\n')
+
+    def test_uses_original_image_size(self):
+        tiny_display = QImage(10, 10, QImage.Format_RGB32)
+        loaded = annotation_loader.load_yolo_seg(
+            self.txt_path, tiny_display,
+            original_image_size=QSize(400, 200))
+        self.assertEqual(len(loaded.shapes), 1)
+        self.assertEqual(loaded.shapes[0][0], 'cat')
+        # First vertex (0.25, 0.25) -> (100, 50) against 400x200
+        self.assertEqual(loaded.shapes[0][1][0], (100, 50))
+
+
+class TestLoadCreateML(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.image_path = os.path.join(self.tmp_dir, 'img.jpg')
+        self.json_path = os.path.join(self.tmp_dir, 'img.json')
+        payload = [{
+            'image': 'img.jpg',
+            'annotations': [{
+                'label': 'cat',
+                'coordinates': {'x': 60, 'y': 70, 'width': 100, 'height': 100},
+            }],
+        }]
+        with open(self.json_path, 'w') as f:
+            json.dump(payload, f)
+
+    def test_returns_shapes(self):
+        loaded = annotation_loader.load_create_ml(self.json_path,
+                                                  self.image_path)
+        self.assertEqual(len(loaded.shapes), 1)
+        self.assertEqual(loaded.shapes[0][0], 'cat')
+
+
+class TestLoadCoco(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.image_path = os.path.join(self.tmp_dir, 'img.jpg')
+        self.json_path = os.path.join(self.tmp_dir, 'annotations.json')
+        payload = {
+            'images': [{'id': 1, 'file_name': 'img.jpg',
+                        'width': 200, 'height': 200}],
+            'categories': [{'id': 1, 'name': 'cat'}],
+            'annotations': [{
+                'id': 1, 'image_id': 1, 'category_id': 1,
+                'bbox': [10, 20, 100, 100], 'iscrowd': 0,
+            }],
+        }
+        with open(self.json_path, 'w') as f:
+            json.dump(payload, f)
+
+    def test_returns_shapes_matched_by_image_basename(self):
+        loaded = annotation_loader.load_coco(self.json_path, self.image_path)
+        self.assertEqual(len(loaded.shapes), 1)
+        self.assertEqual(loaded.shapes[0][0], 'cat')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

First slice of the **MainWindow decomposition** (the 3,700-line god-object in `labelImgPlusPlus.py`).

Extracts the five `load_*_by_filename` reader-glue methods into a focused, unit-testable module: `libs/formats/annotation_loader.py`.

## Why

- The `MockImage` helper (used so YOLO normalized coords convert against the original, pre-scale image size — Issue #31) was **duplicated verbatim** inside both `load_yolo_txt_by_filename` and `load_yolo_seg_by_filename`.
- Reader construction lived inline in `MainWindow`, so it could only be exercised through a full Qt window.

## How

- New `annotation_loader` exposes `load_pascal_voc / load_yolo / load_yolo_seg / load_create_ml / load_coco`, each returning `LoadedAnnotation(shapes, verified)`.
- The duplicated `MockImage` becomes a single `_ImageSizeAdapter`.
- `MainWindow` keeps all UI side effects (`set_format`, `load_labels`, `canvas.verified`, `error_message`) — **per-format ordering is unchanged** — so the methods are now thin delegators. Behavior-preserving.
- Drops the now-unused reader imports (`YoloReader`, `YOLOSegReader`, `CreateMLReader`, `COCOReader`); keeps `PascalVocReader` (still used by `_is_verified`) and the `*_EXT` constants.

## Tests

- New `tests/formats/test_annotation_loader.py` — 9 tests covering each format plus the original-image-size adapter (proves YOLO coords convert against `original_image_size`, not the display image).
- Full suite: **542 passing** (was 533).

Net: `MainWindow` shrinks ~57 lines; the extracted logic is now testable without Qt.