### PR TITLE
refactor: extract fit-to-viewport scale math into view_scaling

### DIFF
--- a/labelImgPlusPlus.py
+++ b/labelImgPlusPlus.py
@@ -55,6 +55,7 @@ from libs.widgets.galleryWidget import GalleryWidget, AnnotationStatus
 from libs.widgets.statsWidget import StatsWidget
 from libs.widgets.labelCheckerDialog import LabelCheckerDialog
 from libs.widgets.keypointPanel import KeypointPanel
+from libs.widgets import view_scaling
 
 # Core
 from libs.core.shape import Shape, ShapeType, DEFAULT_LINE_COLOR, DEFAULT_FILL_COLOR
@@ -2516,20 +2517,13 @@ class MainWindow(QMainWindow, WindowMixin):
 
     def scale_fit_window(self):
         """Figure out the size of the pixmap in order to fit the main widget."""
-        e = 2.0  # So that no scrollbars are generated.
-        w1 = self.centralWidget().width() - e
-        h1 = self.centralWidget().height() - e
-        a1 = w1 / h1
-        # Calculate a new scale value based on the pixmap's aspect ratio.
-        w2 = self.canvas.pixmap.width() - 0.0
-        h2 = self.canvas.pixmap.height() - 0.0
-        a2 = w2 / h2
-        return w1 / w2 if a2 >= a1 else h1 / h2
+        return view_scaling.fit_window_scale(
+            self.centralWidget().width(), self.centralWidget().height(),
+            self.canvas.pixmap.width(), self.canvas.pixmap.height())
 
     def scale_fit_width(self):
-        # The epsilon does not seem to work too well here.
-        w = self.centralWidget().width() - 2.0
-        return w / self.canvas.pixmap.width()
+        return view_scaling.fit_width_scale(
+            self.centralWidget().width(), self.canvas.pixmap.width())
 
     def closeEvent(self, event):
         if not self.may_continue():

--- a/libs/widgets/view_scaling.py
+++ b/libs/widgets/view_scaling.py
@@ -1,0 +1,39 @@
+# libs/widgets/view_scaling.py
+"""Pure geometry helpers for fitting the canvas pixmap into the viewport.
+
+Extracted from ``MainWindow.scale_fit_window`` / ``scale_fit_width`` so the
+aspect-ratio math can be unit tested without a Qt main window. Each helper
+returns a float scale factor; callers multiply by 100 for the zoom widget.
+
+The live code path only calls these with a valid (non-null) image, so the
+degenerate-size guards never fire in practice — they're defensive, ensuring a
+collapsed viewport or empty pixmap returns a safe unit scale instead of raising
+``ZeroDivisionError``.
+"""
+
+_EPSILON = 2.0  # Viewport padding so fitting doesn't itself spawn scrollbars.
+
+
+def fit_window_scale(viewport_width, viewport_height,
+                     pixmap_width, pixmap_height):
+    """Return the scale that fits the pixmap fully inside the viewport.
+
+    Preserves aspect ratio: the limiting dimension (width or height) is chosen
+    by comparing the viewport and pixmap aspect ratios.
+    """
+    w1 = viewport_width - _EPSILON
+    h1 = viewport_height - _EPSILON
+    if h1 <= 0 or pixmap_width <= 0 or pixmap_height <= 0:
+        return 1.0
+    a1 = w1 / h1
+    w2 = float(pixmap_width)
+    h2 = float(pixmap_height)
+    a2 = w2 / h2
+    return w1 / w2 if a2 >= a1 else h1 / h2
+
+
+def fit_width_scale(viewport_width, pixmap_width):
+    """Return the scale that fits the pixmap's width to the viewport width."""
+    if pixmap_width <= 0:
+        return 1.0
+    return (viewport_width - _EPSILON) / pixmap_width

--- a/tests/widgets/test_view_scaling.py
+++ b/tests/widgets/test_view_scaling.py
@@ -1,0 +1,61 @@
+# tests/widgets/test_view_scaling.py
+"""Tests for the pure fit-to-viewport scale helpers.
+
+Extracted from MainWindow.scale_fit_window / scale_fit_width so the
+aspect-ratio math can be exercised without a Qt main window.
+"""
+import os
+import sys
+import unittest
+
+dir_name = os.path.abspath(os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(dir_name, '..', '..'))
+
+from libs.widgets.view_scaling import fit_window_scale, fit_width_scale
+
+# scale_fit_window subtracts a 2px epsilon from the viewport so fitting
+# doesn't itself spawn scrollbars; the tests account for it.
+EPS = 2.0
+
+
+class TestFitWindowScale(unittest.TestCase):
+
+    def test_pixmap_wider_than_viewport_is_width_bound(self):
+        """When the pixmap is relatively wider (a2 >= a1), width is the
+        limiting dimension: scale = (viewport_w - eps) / pixmap_w."""
+        scale = fit_window_scale(802, 602, 400, 100)  # pixmap aspect 4.0
+        self.assertAlmostEqual(scale, (802 - EPS) / 400)
+
+    def test_pixmap_taller_than_viewport_is_height_bound(self):
+        """When the pixmap is relatively taller (a2 < a1), height is the
+        limiting dimension: scale = (viewport_h - eps) / pixmap_h."""
+        scale = fit_window_scale(802, 602, 100, 400)  # pixmap aspect 0.25
+        self.assertAlmostEqual(scale, (602 - EPS) / 400)
+
+    def test_matches_legacy_formula_on_square(self):
+        scale = fit_window_scale(402, 402, 200, 200)
+        # Square pixmap in square viewport: a2 == a1 -> width-bound branch.
+        self.assertAlmostEqual(scale, (402 - EPS) / 200)
+
+    def test_degenerate_pixmap_returns_unit_scale(self):
+        """Zero-sized pixmap must not raise ZeroDivisionError."""
+        self.assertEqual(fit_window_scale(800, 600, 0, 0), 1.0)
+        self.assertEqual(fit_window_scale(800, 600, 100, 0), 1.0)
+
+    def test_degenerate_viewport_returns_unit_scale(self):
+        """Viewport collapsed to the epsilon must not raise."""
+        self.assertEqual(fit_window_scale(800, 2, 100, 100), 1.0)
+
+
+class TestFitWidthScale(unittest.TestCase):
+
+    def test_fits_pixmap_width_to_viewport(self):
+        scale = fit_width_scale(802, 400)
+        self.assertAlmostEqual(scale, (802 - EPS) / 400)
+
+    def test_degenerate_pixmap_returns_unit_scale(self):
+        self.assertEqual(fit_width_scale(800, 0), 1.0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

Second slice of the **MainWindow decomposition**. Extracts the fit-to-viewport scale math from `MainWindow.scale_fit_window` / `scale_fit_width` into a pure `libs/widgets/view_scaling.py`.

## Why

`scale_fit_window` carries the only non-trivial logic in the view subsystem — an aspect-ratio comparison that picks the limiting dimension (width- vs height-bound). It was inline in `MainWindow` and only reachable through a full Qt window, so the branch was untested.

## How

- New `fit_window_scale(viewport_w, viewport_h, pixmap_w, pixmap_h)` and `fit_width_scale(viewport_w, pixmap_w)` — pure float math.
- `MainWindow` methods become thin delegators passing in the widget dimensions. **Live-path behavior is unchanged** (verified against the legacy formula).
- The helpers add a defensive guard: a degenerate (zero-sized) viewport or pixmap returns a unit scale `1.0` instead of raising `ZeroDivisionError`. The live path never hits this (callers guard on a non-null image), so it's purely defensive.

## Tests

- New `tests/widgets/test_view_scaling.py` — 7 tests covering both aspect-ratio branches, the square/equal-aspect edge, and the zero-size guards.
- Full suite: **549 passing** (was 542).