### PR TITLE
refactor: extract statistics orchestration into StatsController

### DIFF
--- a/labelImgPlusPlus.py
+++ b/labelImgPlusPlus.py
@@ -56,6 +56,7 @@ from libs.widgets.statsWidget import StatsWidget
 from libs.widgets.labelCheckerDialog import LabelCheckerDialog
 from libs.widgets.keypointPanel import KeypointPanel
 from libs.widgets import view_scaling
+from libs.widgets.stats_controller import StatsController
 
 # Core
 from libs.core.shape import Shape, ShapeType, DEFAULT_LINE_COLOR, DEFAULT_FILL_COLOR
@@ -320,8 +321,14 @@ class MainWindow(QMainWindow, WindowMixin):
         self.gallery_mode_enabled = False
         self._gallery_batch_id = 0  # For cancelling pending batch processing
         self._status_worker_gen = 0  # Generation counter for status worker
-        self._stats_worker_gen = 0  # Generation counter for stats worker
         self._dock_status_worker_gen = 0  # Generation counter for dock status worker
+        # Statistics orchestration lives in its own controller; the stats
+        # widget is read lazily because the gallery panel is created on demand.
+        self.stats_controller = StatsController(
+            stats_widget_getter=lambda: getattr(self, 'gallery_stats', None),
+            worker_factory=StatisticsWorker)
+        self.stats_controller.current_image_refresh_requested.connect(
+            self._update_current_image_stats)
         self._normal_central_widget = None
         self.screencast = "https://youtu.be/p0nR2YsCY_U"
 
@@ -3524,62 +3531,11 @@ class MainWindow(QMainWindow, WindowMixin):
     # Statistics methods (Issue #19) - Stats shown in gallery mode
     def _refresh_all_statistics(self):
         """Start async refresh of all statistics in the gallery stats widget."""
-        if not hasattr(self, 'gallery_stats') or not self.gallery_stats:
-            return
-
-        # Cancel and cleanup existing worker
-        self._cleanup_stats_worker()
-        self._stats_worker_gen += 1
-        gen = self._stats_worker_gen
-
-        # Create worker with snapshot of current state (thread-safe)
-        self._stats_worker = StatisticsWorker(
-            self.m_img_list,
-            self.default_save_dir  # Pass snapshot, not reference
-        )
-        self._stats_worker.signals.progress.connect(
-            lambda t, a, v, l, g=gen: self._on_stats_progress(t, a, v, l, g))
-        self._stats_worker.signals.finished.connect(
-            lambda g=gen: self._on_stats_finished(g))
-        self._stats_worker.signals.error.connect(
-            lambda e, g=gen: self._on_stats_error(e, g))
-
-        QThreadPool.globalInstance().start(self._stats_worker)
+        self.stats_controller.refresh_all(self.m_img_list, self.default_save_dir)
 
     def _cleanup_stats_worker(self):
-        """Properly cleanup worker and disconnect signals."""
-        if hasattr(self, '_stats_worker') and self._stats_worker:
-            self._stats_worker.cancel()
-            try:
-                self._stats_worker.signals.progress.disconnect()
-                self._stats_worker.signals.finished.disconnect()
-                self._stats_worker.signals.error.disconnect()
-            except (TypeError, RuntimeError):
-                pass  # Already disconnected
-            self._stats_worker = None
-
-    def _on_stats_progress(self, total, annotated, verified, label_counts, gen):
-        """Handle statistics progress update from worker."""
-        # Ignore stale signals from old workers
-        if gen != self._stats_worker_gen:
-            return
-        if hasattr(self, 'gallery_stats') and self.gallery_stats:
-            self.gallery_stats.update_dataset_stats(total, annotated, verified)
-            self.gallery_stats.update_label_distribution(label_counts)
-
-    def _on_stats_finished(self, gen):
-        """Handle statistics computation finished."""
-        if gen != self._stats_worker_gen:
-            return
-        self._update_current_image_stats()
-        self._stats_worker = None
-
-    def _on_stats_error(self, error_msg, gen):
-        """Handle worker errors gracefully."""
-        if gen != self._stats_worker_gen:
-            return
-        print(f"Statistics worker error: {error_msg}")
-        self._stats_worker = None
+        """Cancel the in-flight statistics worker and disconnect its signals."""
+        self.stats_controller.cleanup()
 
     def _update_current_image_stats(self):
         """Update statistics for the current image."""
@@ -3588,7 +3544,7 @@ class MainWindow(QMainWindow, WindowMixin):
 
         annotations_count = len(self.canvas.shapes)
         labels = [shape.label for shape in self.canvas.shapes]
-        self.gallery_stats.update_current_image_stats(annotations_count, labels)
+        self.stats_controller.update_current_image(annotations_count, labels)
 
     def _get_labels_for_image(self, img_path):
         """Get list of labels for an image from its annotation file."""

--- a/libs/widgets/stats_controller.py
+++ b/libs/widgets/stats_controller.py
@@ -1,0 +1,89 @@
+# libs/widgets/stats_controller.py
+"""Background statistics orchestration for the gallery stats panel.
+
+Owns the statistics worker lifecycle, the generation counter that invalidates
+in-flight results when a newer refresh starts, and the dispatch of results to
+the stats widget. Extracted from ``MainWindow`` so the (error-prone)
+stale-signal guarding is unit testable without a Qt main window.
+
+The worker class and the live stats widget are injected so this controller has
+no dependency on the ``MainWindow`` module. The widget is read lazily through a
+getter because the gallery — and its stats panel — is created and destroyed on
+demand.
+"""
+from PyQt5.QtCore import QObject, QThreadPool, pyqtSignal
+
+
+class StatsController(QObject):
+    """Drives async dataset-statistics computation for the stats widget."""
+
+    # Emitted when a full dataset refresh finishes, so the owner can refresh
+    # the current-image panel (which depends on live canvas state the
+    # controller deliberately does not reach into).
+    current_image_refresh_requested = pyqtSignal()
+
+    def __init__(self, stats_widget_getter, worker_factory,
+                 thread_pool=None, parent=None):
+        super().__init__(parent)
+        self._get_widget = stats_widget_getter
+        self._worker_factory = worker_factory
+        self._thread_pool = thread_pool or QThreadPool.globalInstance()
+        self._worker = None
+        self._worker_gen = 0  # Bumped per refresh; guards against stale signals.
+
+    def refresh_all(self, image_list, save_dir):
+        """Start an async refresh of dataset-wide statistics."""
+        if self._get_widget() is None:
+            return
+
+        self.cleanup()
+        self._worker_gen += 1
+        gen = self._worker_gen
+
+        worker = self._worker_factory(image_list, save_dir)
+        worker.signals.progress.connect(
+            lambda t, a, v, l, g=gen: self._on_progress(t, a, v, l, g))
+        worker.signals.finished.connect(lambda g=gen: self._on_finished(g))
+        worker.signals.error.connect(lambda e, g=gen: self._on_error(e, g))
+
+        self._worker = worker
+        self._thread_pool.start(worker)
+
+    def cleanup(self):
+        """Cancel the in-flight worker and disconnect its signals."""
+        if self._worker:
+            self._worker.cancel()
+            try:
+                self._worker.signals.progress.disconnect()
+                self._worker.signals.finished.disconnect()
+                self._worker.signals.error.disconnect()
+            except (TypeError, RuntimeError):
+                pass  # Already disconnected.
+            self._worker = None
+
+    def update_current_image(self, annotations_count, labels):
+        """Push the current image's annotation count and labels to the widget."""
+        widget = self._get_widget()
+        if widget is None:
+            return
+        widget.update_current_image_stats(annotations_count, labels)
+
+    def _on_progress(self, total, annotated, verified, label_counts, gen):
+        if gen != self._worker_gen:
+            return  # Stale signal from a superseded worker.
+        widget = self._get_widget()
+        if widget is not None:
+            widget.update_dataset_stats(total, annotated, verified)
+            widget.update_label_distribution(label_counts)
+
+    def _on_finished(self, gen):
+        if gen != self._worker_gen:
+            return
+        self._worker = None
+        self.current_image_refresh_requested.emit()
+
+    def _on_error(self, error_msg, gen):
+        if gen != self._worker_gen:
+            return
+        print(f"Statistics worker error: {error_msg}")
+        self._worker = None

--- a/tests/widgets/test_stats_controller.py
+++ b/tests/widgets/test_stats_controller.py
@@ -1,0 +1,180 @@
+# tests/widgets/test_stats_controller.py
+"""Tests for StatsController — the background statistics orchestrator.
+
+Exercises the worker lifecycle, the generation counter that invalidates
+in-flight results, and result dispatch to the stats widget, all without real
+threads: the worker, thread pool, and stats widget are injected as fakes.
+"""
+import os
+import sys
+import unittest
+
+dir_name = os.path.abspath(os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(dir_name, '..', '..'))
+
+if 'QT_QPA_PLATFORM' not in os.environ:
+    os.environ['QT_QPA_PLATFORM'] = 'offscreen'
+
+from PyQt5.QtCore import QObject, pyqtSignal
+from PyQt5.QtWidgets import QApplication
+app = QApplication.instance() or QApplication(sys.argv)
+
+from libs.widgets.stats_controller import StatsController
+
+
+class FakeStatsWidget:
+    def __init__(self):
+        self.dataset = None
+        self.label_dist = None
+        self.current = None
+
+    def update_dataset_stats(self, total, annotated, verified):
+        self.dataset = (total, annotated, verified)
+
+    def update_label_distribution(self, counts):
+        self.label_dist = counts
+
+    def update_current_image_stats(self, count, labels):
+        self.current = (count, labels)
+
+
+class FakeSignals(QObject):
+    progress = pyqtSignal(int, int, int, dict)
+    finished = pyqtSignal()
+    error = pyqtSignal(str)
+
+
+class FakeWorker:
+    def __init__(self, image_list, save_dir):
+        self.image_list = list(image_list)
+        self.save_dir = save_dir
+        self.signals = FakeSignals()
+        self.cancelled = False
+
+    def cancel(self):
+        self.cancelled = True
+
+
+class FakeThreadPool:
+    def __init__(self):
+        self.started = []
+
+    def start(self, worker):
+        self.started.append(worker)
+
+
+class StatsControllerTestBase(unittest.TestCase):
+    def setUp(self):
+        self.widget = FakeStatsWidget()
+        self.pool = FakeThreadPool()
+        self.controller = StatsController(
+            stats_widget_getter=lambda: self.widget,
+            worker_factory=FakeWorker,
+            thread_pool=self.pool)
+
+
+class TestRefreshAll(StatsControllerTestBase):
+
+    def test_starts_worker_with_snapshot_and_bumps_generation(self):
+        self.controller.refresh_all(['a.jpg', 'b.jpg'], '/save')
+        self.assertEqual(len(self.pool.started), 1)
+        worker = self.pool.started[0]
+        self.assertEqual(worker.image_list, ['a.jpg', 'b.jpg'])
+        self.assertEqual(worker.save_dir, '/save')
+        self.assertEqual(self.controller._worker_gen, 1)
+
+    def test_noop_when_no_widget(self):
+        controller = StatsController(
+            stats_widget_getter=lambda: None,
+            worker_factory=FakeWorker,
+            thread_pool=self.pool)
+        controller.refresh_all(['a.jpg'], '/save')
+        self.assertEqual(self.pool.started, [])
+        self.assertEqual(controller._worker_gen, 0)
+
+    def test_second_refresh_cancels_first_worker(self):
+        self.controller.refresh_all(['a.jpg'], '/save')
+        first = self.pool.started[0]
+        self.controller.refresh_all(['b.jpg'], '/save')
+        self.assertTrue(first.cancelled)
+        self.assertEqual(self.controller._worker_gen, 2)
+
+
+class TestSignalDispatch(StatsControllerTestBase):
+
+    def test_progress_updates_widget(self):
+        self.controller.refresh_all(['a.jpg'], '/save')
+        worker = self.pool.started[0]
+        worker.signals.progress.emit(10, 6, 2, {'cat': 4})
+        self.assertEqual(self.widget.dataset, (10, 6, 2))
+        self.assertEqual(self.widget.label_dist, {'cat': 4})
+
+    def test_finished_requests_current_image_refresh_and_clears_worker(self):
+        seen = []
+        self.controller.current_image_refresh_requested.connect(
+            lambda: seen.append(True))
+        self.controller.refresh_all(['a.jpg'], '/save')
+        worker = self.pool.started[0]
+        worker.signals.finished.emit()
+        self.assertEqual(seen, [True])
+        self.assertIsNone(self.controller._worker)
+
+    def test_error_clears_worker(self):
+        self.controller.refresh_all(['a.jpg'], '/save')
+        worker = self.pool.started[0]
+        worker.signals.error.emit('boom')
+        self.assertIsNone(self.controller._worker)
+
+
+class TestStaleGenerationGuard(StatsControllerTestBase):
+
+    def test_stale_progress_ignored(self):
+        self.controller._worker_gen = 5
+        self.controller._on_progress(10, 6, 2, {'cat': 4}, gen=4)
+        self.assertIsNone(self.widget.dataset)
+
+    def test_stale_finished_does_not_request_refresh(self):
+        seen = []
+        self.controller.current_image_refresh_requested.connect(
+            lambda: seen.append(True))
+        self.controller._worker_gen = 5
+        self.controller._on_finished(gen=4)
+        self.assertEqual(seen, [])
+
+    def test_stale_error_ignored(self):
+        self.controller._worker_gen = 5
+        self.controller._worker = object()  # sentinel; must survive stale error
+        self.controller._on_error('old', gen=4)
+        self.assertIsNotNone(self.controller._worker)
+
+
+class TestUpdateCurrentImage(StatsControllerTestBase):
+
+    def test_forwards_count_and_labels_to_widget(self):
+        self.controller.update_current_image(3, ['cat', 'dog'])
+        self.assertEqual(self.widget.current, (3, ['cat', 'dog']))
+
+    def test_noop_when_no_widget(self):
+        controller = StatsController(
+            stats_widget_getter=lambda: None,
+            worker_factory=FakeWorker,
+            thread_pool=self.pool)
+        controller.update_current_image(3, ['cat'])  # must not raise
+
+
+class TestCleanup(StatsControllerTestBase):
+
+    def test_cancels_and_clears_worker(self):
+        self.controller.refresh_all(['a.jpg'], '/save')
+        worker = self.pool.started[0]
+        self.controller.cleanup()
+        self.assertTrue(worker.cancelled)
+        self.assertIsNone(self.controller._worker)
+
+    def test_cleanup_is_safe_with_no_worker(self):
+        self.controller.cleanup()  # must not raise
+        self.assertIsNone(self.controller._worker)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

Third slice of the **MainWindow decomposition**. Extracts the background statistics worker lifecycle out of `MainWindow` into `libs/widgets/stats_controller.py`.

## Why

The statistics orchestration was the kind of code that hides bugs: a worker handle, a generation counter to invalidate stale in-flight results, three signal slots each repeating the stale-gen guard, and cleanup/disconnect logic — all inline in the god-object and only reachable through a full Qt window. None of it was unit tested.

## How

`StatsController(QObject)` owns:
- the worker (`refresh_all` / `cleanup`),
- the generation counter that drops signals from a superseded worker,
- dispatch of `progress` / `finished` / `error` to the stats widget.

Designed to be dependency-free of the `MainWindow` module and testable without real threads:
- the **stats widget** is read through an injected getter (the gallery panel is created/destroyed on demand, so a held reference would go stale),
- the **worker class** and **thread pool** are injected.

On finish the controller emits `current_image_refresh_requested`; `MainWindow` connects it to the current-image stats update — preserving the prior post-refresh behavior. `MainWindow` keeps thin `_refresh_all_statistics` / `_cleanup_stats_worker` / `_update_current_image_stats` wrappers (runtime call sites rely on them) and drops the `_on_stats_*` slots plus the `_stats_worker` / `_stats_worker_gen` state.

## Tests

- New `tests/widgets/test_stats_controller.py` — 13 tests using fake widget / worker / thread pool: generation guard (stale progress/finished/error ignored), signal dispatch, worker cancellation on re-refresh and cleanup, and the no-widget guards.
- Full suite: **562 passing** (was 549).

Net: `MainWindow` shrinks ~56 lines; the worker/stale-signal logic is now isolated and tested.