### PR TITLE
fix: defer set_format until reader succeeds (YOLO/Pascal)

### DIFF
--- a/labelImgPlusPlus.py
+++ b/labelImgPlusPlus.py
@@ -3253,9 +3253,17 @@ class MainWindow(QMainWindow, WindowMixin):
         if os.path.isfile(xml_path) is False:
             return
 
-        self.set_format(FORMAT_PASCALVOC)
+        try:
+            loaded = annotation_loader.load_pascal_voc(xml_path)
+        except Exception as e:
+            self.error_message(
+                'Annotation Error',
+                f'Error loading PASCAL VOC annotations from '
+                f'{os.path.basename(xml_path)}: {e}')
+            return
 
-        loaded = annotation_loader.load_pascal_voc(xml_path)
+        # Defer the format switch until the reader succeeds (Issue #69).
+        self.set_format(FORMAT_PASCALVOC)
         self.load_labels(loaded.shapes)
         self.canvas.verified = loaded.verified
 
@@ -3265,18 +3273,21 @@ class MainWindow(QMainWindow, WindowMixin):
         if os.path.isfile(txt_path) is False:
             return
 
-        self.set_format(FORMAT_YOLO)
         # YOLO stores normalized coords; convert against the original image
         # size rather than the (possibly scaled) display image (Issue #31).
         original_size = getattr(self, '_original_image_size', None)
         try:
             loaded = annotation_loader.load_yolo(
                 txt_path, self.image, original_size)
-            self.load_labels(loaded.shapes)
-            self.canvas.verified = loaded.verified
         except Exception as e:
             self.error_message('Annotation Error',
                 f'Error loading YOLO annotations for {os.path.basename(txt_path)}: {e}')
+            return
+
+        # Defer the format switch until the reader succeeds (Issue #69).
+        self.set_format(FORMAT_YOLO)
+        self.load_labels(loaded.shapes)
+        self.canvas.verified = loaded.verified
 
     def load_create_ml_json_by_filename(self, json_path, file_path):
         if self.file_path is None:

--- a/tests/integration/test_main_window.py
+++ b/tests/integration/test_main_window.py
@@ -493,6 +493,43 @@ class TestMainWindowLoaderFormatPreservation(unittest.TestCase):
             self.win.label_file_format, LabelFileFormat.YOLO,
             'format must not be mutated on reader failure')
 
+    def test_load_yolo_txt_does_not_change_format_on_reader_failure(self):
+        """Missing classes.txt makes YoloReader raise; format must not flip
+        and the load must not crash (Issue #69)."""
+        from libs.formats.labelFile import LabelFileFormat
+
+        # Valid YOLO txt but no classes.txt sibling -> reader raises.
+        yolo_dir = tempfile.mkdtemp()
+        try:
+            yolo_txt = os.path.join(yolo_dir, 'x.txt')
+            with open(yolo_txt, 'w') as f:
+                f.write('0 0.5 0.5 0.5 0.5\n')
+
+            # Start from a DIFFERENT format so a wrongful set_format is visible.
+            self.win.label_file_format = LabelFileFormat.PASCAL_VOC
+            self.win.load_yolo_txt_by_filename(yolo_txt)  # must not raise
+            self.assertEqual(
+                self.win.label_file_format, LabelFileFormat.PASCAL_VOC,
+                'format must not be mutated on reader failure')
+        finally:
+            shutil.rmtree(yolo_dir, ignore_errors=True)
+
+    def test_load_pascal_xml_does_not_change_format_on_reader_failure(self):
+        """Malformed XML makes PascalVocReader raise; format must not flip
+        and the load must not crash (Issue #69)."""
+        from libs.formats.labelFile import LabelFileFormat
+
+        bad_xml = os.path.join(self.temp_dir, 'bad.xml')
+        with open(bad_xml, 'w') as f:
+            f.write('<annotation><object><name>cat')  # truncated, invalid XML
+
+        # Start from a DIFFERENT format so a wrongful set_format is visible.
+        self.win.label_file_format = LabelFileFormat.YOLO
+        self.win.load_pascal_xml_by_filename(bad_xml)  # must not raise
+        self.assertEqual(
+            self.win.label_file_format, LabelFileFormat.YOLO,
+            'format must not be mutated on reader failure')
+
 
 class TestMainWindowPolygonKeypointUndo(unittest.TestCase):
     """Integration tests for polygon and keypoint undo support."""


### PR DESCRIPTION
Fixes #69.

## Problem

`load_yolo_txt_by_filename` and `load_pascal_xml_by_filename` called `set_format(...)` **before** constructing the reader. If the reader raised (malformed file, missing `classes.txt`), the user had silently switched their saved-format preference to a format whose file couldn't even be parsed — and the next save landed in the wrong format. CreateML, COCO, and YOLO-seg already deferred correctly.

## Fix

Apply the established pattern: construct the reader inside `try:` and call `set_format(...)` **only after** it returns shapes.

- **YOLO** — reorder so `set_format(FORMAT_YOLO)` runs after a successful read.
- **PASCAL VOC** — same reorder, plus the `catch + error_message + return` handling the other four loaders already had (previously a malformed XML propagated out of the loader). Now it's surfaced gracefully.

## Tests

Two new cases in `TestMainWindowLoaderFormatPreservation`, mirroring the existing COCO/YOLO-seg tests:
- `test_load_yolo_txt_does_not_change_format_on_reader_failure`
- `test_load_pascal_xml_does_not_change_format_on_reader_failure`

Each starts from a *different* format so a wrongful `set_format` is detectable, and asserts the load doesn't crash. CreateML is already covered by the existing `test_load_create_ml_bad_json_does_not_raise`.

Full suite: **564 passing** (was 562).