### PR TITLE
refactor: extract gallery status refresh into GalleryStatusController

### DIFF
--- a/labelImgPlusPlus.py
+++ b/labelImgPlusPlus.py
@@ -13,7 +13,7 @@ try:
     from PyQt5.QtGui import QColor, QCursor, QImage, QImageReader, QPixmap
     from PyQt5.QtCore import (
         Qt, QByteArray, QFileInfo, QProcess, QSize, QTimer, QPoint, QPointF,
-        QVariant, QObject, QRunnable, QThreadPool, pyqtSignal
+        QVariant, QObject, QRunnable, pyqtSignal
     )
     from PyQt5.QtWidgets import (
         QAction, QActionGroup, QApplication, QCheckBox, QComboBox,
@@ -39,7 +39,7 @@ except ImportError:
     )
     from PyQt4.QtCore import (
         Qt, QByteArray, QFileInfo, QProcess, QSize, QTimer, QPoint, QPointF,
-        QVariant, QObject, QRunnable, QThreadPool, pyqtSignal
+        QVariant, QObject, QRunnable, pyqtSignal
     )
 
 # Widgets
@@ -57,6 +57,7 @@ from libs.widgets.labelCheckerDialog import LabelCheckerDialog
 from libs.widgets.keypointPanel import KeypointPanel
 from libs.widgets import view_scaling
 from libs.widgets.stats_controller import StatsController
+from libs.widgets.gallery_status_controller import GalleryStatusController
 
 # Core
 from libs.core.shape import Shape, ShapeType, DEFAULT_LINE_COLOR, DEFAULT_FILL_COLOR
@@ -320,8 +321,20 @@ class MainWindow(QMainWindow, WindowMixin):
         self._beginner = True
         self.gallery_mode_enabled = False
         self._gallery_batch_id = 0  # For cancelling pending batch processing
-        self._status_worker_gen = 0  # Generation counter for status worker
-        self._dock_status_worker_gen = 0  # Generation counter for dock status worker
+        # Gallery annotation-status refresh runs through controllers that
+        # share the status cache; the full-screen and dock galleries each get
+        # one. (Replaces the duplicated _status_worker / _dock_status_worker
+        # flows and their generation counters.)
+        self._full_status_controller = GalleryStatusController(
+            widget_getter=lambda: getattr(self, 'full_gallery', None),
+            cache=self._annotation_status_cache,
+            worker_factory=StatusRefreshWorker,
+            label='Status refresh')
+        self._dock_status_controller = GalleryStatusController(
+            widget_getter=lambda: getattr(self, 'gallery_widget', None),
+            cache=self._annotation_status_cache,
+            worker_factory=StatusRefreshWorker,
+            label='Dock status')
         # Statistics orchestration lives in its own controller; the stats
         # widget is read lazily because the gallery panel is created on demand.
         self.stats_controller = StatsController(
@@ -1267,71 +1280,13 @@ class MainWindow(QMainWindow, WindowMixin):
         self.gallery_image_activated(image_path)
 
     def _refresh_full_gallery_statuses(self):
-        """Update statuses for full-screen gallery using async worker."""
-        if not (hasattr(self, 'full_gallery') and self.full_gallery):
-            return
-
-        # Apply cached statuses immediately for instant feedback
-        cached_statuses = {p: self._annotation_status_cache[p]
-                          for p in self.m_img_list if p in self._annotation_status_cache}
-        if cached_statuses:
-            self.full_gallery.update_all_statuses(cached_statuses)
-
-        # Get uncached images for async processing
-        uncached = [p for p in self.m_img_list if p not in self._annotation_status_cache]
-        if not uncached:
-            return
-
-        # Cancel existing worker and start new async worker with new generation
-        self._cleanup_status_worker()
-        self._status_worker_gen += 1
-        gen = self._status_worker_gen
-        self._status_worker = StatusRefreshWorker(uncached, self.default_save_dir)
-        self._status_worker.signals.batch_ready.connect(
-            lambda s, g=gen: self._on_status_batch_ready(s, g))
-        self._status_worker.signals.finished.connect(
-            lambda g=gen: self._on_status_refresh_finished(g))
-        self._status_worker.signals.error.connect(
-            lambda e, g=gen: self._on_status_refresh_error(e, g))
-        QThreadPool.globalInstance().start(self._status_worker)
+        """Update statuses for the full-screen gallery via async worker."""
+        self._full_status_controller.refresh(
+            self.m_img_list, self.default_save_dir)
 
     def _cleanup_status_worker(self):
-        """Properly cleanup status worker and disconnect signals."""
-        if hasattr(self, '_status_worker') and self._status_worker:
-            self._status_worker.cancel()
-            try:
-                self._status_worker.signals.batch_ready.disconnect()
-                self._status_worker.signals.finished.disconnect()
-                self._status_worker.signals.error.disconnect()
-            except (TypeError, RuntimeError):
-                pass
-            self._status_worker = None
-
-    def _on_status_batch_ready(self, statuses, gen):
-        """Handle status batch from async worker."""
-        # Ignore stale signals from old workers
-        if gen != self._status_worker_gen:
-            return
-        # Early exit if gallery was closed
-        if not (hasattr(self, 'full_gallery') and self.full_gallery):
-            return
-        # Update cache with computed statuses
-        self._annotation_status_cache.update(statuses)
-        # Update gallery UI
-        self.full_gallery.update_all_statuses(statuses)
-
-    def _on_status_refresh_finished(self, gen):
-        """Handle status refresh completion."""
-        if gen != self._status_worker_gen:
-            return
-        self._status_worker = None
-
-    def _on_status_refresh_error(self, error_msg, gen):
-        """Handle status worker errors."""
-        if gen != self._status_worker_gen:
-            return
-        print(f"Status refresh worker error: {error_msg}")
-        self._status_worker = None
+        """Cancel the full-screen gallery status worker."""
+        self._full_status_controller.cleanup()
 
     def populate_mode_actions(self):
         if self.beginner():
@@ -1750,68 +1705,13 @@ class MainWindow(QMainWindow, WindowMixin):
             self._annotation_status_cache.clear()
 
     def _refresh_gallery_statuses(self):
-        """Update all gallery thumbnail statuses using async worker."""
-        if not hasattr(self, 'gallery_widget') or not self.gallery_widget:
-            return
-
-        # Apply cached statuses immediately
-        cached = {p: self._annotation_status_cache[p]
-                  for p in self.m_img_list if p in self._annotation_status_cache}
-        if cached:
-            self.gallery_widget.update_all_statuses(cached)
-
-        # Get uncached images for async processing
-        uncached = [p for p in self.m_img_list if p not in self._annotation_status_cache]
-        if not uncached:
-            return
-
-        # Cancel existing worker and start new async worker with new generation
-        self._cleanup_dock_status_worker()
-        self._dock_status_worker_gen += 1
-        gen = self._dock_status_worker_gen
-        self._dock_status_worker = StatusRefreshWorker(uncached, self.default_save_dir)
-        self._dock_status_worker.signals.batch_ready.connect(
-            lambda s, g=gen: self._on_dock_status_batch_ready(s, g))
-        self._dock_status_worker.signals.finished.connect(
-            lambda g=gen: self._on_dock_status_finished(g))
-        self._dock_status_worker.signals.error.connect(
-            lambda e, g=gen: self._on_dock_status_error(e, g))
-        QThreadPool.globalInstance().start(self._dock_status_worker)
+        """Update all dock gallery thumbnail statuses via async worker."""
+        self._dock_status_controller.refresh(
+            self.m_img_list, self.default_save_dir)
 
     def _cleanup_dock_status_worker(self):
-        """Cleanup dock gallery status worker."""
-        if hasattr(self, '_dock_status_worker') and self._dock_status_worker:
-            self._dock_status_worker.cancel()
-            try:
-                self._dock_status_worker.signals.batch_ready.disconnect()
-                self._dock_status_worker.signals.finished.disconnect()
-                self._dock_status_worker.signals.error.disconnect()
-            except (TypeError, RuntimeError):
-                pass
-            self._dock_status_worker = None
-
-    def _on_dock_status_batch_ready(self, statuses, gen):
-        """Handle status batch for dock gallery."""
-        # Ignore stale signals from old workers
-        if gen != self._dock_status_worker_gen:
-            return
-        if not hasattr(self, 'gallery_widget') or not self.gallery_widget:
-            return
-        self._annotation_status_cache.update(statuses)
-        self.gallery_widget.update_all_statuses(statuses)
-
-    def _on_dock_status_finished(self, gen):
-        """Handle dock status refresh completion."""
-        if gen != self._dock_status_worker_gen:
-            return
-        self._dock_status_worker = None
-
-    def _on_dock_status_error(self, error_msg, gen):
-        """Handle dock status worker errors."""
-        if gen != self._dock_status_worker_gen:
-            return
-        print(f"Dock status worker error: {error_msg}")
-        self._dock_status_worker = None
+        """Cancel the dock gallery status worker."""
+        self._dock_status_controller.cleanup()
 
     def _update_current_image_gallery_status(self):
         """Update gallery status for current image after save/verify."""

--- a/libs/widgets/gallery_status_controller.py
+++ b/libs/widgets/gallery_status_controller.py
@@ -1,0 +1,91 @@
+# libs/widgets/gallery_status_controller.py
+"""Async annotation-status refresh for a gallery widget.
+
+Owns the status-refresh worker lifecycle, the generation counter that drops
+results from a superseded worker, and the split between applying already-cached
+statuses immediately and computing the rest in the background. Extracted from
+``MainWindow``, where the full-screen-gallery and dock-gallery flows were two
+verbatim copies of this logic.
+
+The gallery widget is read lazily through a getter (galleries are created and
+destroyed on demand) and the status cache is shared by reference, so the
+full-gallery and dock controllers — and the synchronous cache helpers that
+remain on ``MainWindow`` — all see the same computed statuses. The worker class
+and thread pool are injected, keeping this controller free of any dependency on
+the ``MainWindow`` module and unit testable without real threads.
+"""
+from PyQt5.QtCore import QObject, QThreadPool
+
+
+class GalleryStatusController(QObject):
+    """Drives async annotation-status computation for one gallery widget."""
+
+    def __init__(self, widget_getter, cache, worker_factory,
+                 thread_pool=None, label='Status', parent=None):
+        super().__init__(parent)
+        self._get_widget = widget_getter
+        self._cache = cache  # Shared {path: AnnotationStatus} dict (by reference).
+        self._worker_factory = worker_factory
+        self._thread_pool = thread_pool or QThreadPool.globalInstance()
+        self._worker = None
+        self._worker_gen = 0  # Bumped per refresh; guards against stale signals.
+        self._label = label
+
+    def refresh(self, image_list, save_dir):
+        """Apply cached statuses immediately, then compute the rest async."""
+        widget = self._get_widget()
+        if widget is None:
+            return
+
+        cached = {p: self._cache[p] for p in image_list if p in self._cache}
+        if cached:
+            widget.update_all_statuses(cached)
+
+        uncached = [p for p in image_list if p not in self._cache]
+        if not uncached:
+            return
+
+        self.cleanup()
+        self._worker_gen += 1
+        gen = self._worker_gen
+
+        worker = self._worker_factory(uncached, save_dir)
+        worker.signals.batch_ready.connect(
+            lambda s, g=gen: self._on_batch_ready(s, g))
+        worker.signals.finished.connect(lambda g=gen: self._on_finished(g))
+        worker.signals.error.connect(lambda e, g=gen: self._on_error(e, g))
+
+        self._worker = worker
+        self._thread_pool.start(worker)
+
+    def cleanup(self):
+        """Cancel the in-flight worker and disconnect its signals."""
+        if self._worker:
+            self._worker.cancel()
+            try:
+                self._worker.signals.batch_ready.disconnect()
+                self._worker.signals.finished.disconnect()
+                self._worker.signals.error.disconnect()
+            except (TypeError, RuntimeError):
+                pass  # Already disconnected.
+            self._worker = None
+
+    def _on_batch_ready(self, statuses, gen):
+        if gen != self._worker_gen:
+            return  # Stale signal from a superseded worker.
+        widget = self._get_widget()
+        if widget is None:
+            return
+        self._cache.update(statuses)
+        widget.update_all_statuses(statuses)
+
+    def _on_finished(self, gen):
+        if gen != self._worker_gen:
+            return
+        self._worker = None
+
+    def _on_error(self, error_msg, gen):
+        if gen != self._worker_gen:
+            return
+        print(f"{self._label} worker error: {error_msg}")
+        self._worker = None

--- a/tests/widgets/test_gallery_status_controller.py
+++ b/tests/widgets/test_gallery_status_controller.py
@@ -1,0 +1,188 @@
+# tests/widgets/test_gallery_status_controller.py
+"""Tests for GalleryStatusController — async annotation-status refresh.
+
+Covers the cached-immediate / uncached-async split, the generation counter
+that drops stale results, the shared status cache, and worker cleanup — all
+without real threads (worker, thread pool, and gallery widget are fakes).
+"""
+import os
+import sys
+import unittest
+
+dir_name = os.path.abspath(os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(dir_name, '..', '..'))
+
+if 'QT_QPA_PLATFORM' not in os.environ:
+    os.environ['QT_QPA_PLATFORM'] = 'offscreen'
+
+from PyQt5.QtCore import QObject, pyqtSignal
+from PyQt5.QtWidgets import QApplication
+app = QApplication.instance() or QApplication(sys.argv)
+
+from libs.widgets.gallery_status_controller import GalleryStatusController
+
+
+class FakeGallery:
+    def __init__(self):
+        self.all_status_calls = []
+
+    def update_all_statuses(self, statuses):
+        self.all_status_calls.append(dict(statuses))
+
+
+class FakeSignals(QObject):
+    batch_ready = pyqtSignal(dict)
+    finished = pyqtSignal()
+    error = pyqtSignal(str)
+
+
+class FakeWorker:
+    def __init__(self, image_list, save_dir):
+        self.image_list = list(image_list)
+        self.save_dir = save_dir
+        self.signals = FakeSignals()
+        self.cancelled = False
+
+    def cancel(self):
+        self.cancelled = True
+
+
+class FakeThreadPool:
+    def __init__(self):
+        self.started = []
+
+    def start(self, worker):
+        self.started.append(worker)
+
+
+def make_controller(widget, cache, pool):
+    return GalleryStatusController(
+        widget_getter=lambda: widget,
+        cache=cache,
+        worker_factory=FakeWorker,
+        thread_pool=pool,
+        label='Status refresh')
+
+
+class TestRefresh(unittest.TestCase):
+    def setUp(self):
+        self.widget = FakeGallery()
+        self.cache = {}
+        self.pool = FakeThreadPool()
+        self.controller = make_controller(self.widget, self.cache, self.pool)
+
+    def test_applies_cached_immediately_and_starts_worker_for_uncached(self):
+        self.cache['a.jpg'] = 'HAS_LABELS'
+        self.controller.refresh(['a.jpg', 'b.jpg'], '/save')
+
+        # Cached status pushed to the widget right away.
+        self.assertEqual(self.widget.all_status_calls, [{'a.jpg': 'HAS_LABELS'}])
+        # Only the uncached image goes to the worker.
+        self.assertEqual(len(self.pool.started), 1)
+        self.assertEqual(self.pool.started[0].image_list, ['b.jpg'])
+        self.assertEqual(self.pool.started[0].save_dir, '/save')
+        self.assertEqual(self.controller._worker_gen, 1)
+
+    def test_all_cached_applies_but_starts_no_worker(self):
+        self.cache.update({'a.jpg': 'VERIFIED', 'b.jpg': 'NO_LABELS'})
+        self.controller.refresh(['a.jpg', 'b.jpg'], '/save')
+
+        self.assertEqual(len(self.widget.all_status_calls), 1)
+        self.assertEqual(self.pool.started, [])
+        self.assertEqual(self.controller._worker_gen, 0)
+
+    def test_noop_without_widget(self):
+        controller = make_controller(None, self.cache, self.pool)
+        controller.refresh(['a.jpg'], '/save')
+        self.assertEqual(self.pool.started, [])
+        self.assertEqual(controller._worker_gen, 0)
+
+    def test_second_refresh_cancels_first_worker(self):
+        self.controller.refresh(['a.jpg'], '/save')
+        first = self.pool.started[0]
+        self.controller.refresh(['b.jpg'], '/save')
+        self.assertTrue(first.cancelled)
+        self.assertEqual(self.controller._worker_gen, 2)
+
+
+class TestSignalDispatch(unittest.TestCase):
+    def setUp(self):
+        self.widget = FakeGallery()
+        self.cache = {}
+        self.pool = FakeThreadPool()
+        self.controller = make_controller(self.widget, self.cache, self.pool)
+
+    def test_batch_ready_updates_cache_and_widget(self):
+        self.controller.refresh(['a.jpg'], '/save')
+        worker = self.pool.started[0]
+        worker.signals.batch_ready.emit({'a.jpg': 'HAS_LABELS'})
+
+        self.assertEqual(self.cache['a.jpg'], 'HAS_LABELS')
+        self.assertIn({'a.jpg': 'HAS_LABELS'}, self.widget.all_status_calls)
+
+    def test_stale_batch_ignored(self):
+        self.controller._worker_gen = 5
+        self.controller._on_batch_ready({'a.jpg': 'HAS_LABELS'}, gen=4)
+        self.assertNotIn('a.jpg', self.cache)
+        self.assertEqual(self.widget.all_status_calls, [])
+
+    def test_batch_ignored_when_widget_gone(self):
+        controller = make_controller(None, self.cache, self.pool)
+        controller._worker_gen = 1
+        controller._on_batch_ready({'a.jpg': 'X'}, gen=1)
+        # Cache must not be updated if there is no widget to show it.
+        self.assertNotIn('a.jpg', self.cache)
+
+    def test_finished_clears_worker(self):
+        self.controller.refresh(['a.jpg'], '/save')
+        self.pool.started[0].signals.finished.emit()
+        self.assertIsNone(self.controller._worker)
+
+    def test_error_clears_worker(self):
+        self.controller.refresh(['a.jpg'], '/save')
+        self.pool.started[0].signals.error.emit('boom')
+        self.assertIsNone(self.controller._worker)
+
+    def test_stale_finished_ignored(self):
+        self.controller._worker_gen = 5
+        self.controller._worker = object()  # sentinel must survive
+        self.controller._on_finished(gen=4)
+        self.assertIsNotNone(self.controller._worker)
+
+
+class TestCleanup(unittest.TestCase):
+    def test_cancels_and_clears(self):
+        widget, cache, pool = FakeGallery(), {}, FakeThreadPool()
+        controller = make_controller(widget, cache, pool)
+        controller.refresh(['a.jpg'], '/save')
+        worker = pool.started[0]
+        controller.cleanup()
+        self.assertTrue(worker.cancelled)
+        self.assertIsNone(controller._worker)
+
+    def test_cleanup_safe_with_no_worker(self):
+        controller = make_controller(FakeGallery(), {}, FakeThreadPool())
+        controller.cleanup()
+        self.assertIsNone(controller._worker)
+
+
+class TestSharedCache(unittest.TestCase):
+    def test_two_controllers_share_cache(self):
+        """The full-gallery and dock controllers share one cache dict, so a
+        status computed by one is seen by the other."""
+        cache = {}
+        pool = FakeThreadPool()
+        full = make_controller(FakeGallery(), cache, pool)
+        dock = make_controller(FakeGallery(), cache, pool)
+
+        full.refresh(['a.jpg'], '/save')
+        full._on_batch_ready({'a.jpg': 'VERIFIED'}, gen=full._worker_gen)
+
+        # dock sees the cached status and applies it without a worker.
+        pool.started.clear()
+        dock.refresh(['a.jpg'], '/save')
+        self.assertEqual(pool.started, [])  # nothing uncached for dock
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

Fourth slice of the **MainWindow decomposition**. Collapses the two duplicated gallery status-refresh flows into one reusable `libs/widgets/gallery_status_controller.py`.

## Why

`_refresh_full_gallery_statuses` (full-screen gallery) and `_refresh_gallery_statuses` (dock gallery) were **verbatim copies** of the same async flow — apply cached statuses immediately, compute the rest in a `StatusRefreshWorker`, drop stale results via a generation counter, push to the widget — differing only in the target widget, worker handle, and generation counter. Six `_on_*` handlers and two `_cleanup_*` methods were duplicated alongside.

## How

`GalleryStatusController(QObject)` owns one such flow. MainWindow creates **two instances** (full + dock) that **share the annotation-status cache by reference**, so a status computed for one gallery is instantly available to the other and to the synchronous cache helpers.

Dependency-free of the MainWindow module and testable without threads:
- the gallery widget is read through an injected **getter** (galleries are created/destroyed on demand),
- the **cache** dict, **worker class**, and **thread pool** are injected.

MainWindow keeps thin `_refresh_*` / `_cleanup_*` wrappers (call sites rely on them) and the sync cache helpers (`_get_annotation_status` / `_invalidate_status_cache` / `_update_current_image_gallery_status`). It drops both worker flows, the six handlers, the two generation counters, and the now-unused `QThreadPool` import.

## Tests

New `tests/widgets/test_gallery_status_controller.py` — 13 tests using fake gallery/worker/thread-pool: cached-immediate vs uncached-async split, generation guard (stale batch/finished ignored), widget-gone guard, cleanup/cancel, and the shared-cache behavior across two controllers.

Full suite: **585 passing** (was 572). Net: MainWindow shrinks ~127 lines.