### PR TITLE
refactor: consolidate format metadata into a single registry

### DIFF
--- a/labelImgPlusPlus.py
+++ b/labelImgPlusPlus.py
@@ -75,6 +75,7 @@ from libs.formats.yolo_io import TXT_EXT
 from libs.formats.create_ml_io import JSON_EXT
 from libs.formats.annotation_probe import probe as probe_annotation
 from libs.formats import annotation_loader
+from libs.formats import format_metadata
 
 # Utils
 from libs.utils.constants import (
@@ -546,24 +547,10 @@ class MainWindow(QMainWindow, WindowMixin):
         save = action(get_str('save'), self.save_file,
                       self.shortcut_config.get('save'), 'save', get_str('saveDetail'), enabled=False)
 
-        def get_format_meta(format):
-            """Return a tuple containing (title, icon_name) of the selected format."""
-            if format == LabelFileFormat.PASCAL_VOC:
-                return '&PascalVOC', 'format_voc'
-            elif format == LabelFileFormat.YOLO:
-                return '&YOLO', 'format_yolo'
-            elif format == LabelFileFormat.CREATE_ML:
-                return '&CreateML', 'format_createml'
-            elif format == LabelFileFormat.COCO:
-                return '&COCO', 'format_createml'
-            elif format == LabelFileFormat.YOLO_SEG:
-                return '&YOLO-seg', 'format_yolo'
-            # Default fallback
-            return '&PascalVOC', 'format_voc'
-
-        save_format = action(get_format_meta(self.label_file_format)[0],
+        current_format_meta = format_metadata.meta_for_enum(self.label_file_format)
+        save_format = action(current_format_meta.menu_title,
                              self.change_format, self.shortcut_config.get('save_format'),
-                             get_format_meta(self.label_file_format)[1],
+                             current_format_meta.icon,
                              get_str('changeSaveFormat'), enabled=True)
 
         save_as = action(get_str('saveAs'), self.save_file_as,
@@ -1123,52 +1110,18 @@ class MainWindow(QMainWindow, WindowMixin):
 
     # Support Functions #
     def set_format(self, save_format):
+        meta = format_metadata.by_name(save_format)
+        if meta is None:
+            return
         theme = getattr(self, '_current_theme', Theme.LIGHT)
-        if save_format == FORMAT_PASCALVOC:
-            self.actions.save_format.setText(FORMAT_PASCALVOC)
-            self.actions.save_format.setIcon(themed_icon("format_voc", theme))
-            self.label_file_format = LabelFileFormat.PASCAL_VOC
-            LabelFile.suffix = XML_EXT
-
-        elif save_format == FORMAT_YOLO:
-            self.actions.save_format.setText(FORMAT_YOLO)
-            self.actions.save_format.setIcon(themed_icon("format_yolo", theme))
-            self.label_file_format = LabelFileFormat.YOLO
-            LabelFile.suffix = TXT_EXT
-
-        elif save_format == FORMAT_CREATEML:
-            self.actions.save_format.setText(FORMAT_CREATEML)
-            self.actions.save_format.setIcon(themed_icon("format_createml", theme))
-            self.label_file_format = LabelFileFormat.CREATE_ML
-            LabelFile.suffix = JSON_EXT
-
-        elif save_format == FORMAT_COCO:
-            self.actions.save_format.setText(FORMAT_COCO)
-            self.actions.save_format.setIcon(themed_icon("format_createml", theme))
-            self.label_file_format = LabelFileFormat.COCO
-            LabelFile.suffix = JSON_EXT
-
-        elif save_format == FORMAT_YOLO_SEG:
-            self.actions.save_format.setText(FORMAT_YOLO_SEG)
-            self.actions.save_format.setIcon(themed_icon("format_yolo", theme))
-            self.label_file_format = LabelFileFormat.YOLO_SEG
-            LabelFile.suffix = TXT_EXT
+        self.actions.save_format.setText(meta.name)
+        self.actions.save_format.setIcon(themed_icon(meta.icon, theme))
+        self.label_file_format = meta.enum
+        LabelFile.suffix = meta.suffix
 
     def change_format(self):
         """Cycle through annotation formats: VOC -> YOLO -> CreateML -> COCO -> YOLO-seg -> VOC."""
-        format_cycle = {
-            LabelFileFormat.PASCAL_VOC: (FORMAT_YOLO, "Switching to YOLO format.\n\nNote: The 'difficult' flag will be lost."),
-            LabelFileFormat.YOLO: (FORMAT_CREATEML, "Switching to CreateML format."),
-            LabelFileFormat.CREATE_ML: (FORMAT_COCO, "Switching to COCO format.\n\nSupports polygon annotations natively."),
-            LabelFileFormat.COCO: (FORMAT_YOLO_SEG, "Switching to YOLO-seg format.\n\nSupports polygon annotations natively."),
-            LabelFileFormat.YOLO_SEG: (FORMAT_PASCALVOC, "Switching to PASCAL VOC format."),
-        }
-
-        entry = format_cycle.get(self.label_file_format)
-        if entry is None:
-            raise ValueError('Unknown label file format.')
-
-        new_format, warning = entry
+        new_format, warning = format_metadata.next_in_cycle(self.label_file_format)
 
         # Show confirmation dialog
         msg = QMessageBox()

--- a/libs/formats/format_metadata.py
+++ b/libs/formats/format_metadata.py
@@ -1,0 +1,80 @@
+# libs/formats/format_metadata.py
+"""Single source of truth for annotation-format display metadata.
+
+Consolidates the per-format data that used to be spread across
+``MainWindow.get_format_meta`` (menu title + icon), ``set_format`` (icon, enum,
+file suffix) and ``change_format`` (the cycle order + warnings): the identifier
+strings (``FORMAT_*``), the :class:`LabelFileFormat` enum, themed-icon names,
+menu titles, and file suffixes.
+
+The module holds only data and lookups — no Qt — so it stays unit testable and
+free of any dependency on the ``MainWindow`` module.
+"""
+from collections import namedtuple
+
+from libs.formats.labelFile import LabelFileFormat
+from libs.formats.pascal_voc_io import XML_EXT
+from libs.formats.yolo_io import TXT_EXT
+from libs.formats.create_ml_io import JSON_EXT
+from libs.utils.constants import (
+    FORMAT_PASCALVOC, FORMAT_YOLO, FORMAT_CREATEML, FORMAT_COCO, FORMAT_YOLO_SEG)
+
+FormatMeta = namedtuple(
+    'FormatMeta', ['name', 'enum', 'icon', 'menu_title', 'suffix'])
+
+# Order defines the change_format() cycle.
+_FORMATS = [
+    FormatMeta(FORMAT_PASCALVOC, LabelFileFormat.PASCAL_VOC,
+               'format_voc', '&PascalVOC', XML_EXT),
+    FormatMeta(FORMAT_YOLO, LabelFileFormat.YOLO,
+               'format_yolo', '&YOLO', TXT_EXT),
+    FormatMeta(FORMAT_CREATEML, LabelFileFormat.CREATE_ML,
+               'format_createml', '&CreateML', JSON_EXT),
+    FormatMeta(FORMAT_COCO, LabelFileFormat.COCO,
+               'format_createml', '&COCO', JSON_EXT),
+    FormatMeta(FORMAT_YOLO_SEG, LabelFileFormat.YOLO_SEG,
+               'format_yolo', '&YOLO-seg', TXT_EXT),
+]
+
+_BY_NAME = {m.name: m for m in _FORMATS}
+_BY_ENUM = {m.enum: m for m in _FORMATS}
+
+# Warning shown when cycling away from each format (keyed by the format being
+# left), preserving the original change_format messages.
+_CYCLE_WARNINGS = {
+    LabelFileFormat.PASCAL_VOC:
+        "Switching to YOLO format.\n\nNote: The 'difficult' flag will be lost.",
+    LabelFileFormat.YOLO: "Switching to CreateML format.",
+    LabelFileFormat.CREATE_ML:
+        "Switching to COCO format.\n\nSupports polygon annotations natively.",
+    LabelFileFormat.COCO:
+        "Switching to YOLO-seg format.\n\nSupports polygon annotations natively.",
+    LabelFileFormat.YOLO_SEG: "Switching to PASCAL VOC format.",
+}
+
+
+def by_name(name):
+    """Return the :class:`FormatMeta` for a ``FORMAT_*`` string, or None."""
+    return _BY_NAME.get(name)
+
+
+def meta_for_enum(enum):
+    """Return the :class:`FormatMeta` for a ``LabelFileFormat``.
+
+    Falls back to PASCAL VOC for an unknown value, mirroring the old
+    ``get_format_meta`` default.
+    """
+    return _BY_ENUM.get(enum, _FORMATS[0])
+
+
+def next_in_cycle(enum):
+    """Return ``(next_format_name, warning)`` for cycling from ``enum``.
+
+    Raises :class:`ValueError` for an unknown format, matching the prior
+    ``change_format`` behavior.
+    """
+    if enum not in _BY_ENUM:
+        raise ValueError('Unknown label file format.')
+    idx = _FORMATS.index(_BY_ENUM[enum])
+    nxt = _FORMATS[(idx + 1) % len(_FORMATS)]
+    return nxt.name, _CYCLE_WARNINGS[enum]

--- a/tests/formats/test_format_metadata.py
+++ b/tests/formats/test_format_metadata.py
@@ -1,0 +1,94 @@
+# tests/formats/test_format_metadata.py
+"""Tests for the annotation-format metadata registry.
+
+Consolidates the format display data (identifier strings, LabelFileFormat
+enum, menu titles, themed-icon names, file suffixes, and the change-format
+cycle) that used to be spread across MainWindow.get_format_meta / set_format /
+change_format.
+"""
+import os
+import sys
+import unittest
+
+dir_name = os.path.abspath(os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(dir_name, '..', '..'))
+
+from libs.formats import format_metadata as fm
+from libs.formats.labelFile import LabelFileFormat
+from libs.formats.pascal_voc_io import XML_EXT
+from libs.formats.yolo_io import TXT_EXT
+from libs.formats.create_ml_io import JSON_EXT
+from libs.utils.constants import (
+    FORMAT_PASCALVOC, FORMAT_YOLO, FORMAT_CREATEML, FORMAT_COCO, FORMAT_YOLO_SEG)
+
+
+class TestByName(unittest.TestCase):
+
+    def test_maps_each_identifier_to_meta(self):
+        cases = [
+            (FORMAT_PASCALVOC, LabelFileFormat.PASCAL_VOC, 'format_voc', XML_EXT),
+            (FORMAT_YOLO, LabelFileFormat.YOLO, 'format_yolo', TXT_EXT),
+            (FORMAT_CREATEML, LabelFileFormat.CREATE_ML, 'format_createml', JSON_EXT),
+            (FORMAT_COCO, LabelFileFormat.COCO, 'format_createml', JSON_EXT),
+            (FORMAT_YOLO_SEG, LabelFileFormat.YOLO_SEG, 'format_yolo', TXT_EXT),
+        ]
+        for name, enum, icon, suffix in cases:
+            meta = fm.by_name(name)
+            self.assertIsNotNone(meta, name)
+            self.assertEqual(meta.name, name)
+            self.assertEqual(meta.enum, enum)
+            self.assertEqual(meta.icon, icon)
+            self.assertEqual(meta.suffix, suffix)
+
+    def test_unknown_name_returns_none(self):
+        self.assertIsNone(fm.by_name('NOT_A_FORMAT'))
+
+
+class TestMetaForEnum(unittest.TestCase):
+
+    def test_menu_titles_and_icons(self):
+        self.assertEqual(fm.meta_for_enum(LabelFileFormat.PASCAL_VOC).menu_title,
+                         '&PascalVOC')
+        self.assertEqual(fm.meta_for_enum(LabelFileFormat.YOLO).menu_title, '&YOLO')
+        self.assertEqual(fm.meta_for_enum(LabelFileFormat.CREATE_ML).menu_title,
+                         '&CreateML')
+        self.assertEqual(fm.meta_for_enum(LabelFileFormat.COCO).menu_title, '&COCO')
+        self.assertEqual(fm.meta_for_enum(LabelFileFormat.YOLO_SEG).menu_title,
+                         '&YOLO-seg')
+
+    def test_unknown_enum_falls_back_to_pascal_voc(self):
+        meta = fm.meta_for_enum(None)
+        self.assertEqual(meta.enum, LabelFileFormat.PASCAL_VOC)
+        self.assertEqual(meta.menu_title, '&PascalVOC')
+
+
+class TestCycle(unittest.TestCase):
+
+    def test_cycle_order_and_warnings(self):
+        nxt, warn = fm.next_in_cycle(LabelFileFormat.PASCAL_VOC)
+        self.assertEqual(nxt, FORMAT_YOLO)
+        self.assertIn('difficult', warn)
+
+        self.assertEqual(fm.next_in_cycle(LabelFileFormat.YOLO)[0], FORMAT_CREATEML)
+        self.assertEqual(fm.next_in_cycle(LabelFileFormat.CREATE_ML)[0], FORMAT_COCO)
+        self.assertEqual(fm.next_in_cycle(LabelFileFormat.COCO)[0], FORMAT_YOLO_SEG)
+        self.assertEqual(fm.next_in_cycle(LabelFileFormat.YOLO_SEG)[0],
+                         FORMAT_PASCALVOC)
+
+    def test_full_cycle_returns_to_start(self):
+        enum = LabelFileFormat.PASCAL_VOC
+        seen = [enum]
+        for _ in range(5):
+            name, _w = fm.next_in_cycle(enum)
+            enum = fm.by_name(name).enum
+            seen.append(enum)
+        self.assertEqual(seen[0], seen[-1])  # back to PASCAL_VOC after 5 hops
+        self.assertEqual(len(set(seen[:-1])), 5)  # all five visited once
+
+    def test_unknown_format_raises(self):
+        with self.assertRaises(ValueError):
+            fm.next_in_cycle(None)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

Fifth (final planned) slice of the **MainWindow decomposition**. Consolidates the annotation-format display data into `libs/formats/format_metadata.py`.

## Why

The same per-format facts lived in three hand-synced places in MainWindow:
- `get_format_meta` — menu title + icon (a nested `if/elif` in `__init__`),
- `set_format` — icon, enum, file suffix (a five-branch `if/elif`),
- `change_format` — the cycle order + warning messages.

## How

One ordered list of `FormatMeta(name, enum, icon, menu_title, suffix)` records is the single source of truth, with three lookups:
- `by_name(FORMAT_*)` → meta (or None),
- `meta_for_enum(LabelFileFormat)` → meta (PASCAL VOC fallback, as before),
- `next_in_cycle(LabelFileFormat)` → `(next_name, warning)` (raises `ValueError` on unknown, as before).

The module is pure data (no Qt), so it has no dependency on the MainWindow module and is unit testable. `set_format`/`change_format` become thin lookups and the nested `get_format_meta` is removed. Icons, suffixes, cycle order, and warnings are all preserved.

## Tests

New `tests/formats/test_format_metadata.py` — 7 tests: every identifier→meta mapping, the enum fallback, and the full 5-step cycle with warnings.

Full suite: **592 passing** (was 585). MainWindow shrinks ~59 lines.

---

This completes the five planned decomposition slices (#82, #83, #84, #88, this). MainWindow has shed ~300 lines of orchestration into focused, unit-tested modules.