### PR TITLE
refactor: central DPI scaling utility (libs/utils/dpi.py)

### DIFF
--- a/libs/utils/dpi.py
+++ b/libs/utils/dpi.py
@@ -1,0 +1,50 @@
+# libs/utils/dpi.py
+"""Central DPI scaling utilities for HiDPI displays.
+
+A single source of truth for the screen scale factor so chrome, dialogs,
+stylesheets, and icons all scale by the same amount. Widget modules and the
+theme system import from here rather than computing DPI themselves.
+"""
+
+try:
+    from PyQt5.QtWidgets import QApplication
+except ImportError:
+    from PyQt4.QtGui import QApplication
+
+
+def get_dpi_scale_factor():
+    """Return the DPI scale factor for the primary screen.
+
+    Returns:
+        float: Scale factor (1.0 for standard 96 DPI, higher for HiDPI
+            displays). Falls back to 1.0 when no application or screen is
+            available (e.g. headless tests, Qt4).
+    """
+    app = QApplication.instance()
+    if app is None:
+        return 1.0
+
+    try:
+        screen = app.primaryScreen()
+        if screen:
+            # Logical DPI accounts for the user's display scaling setting.
+            logical_dpi = screen.logicalDotsPerInch()
+            # 96 DPI is the standard baseline on most systems.
+            return logical_dpi / 96.0
+    except AttributeError:
+        # Qt4 has no primaryScreen(); treat as unscaled.
+        pass
+
+    return 1.0
+
+
+def scale_px(n):
+    """Scale a base pixel value by the current DPI factor.
+
+    Args:
+        n: Pixel value defined at the 96 DPI baseline.
+
+    Returns:
+        int: ``n`` scaled by the DPI factor, rounded to the nearest integer.
+    """
+    return int(round(n * get_dpi_scale_factor()))

--- a/libs/widgets/toolBar.py
+++ b/libs/widgets/toolBar.py
@@ -5,16 +5,18 @@ try:
     from PyQt5.QtCore import Qt, pyqtSignal, QSize
     from PyQt5.QtWidgets import (
         QToolBar, QToolButton, QWidgetAction, QWidget,
-        QMenu, QSizePolicy, QApplication
+        QMenu, QSizePolicy
     )
 except ImportError:
     from PyQt4.QtGui import (
         QToolBar, QToolButton, QWidgetAction, QWidget,
-        QMenu, QSizePolicy, QApplication
+        QMenu, QSizePolicy
     )
     from PyQt4.QtCore import Qt, pyqtSignal, QSize
 
 from libs.utils.styles import Theme, get_expand_button_style
+# Re-exported for back-compat: get_dpi_scale_factor now lives in libs.utils.dpi.
+from libs.utils.dpi import get_dpi_scale_factor
 
 
 # Base icon size for toolbar buttons (Feather icons are 24x24)
@@ -22,31 +24,6 @@ BASE_ICON_SIZE = 22
 # Minimum and maximum icon sizes for scaling
 MIN_ICON_SIZE = 16
 MAX_ICON_SIZE = 48
-
-
-def get_dpi_scale_factor():
-    """Get the DPI scale factor for the primary screen.
-
-    Returns:
-        float: Scale factor (1.0 for standard 96 DPI, higher for HiDPI displays)
-    """
-    app = QApplication.instance()
-    if app is None:
-        return 1.0
-
-    # Try to get the primary screen
-    try:
-        screen = app.primaryScreen()
-        if screen:
-            # Get logical DPI (accounts for user scaling settings)
-            logical_dpi = screen.logicalDotsPerInch()
-            # Standard DPI is 96 on most systems
-            return logical_dpi / 96.0
-    except AttributeError:
-        # Qt4 fallback
-        pass
-
-    return 1.0
 
 
 def calculate_icon_size(base_size=BASE_ICON_SIZE):

--- a/tests/utils/test_dpi.py
+++ b/tests/utils/test_dpi.py
@@ -1,0 +1,58 @@
+# tests/utils/test_dpi.py
+"""Tests for the central DPI scaling utilities."""
+
+import os
+import unittest
+from unittest.mock import patch
+
+os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')
+
+from PyQt5.QtWidgets import QApplication
+
+app = QApplication.instance() or QApplication([])
+
+from libs.utils import dpi
+
+
+class TestScalePx(unittest.TestCase):
+    """scale_px multiplies a base pixel value by the current DPI factor."""
+
+    def test_at_1x_returns_input_unchanged(self):
+        with patch.object(dpi, 'get_dpi_scale_factor', return_value=1.0):
+            self.assertEqual(dpi.scale_px(450), 450)
+
+    def test_at_2x_doubles_value(self):
+        with patch.object(dpi, 'get_dpi_scale_factor', return_value=2.0):
+            self.assertEqual(dpi.scale_px(450), 900)
+
+    def test_fractional_factor_rounds_to_nearest_int(self):
+        with patch.object(dpi, 'get_dpi_scale_factor', return_value=1.25):
+            self.assertEqual(dpi.scale_px(80), 100)
+
+    def test_returns_int_type(self):
+        with patch.object(dpi, 'get_dpi_scale_factor', return_value=1.5):
+            result = dpi.scale_px(24)
+            self.assertIsInstance(result, int)
+            self.assertEqual(result, 36)
+
+    def test_zero_stays_zero(self):
+        with patch.object(dpi, 'get_dpi_scale_factor', return_value=2.0):
+            self.assertEqual(dpi.scale_px(0), 0)
+
+
+class TestGetDpiScaleFactor(unittest.TestCase):
+    """get_dpi_scale_factor reads the primary screen's logical DPI."""
+
+    def test_returns_one_when_no_application(self):
+        with patch.object(dpi, 'QApplication') as mock_app:
+            mock_app.instance.return_value = None
+            self.assertEqual(dpi.get_dpi_scale_factor(), 1.0)
+
+    def test_returns_positive_float(self):
+        factor = dpi.get_dpi_scale_factor()
+        self.assertIsInstance(factor, float)
+        self.assertGreater(factor, 0.0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

First slice of issue #66 (HiDPI scaling). Establishes the single source of truth for screen scaling before any sites are rewired.

- New `libs/utils/dpi.py`:
  - `get_dpi_scale_factor()` — moved verbatim out of `libs/widgets/toolBar.py` (cross-cutting concern; doesn't belong in a widget module).
  - `scale_px(n)` — scales a 96-DPI baseline pixel value by the current factor, rounded to nearest int.
- `toolBar.py` now imports `get_dpi_scale_factor` from `dpi.py` and re-exports it (back-compat shim); dropped the now-unused `QApplication` import.

## Why a dedicated module

Both `styles.py` (stylesheet generation) and `toolBar.py` (icon sizing) need the factor. A single-purpose `dpi.py` keeps it testable in isolation and avoids each site recomputing DPI. Chrome will scale by the **same** factor that already drives icon sizing, which is what keeps the UI proportional.

## Tests

- New `tests/utils/test_dpi.py` (7 tests): `scale_px` at 1×/2×/fractional, int type, zero, and `get_dpi_scale_factor` fallback when no `QApplication`.
- Full suite green (599 passed), `QT_QPA_PLATFORM=offscreen`.

## Behaviour

No change. Pure extraction + new helper with no consumers yet. Follow-up slices wire `scale_px` into dialog/dock/status/gallery sizes and into `styles.py` stylesheet literals.

Refs #66