### PR TITLE
feat: scale fixed widget sizes for HiDPI displays

### DIFF
--- a/libs/widgets/batchVerifyDialog.py
+++ b/libs/widgets/batchVerifyDialog.py
@@ -7,6 +7,8 @@ from PyQt5.QtWidgets import (
 )
 from PyQt5.QtCore import Qt
 
+from libs.utils.dpi import scale_px
+
 
 class BatchVerifyDialog(QDialog):
     """Dialog for batch verifying or unverifying annotated images.
@@ -28,7 +30,7 @@ class BatchVerifyDialog(QDialog):
         """
         super().__init__(parent)
         self.setWindowTitle('Batch Verify')
-        self.setMinimumWidth(350)
+        self.setMinimumWidth(scale_px(350))
 
         layout = QVBoxLayout()
         layout.addWidget(QLabel(f'Images: {image_count}'))

--- a/libs/widgets/galleryWidget.py
+++ b/libs/widgets/galleryWidget.py
@@ -21,6 +21,7 @@ try:
 except ImportError:
     ElementTree = None
 
+from libs.utils.dpi import scale_px
 from libs.utils.styles import Theme, get_slider_style, get_gallery_controls_style, get_gallery_list_style
 
 
@@ -374,7 +375,7 @@ class GalleryWidget(QWidget):
             }
             for label, size in self.size_presets.items():
                 btn = QPushButton(label)
-                btn.setFixedSize(32, 26)
+                btn.setFixedSize(scale_px(32), scale_px(26))
                 btn.setAutoFillBackground(True)  # Required for stylesheet bg
                 btn.clicked.connect(lambda checked, s=size: self._set_preset_size(s))
                 slider_layout.addWidget(btn)
@@ -392,7 +393,7 @@ class GalleryWidget(QWidget):
 
             # Size value display
             self.size_value_label = QLabel(f"{self._icon_size}px")
-            self.size_value_label.setMinimumWidth(50)
+            self.size_value_label.setMinimumWidth(scale_px(50))
             slider_layout.addWidget(self.size_value_label)
 
             layout.addWidget(self._slider_frame)

--- a/libs/widgets/keypointPanel.py
+++ b/libs/widgets/keypointPanel.py
@@ -6,6 +6,7 @@ from PyQt5.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QLabel,
 from PyQt5.QtCore import pyqtSignal, Qt
 
 from libs.core.keypoint_config import get_keypoint_color, get_template
+from libs.utils.dpi import scale_px
 from libs.utils.styles import Theme, get_theme_colors
 
 
@@ -54,7 +55,7 @@ class KeypointPanel(QWidget):
             row.setSpacing(4)
 
             status_label = QLabel('\u25cb')
-            status_label.setFixedWidth(16)
+            status_label.setFixedWidth(scale_px(16))
             status_label.setAlignment(Qt.AlignCenter)
 
             name_btn = QPushButton(name.replace('_', ' ').title())
@@ -64,10 +65,10 @@ class KeypointPanel(QWidget):
                 lambda checked, idx=i: self.keypointClicked.emit(idx))
 
             color_indicator = QLabel()
-            color_indicator.setFixedSize(8, 8)
+            color_indicator.setFixedSize(scale_px(8), scale_px(8))
             color_hex = get_keypoint_color(i, template_name)
             color_indicator.setStyleSheet(
-                'background: %s; border-radius: 4px;' % color_hex)
+                'background: %s; border-radius: %dpx;' % (color_hex, scale_px(4)))
 
             row.addWidget(color_indicator)
             row.addWidget(status_label)

--- a/libs/widgets/shortcutsDialog.py
+++ b/libs/widgets/shortcutsDialog.py
@@ -7,6 +7,7 @@ from PyQt5.QtWidgets import (
 )
 from PyQt5.QtCore import Qt
 
+from libs.utils.dpi import scale_px
 from libs.utils.styles import Theme, get_theme_colors, hex_to_qcolor
 
 
@@ -14,7 +15,7 @@ class ShortcutsDialog(QDialog):
     def __init__(self, shortcut_config, action_map, parent=None):
         super().__init__(parent)
         self.setWindowTitle('Keyboard Shortcuts')
-        self.setMinimumSize(550, 500)
+        self.setMinimumSize(scale_px(550), scale_px(500))
         self.config = shortcut_config
         self.action_map = action_map  # {action_name: QAction}
         self._pending = dict(shortcut_config.get_all())

--- a/libs/widgets/splitDialog.py
+++ b/libs/widgets/splitDialog.py
@@ -9,6 +9,8 @@ from PyQt5.QtWidgets import (
     QProgressBar, QPushButton, QRadioButton, QSpinBox, QVBoxLayout,
 )
 
+from libs.utils.dpi import scale_px
+
 
 class SplitDialog(QDialog):
     """Dialog for configuring dataset train/val/test split parameters."""
@@ -16,7 +18,7 @@ class SplitDialog(QDialog):
     def __init__(self, parent=None, image_count=0, default_dir=''):
         super().__init__(parent)
         self.setWindowTitle('Split Dataset')
-        self.setMinimumWidth(450)
+        self.setMinimumWidth(scale_px(450))
         self._image_count = image_count
 
         layout = QVBoxLayout()

--- a/libs/widgets/toolBar.py
+++ b/libs/widgets/toolBar.py
@@ -15,8 +15,8 @@ except ImportError:
     from PyQt4.QtCore import Qt, pyqtSignal, QSize
 
 from libs.utils.styles import Theme, get_expand_button_style
-# Re-exported for back-compat: get_dpi_scale_factor now lives in libs.utils.dpi.
-from libs.utils.dpi import get_dpi_scale_factor
+# get_dpi_scale_factor re-exported for back-compat; it now lives in libs.utils.dpi.
+from libs.utils.dpi import get_dpi_scale_factor, scale_px
 
 
 # Base icon size for toolbar buttons (Feather icons are 24x24)
@@ -61,8 +61,8 @@ class ToolBar(QToolBar):
 
         # Expand/collapse state
         self._expanded = False
-        self._collapsed_width = 85
-        self._expanded_width = 140
+        self._collapsed_width = scale_px(85)
+        self._expanded_width = scale_px(140)
         self._expand_btn = None
 
     def addAction(self, action):

--- a/tests/widgets/test_hidpi_scaling.py
+++ b/tests/widgets/test_hidpi_scaling.py
@@ -1,0 +1,88 @@
+# tests/widgets/test_hidpi_scaling.py
+"""HiDPI scaling of fixed widget sizes (issue #66).
+
+Each test pins the DPI factor to 2x and asserts that the widget's fixed or
+minimum dimensions double. At the default 1x factor these wraps are no-ops,
+so the production change is invisible on standard displays.
+"""
+
+import os
+import unittest
+from unittest.mock import patch
+
+os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')
+
+from PyQt5.QtWidgets import QApplication
+
+app = QApplication.instance() or QApplication([])
+
+from libs.utils import dpi
+from libs.core.shortcut_config import ShortcutConfig
+from libs.widgets.batchVerifyDialog import BatchVerifyDialog
+from libs.widgets.shortcutsDialog import ShortcutsDialog
+from libs.widgets.splitDialog import SplitDialog
+from libs.widgets.keypointPanel import KeypointPanel
+from libs.widgets.galleryWidget import GalleryWidget
+from libs.widgets.toolBar import ToolBar
+
+
+def _at_2x():
+    """Patch the DPI factor to 2.0 for the duration of a with-block."""
+    return patch.object(dpi, 'get_dpi_scale_factor', return_value=2.0)
+
+
+class TestDialogMinimumsScale(unittest.TestCase):
+    def test_split_dialog_minimum_width_doubles(self):
+        with _at_2x():
+            dialog = SplitDialog(parent=None, image_count=10, default_dir='/tmp')
+        self.assertEqual(dialog.minimumWidth(), 900)
+
+    def test_batch_verify_dialog_minimum_width_doubles(self):
+        with _at_2x():
+            dialog = BatchVerifyDialog(parent=None, image_count=10,
+                                       annotated_count=5)
+        self.assertEqual(dialog.minimumWidth(), 700)
+
+    def test_shortcuts_dialog_minimum_size_doubles(self):
+        with _at_2x():
+            dialog = ShortcutsDialog(ShortcutConfig(), {})
+        self.assertEqual(dialog.minimumWidth(), 1100)
+        self.assertEqual(dialog.minimumHeight(), 1000)
+
+
+class TestToolBarWidthsScale(unittest.TestCase):
+    def test_collapsed_and_expanded_widths_double(self):
+        with _at_2x():
+            toolbar = ToolBar('test')
+        self.assertEqual(toolbar._collapsed_width, 170)
+        self.assertEqual(toolbar._expanded_width, 280)
+
+
+class TestGalleryControlsScale(unittest.TestCase):
+    def test_preset_buttons_fixed_size_doubles(self):
+        with _at_2x():
+            gallery = GalleryWidget(show_size_slider=True)
+        self.assertTrue(gallery._preset_buttons)
+        btn = gallery._preset_buttons[0]
+        self.assertEqual(btn.minimumWidth(), 64)
+        self.assertEqual(btn.minimumHeight(), 52)
+
+    def test_size_value_label_minimum_width_doubles(self):
+        with _at_2x():
+            gallery = GalleryWidget(show_size_slider=True)
+        self.assertEqual(gallery.size_value_label.minimumWidth(), 100)
+
+
+class TestKeypointPanelIndicatorsScale(unittest.TestCase):
+    def test_status_label_fixed_width_doubles(self):
+        with _at_2x():
+            panel = KeypointPanel()
+            panel.load_template('person')
+        self.assertTrue(panel._rows)
+        status = panel._rows[0]['status']
+        self.assertEqual(status.minimumWidth(), 32)
+        self.assertEqual(status.maximumWidth(), 32)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Second slice of issue #66. Wires the `scale_px` helper from #90 into the hardcoded fixed/minimum widget sizes so chrome scales with DPI like the icons already do.

Sites scaled (via `scale_px`):
- `splitDialog` / `batchVerifyDialog` / `shortcutsDialog` — dialog minimum sizes
- `keypointPanel` — per-row status label width, colour indicator size, and its `border-radius` (kept = size/2 so it stays round)
- `galleryWidget` — preset size buttons (`32x26`) and the size-value label min width
- `toolBar` — collapsed (`85`) / expanded (`140`) widths

## Behaviour

At the default **1x** factor every wrap is a no-op — standard displays are byte-for-byte unchanged. On a 2x display these dimensions double.

## Tests

New `tests/widgets/test_hidpi_scaling.py` (7 tests) pins the factor to 2x via `patch.object(dpi, 'get_dpi_scale_factor', return_value=2.0)`, constructs each widget, and asserts the dimension doubles (using `minimumWidth/Height`, which `setFixed*` sets directly and is reliable pre-show). Full suite green (606 passed).

## Not in this slice

- MainWindow chrome (dock minimums, status-bar label widths, `gallery_stats` min width) — next slice.
- Stylesheet `padding`/`margin`/`font-size` literals in `styles.py` — separate slice.
- Canvas hit-test epsilon — deliberately deferred; it changes interaction tolerance and warrants a manual check on real hardware.

Refs #66