### PR TITLE
feat: scale MainWindow chrome minimums for HiDPI displays

### DIFF
--- a/labelImgPlusPlus.py
+++ b/labelImgPlusPlus.py
@@ -95,6 +95,7 @@ from libs.utils.utils import (
     new_icon, themed_icon, new_action, add_actions, format_shortcut, Struct,
     generate_color_by_text, have_qstring, natural_sort
 )
+from libs.utils.dpi import scale_px
 from libs.utils.stringBundle import StringBundle
 from libs.utils.styles import get_combined_style, Theme, get_stylesheet, get_canvas_background
 from libs.utils.ustr import ustr
@@ -507,10 +508,10 @@ class MainWindow(QMainWindow, WindowMixin):
         self.file_dock.setFeatures(QDockWidget.DockWidgetMovable | QDockWidget.DockWidgetFloatable)
 
         # Set minimum sizes for better resize UX
-        self.dock.setMinimumHeight(100)
-        self.file_dock.setMinimumHeight(100)
-        self.dock.setMinimumWidth(200)
-        self.file_dock.setMinimumWidth(200)
+        self.dock.setMinimumHeight(scale_px(100))
+        self.file_dock.setMinimumHeight(scale_px(100))
+        self.dock.setMinimumWidth(scale_px(200))
+        self.file_dock.setMinimumWidth(scale_px(200))
 
         # Features toggled by advanced mode (closable/floatable for labels dock)
         self.dock_features = QDockWidget.DockWidgetClosable | QDockWidget.DockWidgetFloatable
@@ -1069,17 +1070,17 @@ class MainWindow(QMainWindow, WindowMixin):
         # Status bar permanent widgets (left to right)
         # Image counter
         self.label_image_count = QLabel('Image: 0 / 0')
-        self.label_image_count.setMinimumWidth(100)
+        self.label_image_count.setMinimumWidth(scale_px(100))
         self.statusBar().addPermanentWidget(self.label_image_count)
 
         # Annotation count
         self.label_box_count = QLabel('Boxes: 0')
-        self.label_box_count.setMinimumWidth(70)
+        self.label_box_count.setMinimumWidth(scale_px(70))
         self.statusBar().addPermanentWidget(self.label_box_count)
 
         # Zoom level
         self.label_zoom = QLabel('Zoom: 100%')
-        self.label_zoom.setMinimumWidth(80)
+        self.label_zoom.setMinimumWidth(scale_px(80))
         self.statusBar().addPermanentWidget(self.label_zoom)
 
         # Save status indicator
@@ -1220,8 +1221,8 @@ class MainWindow(QMainWindow, WindowMixin):
         # Stats panel (side)
         self.gallery_stats = StatsWidget()
         self.gallery_stats.refresh_btn.clicked.connect(self._refresh_all_statistics)
-        self.gallery_stats.setMaximumWidth(300)
-        self.gallery_stats.setMinimumWidth(250)
+        self.gallery_stats.setMaximumWidth(scale_px(300))
+        self.gallery_stats.setMinimumWidth(scale_px(250))
         layout.addWidget(self.gallery_stats, stretch=1)
 
         self.gallery_window.setCentralWidget(central_widget)

--- a/tests/integration/test_main_window.py
+++ b/tests/integration/test_main_window.py
@@ -806,5 +806,30 @@ class TestBatchVerify(unittest.TestCase):
             PascalVocReader(os.path.join(self.d, 'a.xml')).verified)
 
 
+class TestMainWindowChromeScalesForHiDPI(unittest.TestCase):
+    """MainWindow status-bar label widths scale with DPI (issue #66).
+
+    Dock minimums (200x100) are also wrapped in scale_px, but their effective
+    minimumWidth/Height is content-dominated (the docked widgets impose a
+    larger floor), so they are not asserted here.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        # Build the window once, under a pinned 2x factor. Keep app/win as
+        # class attributes so the QApplication is not garbage-collected
+        # mid-suite (a local binding would destroy it and segfault later
+        # tests). This mirrors the other integration test classes.
+        from unittest.mock import patch
+        from libs.utils import dpi
+        with patch.object(dpi, 'get_dpi_scale_factor', return_value=2.0):
+            cls.app, cls.win = get_main_app()
+
+    def test_status_bar_label_minimums_double_at_2x(self):
+        self.assertEqual(self.win.label_image_count.minimumWidth(), 200)
+        self.assertEqual(self.win.label_box_count.minimumWidth(), 140)
+        self.assertEqual(self.win.label_zoom.minimumWidth(), 160)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

Third slice of issue #66. Wires `scale_px` into the MainWindow chrome size literals.

- Status-bar label minimum widths — `image count` (100), `box count` (70), `zoom` (80)
- Dock minimums — labels/file docks `200x100`
- Gallery stats panel — min `250` **and** max `300` (both scaled, so min can't exceed max at high factors)

## Behaviour

No-op at 1x; doubles at 2x.

## What's testable here

The status-bar labels are the clean win — their `minimumWidth()` binds directly, so the integration test asserts they double at 2x. The **dock** minimums are content-dominated in practice (the docked widgets impose a larger floor, ~419x338), so they're scaled for floor-intent consistency but not asserted. The gallery stats panel is built lazily, so it isn't directly asserted either.

## Test design note

The new integration test builds the window once under a pinned 2x factor and holds `app`/`win` at **class scope**. A local binding would let the second `QApplication` get garbage-collected at method end and segfault later tests — class scope (matching the other integration test classes) keeps it alive. Full suite green (607 passed).

Refs #66