### PR TITLE
fix: correct module path for auto icon-size import

### DIFF
--- a/labelImgPlusPlus.py
+++ b/labelImgPlusPlus.py
@@ -3257,7 +3257,7 @@ class MainWindow(QMainWindow, WindowMixin):
 
             if size == 0:
                 # Auto mode - recalculate from DPI
-                from libs.toolBar import calculate_icon_size
+                from libs.widgets.toolBar import calculate_icon_size
                 size = calculate_icon_size()
 
             # Update toolbar icon size

--- a/tests/integration/test_main_window.py
+++ b/tests/integration/test_main_window.py
@@ -58,6 +58,21 @@ class TestMainWindowFileOperations(unittest.TestCase):
         self.assertEqual(self.win.file_path, self.test_image_path)
         self.assertFalse(self.win.image.isNull())
 
+    def test_change_icon_size_auto_mode_does_not_raise(self):
+        """Selecting 'Auto' icon size must not crash.
+
+        Regression: the auto branch imported calculate_icon_size from the
+        non-existent module path `libs.toolBar` (it lives in
+        `libs.widgets.toolBar`), raising ModuleNotFoundError. sender() is
+        patched to a fake Auto action (data() == 0) and the slot is called
+        directly so any exception propagates.
+        """
+        from unittest.mock import MagicMock, patch
+        fake_action = MagicMock()
+        fake_action.data.return_value = 0  # 0 == Auto
+        with patch.object(self.win, 'sender', return_value=fake_action):
+            self.win.change_icon_size()  # must not raise
+
     def test_apply_theme_without_scroll_area_does_not_raise(self):
         """_apply_theme must not NameError when scroll_area is absent.
 


### PR DESCRIPTION
## Summary

`change_icon_size`'s auto branch did `from libs.toolBar import calculate_icon_size` — but that module doesn't exist (it's `libs.widgets.toolBar`). Selecting the **Auto** toolbar icon size raised `ModuleNotFoundError`.

One-line path fix.

## Test

New regression test patches `sender()` to a fake Auto action (`data() == 0`) and calls `change_icon_size()` directly so the exception propagates (signal dispatch would swallow it). RED → `ModuleNotFoundError`; GREEN after the fix. Full suite green (608 passed).

Found incidentally while wiring DPI scaling for #66.