### PR TITLE
feat: scale canvas hit-test epsilon for HiDPI displays

### DIFF
--- a/libs/widgets/canvas.py
+++ b/libs/widgets/canvas.py
@@ -14,6 +14,7 @@ except ImportError:
 import math
 
 from libs.core.shape import Shape, ShapeType
+from libs.utils.dpi import scale_px
 from libs.utils.utils import distance
 from libs.utils.styles import Theme
 
@@ -77,11 +78,14 @@ class Canvas(QWidget):
 
     CREATE, EDIT, CREATE_POLYGON, KEYPOINT_MODE = list(range(4))
 
-    epsilon = 24.0
-
     def __init__(self, *args, **kwargs):
         super(Canvas, self).__init__(*args, **kwargs)
         # Initialise local state.
+        # Hit-test tolerance as a screen-pixel radius; scaled for HiDPI so
+        # grabbing vertices feels the same on high-density displays. Set per
+        # instance (not a class attribute) so the DPI factor is read after the
+        # QApplication exists.
+        self.epsilon = float(scale_px(24))
         self.mode = self.EDIT
         self.shapes = []
         self.current = None

--- a/tests/widgets/test_hidpi_scaling.py
+++ b/tests/widgets/test_hidpi_scaling.py
@@ -24,6 +24,7 @@ from libs.widgets.splitDialog import SplitDialog
 from libs.widgets.keypointPanel import KeypointPanel
 from libs.widgets.galleryWidget import GalleryWidget
 from libs.widgets.toolBar import ToolBar
+from libs.widgets.canvas import Canvas
 
 
 def _at_2x():
@@ -82,6 +83,20 @@ class TestKeypointPanelIndicatorsScale(unittest.TestCase):
         status = panel._rows[0]['status']
         self.assertEqual(status.minimumWidth(), 32)
         self.assertEqual(status.maximumWidth(), 32)
+
+
+class TestCanvasEpsilonScales(unittest.TestCase):
+    """The hit-test epsilon is a screen-pixel radius, so it scales with DPI."""
+
+    def test_epsilon_doubles_at_2x(self):
+        with _at_2x():
+            canvas = Canvas()
+        self.assertEqual(canvas.epsilon, 48.0)
+
+    def test_epsilon_unchanged_at_1x(self):
+        with patch.object(dpi, 'get_dpi_scale_factor', return_value=1.0):
+            canvas = Canvas()
+        self.assertEqual(canvas.epsilon, 24.0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Last item of issue #66. The canvas vertex/edge grab tolerance `epsilon` (24px) is a **screen-pixel radius** — the nearest-vertex threshold divides it by the zoom scale — so on HiDPI displays it should scale to preserve the same physical grab feel. Wrapped in `scale_px`.

`epsilon` moves from a **class attribute to a per-instance** value (`self.epsilon = float(scale_px(24))` in `__init__`) so the DPI factor is read at Canvas construction, after `QApplication` exists — a class-body `scale_px(24)` would evaluate at import time and always be 1x. Verified nothing reads `Canvas.epsilon` as a class attribute or overrides it.

## Behaviour

No-op at 1x (stays `24.0`); `48.0` at 2x.

⚠️ The HiDPI *feel* (click-to-vertex tolerance) was not verified on real high-density hardware — the offscreen test platform reports factor 1.0. The scaling is semantically correct per the code's own "screen-pixel radius" contract, but worth a manual sanity check on a 2x display.

## Tests

2 new tests in `tests/widgets/test_hidpi_scaling.py`: epsilon doubles at 2x, unchanged at 1x. Full suite green (614 passed).

Closes #66