### PR TITLE
feat(video): add smart video annotation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,13 @@ jobs:
           pyrcc5 -o libs/resources.py resources.qrc
           python scripts/verify_qt_resources.py
 
+      - name: Verify base startup stays optional-feature-free
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: |
+          python -c "import sys; import labelImgPlusPlus; assert 'av' not in sys.modules; assert 'cv2' not in sys.modules; assert 'numpy' not in sys.modules"
+          python -c "from libs.core.video_decoder import VIDEO_INSTALL_HINT; assert 'labelimgplusplus[video]' in VIDEO_INSTALL_HINT"
+
       - name: Run tests
         env:
           QT_QPA_PLATFORM: offscreen
@@ -91,8 +98,117 @@ jobs:
             tests/utils/test_sam_constants.py \
             -v
 
+  video-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: pyproject.toml
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils libegl1-mesa-dev
+
+      - name: Install package with video dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install '.[video]' pytest
+
+      - name: Build and verify Qt resources
+        run: |
+          pyrcc5 -o libs/resources.py resources.qrc
+          python scripts/verify_qt_resources.py
+
+      - name: Run focused video tests
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: python -m pytest tests/video -v
+
+  sam-video-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.8', '3.13']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: pyproject.toml
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils libegl1-mesa-dev
+
+      - name: Install combined optional dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install '.[sam,video]' pytest
+
+      - name: Build and verify Qt resources
+        run: |
+          pyrcc5 -o libs/resources.py resources.qrc
+          python scripts/verify_qt_resources.py
+
+      - name: Run combined feature tests
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: |
+          python -m pytest \
+            tests/video \
+            tests/integrations \
+            tests/integration/test_sam_controller.py \
+            tests/integration/test_sam_mainwindow.py \
+            tests/widgets/test_canvas_sam.py \
+            tests/widgets/test_sam_settings_dialog.py \
+            tests/utils/test_sam_constants.py \
+            -v
+
+  video-platform-smoke:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: pyproject.toml
+
+      - name: Install package with video dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install '.[video]' pytest
+
+      - name: Run decoder and persistence smoke tests
+        run: |
+          python -m pytest tests/video/test_decoder.py tests/video/test_project.py tests/video/test_model.py tests/video/test_tracking.py tests/video/test_export.py -v
+
   build-release:
-    needs: [test, sam-test]
+    needs: [test, sam-test, video-test, sam-video-test, video-platform-smoke]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
 
@@ -149,7 +265,7 @@ jobs:
           if-no-files-found: error
 
   package-macos:
-    needs: [test, sam-test]
+    needs: [test, sam-test, video-test, sam-video-test, video-platform-smoke]
     runs-on: macos-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
@@ -175,7 +291,7 @@ jobs:
           if-no-files-found: error
 
   package-windows:
-    needs: [test, sam-test]
+    needs: [test, sam-test, video-test, sam-video-test, video-platform-smoke]
     runs-on: windows-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
@@ -202,7 +318,7 @@ jobs:
           if-no-files-found: error
 
   package-linux:
-    needs: [test, sam-test]
+    needs: [test, sam-test, video-test, sam-video-test, video-platform-smoke]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -204,8 +204,10 @@ jobs:
           pip install '.[video]' pytest
 
       - name: Run decoder and persistence smoke tests
+        env:
+          QT_QPA_PLATFORM: offscreen
         run: |
-          python -m pytest tests/video/test_decoder.py tests/video/test_project.py tests/video/test_model.py tests/video/test_tracking.py tests/video/test_export.py -v
+          python -m pytest tests/video/test_decoder.py tests/video/test_project.py tests/video/test_model.py tests/video/test_tracking.py tests/video/test_export.py tests/video/test_opening.py tests/video/test_navigation.py tests/video/test_timeline.py -v
 
   build-release:
     needs: [test, sam-test, video-test, sam-video-test, video-platform-smoke]

--- a/README.rst
+++ b/README.rst
@@ -106,6 +106,23 @@ Workflow and Interface
     extra installed, the action stays disabled (with an install hint) and
     nothing else changes.
 
+**Smart Video Annotation** (optional)
+    Open local MP4, MOV, MKV, and AVI video, annotate on exact presentation
+    timestamps, interpolate rectangle keyframes, and propagate rectangles with
+    reviewable optical-flow suggestions. Video work is stored in a sibling
+    ``<video>.labelimgpp.sqlite`` project; existing image annotations and
+    formats are unchanged.
+
+    .. code:: shell
+
+        pip install labelimgplusplus[video]
+
+    The timeline supports frame stepping, exact timecode seeks, variable-rate
+    media, playback without audio, track markers, and verified-frame markers.
+    Accepted frames export to VOC, YOLO, YOLO-seg, COCO, or CreateML. See the
+    `Smart Video Annotation Guide <https://github.com/abhiksark/labelImg-plus-plus/blob/dev/docs/features/smart-video-annotation.md>`_
+    for the project, review, and export workflow.
+
 Installation
 ------------
 
@@ -132,6 +149,13 @@ With a specific image or directory:
 .. code:: shell
 
     labelimgpp [IMAGE_PATH] [PRE-DEFINED CLASS FILE] [SAVE_DIR]
+
+The first positional path can also be a local video or a
+``.labelimgpp.sqlite`` video project. Optional features can be combined:
+
+.. code:: shell
+
+    pip install labelimgplusplus[sam,video]
 
 Build from Source
 ~~~~~~~~~~~~~~~~~
@@ -170,6 +194,10 @@ Quick Start
 4. **Save**: Press **Ctrl+S** to save annotations
 5. **Navigate**: Use **D** (next) and **A** (previous) to move between images
 6. **Review**: Press **Ctrl+G** for gallery mode to review all annotations
+
+For video, press **Ctrl+Alt+V**, draw a rectangle or polygon on the paused
+frame, then use the **Tracks** tab and **Tools** menu to add keyframes, track,
+review suggestions, and export accepted frames.
 
 Supported Annotation Formats
 ----------------------------
@@ -212,6 +240,8 @@ These are the defaults. They can be changed from **Help → Keyboard Shortcuts**
 +--------------------+--------------------------------------------+
 | Ctrl + O           | Open file                                  |
 +--------------------+--------------------------------------------+
+| Ctrl + Alt + V     | Open video or video project                |
++--------------------+--------------------------------------------+
 | Ctrl + U           | Open directory                             |
 +--------------------+--------------------------------------------+
 | Ctrl + R           | Change save directory                      |
@@ -232,6 +262,11 @@ These are the defaults. They can be changed from **Help → Keyboard Shortcuts**
 +--------------------+--------------------------------------------+
 | Ctrl + G           | Toggle Gallery Mode                        |
 +--------------------+--------------------------------------------+
+
+In video mode, **A/D** step exact frames, **Ctrl+Space** toggles playback,
+**Shift+K** adds a keyframe to the selected track, **T/Shift+T** track forward
+or backward, and **Shift+Enter/Backspace** accept or reject the current
+suggestion. **Space** continues to verify the current frame.
 
 **Annotation**
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,7 +24,7 @@ are parsed and indexed once per `(path, mtime_ns, size)` fingerprint.
 UI navigation calls `request_load_file()`. Its worker returns an immutable
 `ImageLoadResult` containing a worker-owned `QImage` and raw shape tuples. Only
 the application thread creates `QPixmap`, `Shape`, and widget items. A
-fingerprinted five-frame/128 MiB LRU supports adjacent-image prefetch. The
+fingerprinted five-frame/96 MiB LRU supports adjacent-image prefetch. The
 historical synchronous `load_file()` remains available to extensions and
 tests.
 
@@ -32,6 +32,47 @@ Menu, shortcut, autosave, navigation, and verification saves create immutable
 `SaveRequest` values. Worker serialization is atomically published with
 `os.replace`; a revision check marks the document clean only if no later edit
 occurred. `save_file()` remains the synchronous compatibility entry point.
+
+## Smart-video pipeline
+
+`DocumentKind` isolates no-document, image, and video state. Video requests use
+a dedicated one-thread decoder lane; tracking and export use independent PyAV
+contexts on the background lane so bulk work cannot block scrubbing. Workers
+return immutable records and detached `QImage` values. `QPixmap`, `Shape`, dock,
+track-list, timeline, and canvas mutation remain on `QApplication.thread()`.
+
+Opening is transactional. `video_session.py` resolves a video/project source,
+opens the first playable stream, fingerprints bounded source samples, decodes
+the first frame, and validates or initializes SQLite before MainWindow swaps
+the visible document. Failed or stale requests close their new container and
+leave the old document intact. `open_video()` is the synchronous compatibility
+path; `request_open_video()` is the GUI path.
+
+The session-owned `VideoDecoderSession` seeks in stream PTS/time-base units,
+decodes forward from a keyframe, supports nearest or at/after selection, and
+applies stream or display-matrix rotation before display. Video uses up to 12
+entries in the shared 96 MiB frame cache. Together with two 16 MiB gallery
+caches, the application cache ceiling remains 128 MiB.
+
+`VideoProjectModel` is the in-memory overlay. It materializes accepted manual
+states, accepted tracker states, pending suggestions, or rectangle/keypoint
+interpolation in that order. Polygon interpolation is forbidden. Canvas edits
+become accepted manual observations; computed occurrences never serialize as
+image `Shape` state.
+
+`video_project.py` owns the application-ID/schema-versioned SQLite file. WAL,
+foreign keys, `synchronous=FULL`, busy timeout, expected durable revisions, and
+`BEGIN IMMEDIATE` delta commits fence concurrent or failed saves. MainWindow
+chains writes and only marks clean when the saved revision still matches.
+Save As uses SQLite backup and clean close checkpoints WAL.
+
+`video_tracking.py` performs bounded-resolution Shi–Tomasi/Lucas–Kanade flow
+and RANSAC affine estimation, emitting immutable pending observations. Session,
+request, generation, document-revision, and seed-revision checks discard stale
+batches. `video_export.py` decodes original-resolution oriented frames in an
+independent context, filters to accepted materialization, reuses the existing
+format contracts, and atomically publishes an owned staging directory plus a
+video manifest.
 
 ## System Architecture
 
@@ -422,10 +463,11 @@ labelImg++/
 
 ## Threading Model
 
-labelImg++ runs entirely on the main Qt event loop thread:
-- No background workers for I/O
-- UI remains responsive for typical image sizes
-- Large images may cause brief freezes during load/save
+The Qt application thread owns widgets, `QPixmap`, `Shape`, selection, and
+document mutation. Bounded coordinator lanes own image decode/catalog work,
+bulk jobs, SAM, and serialized interactive video decode. Background work uses
+immutable snapshots, cooperative cancellation, generation fencing, and queued
+signals to return plain data or detached `QImage` values to the UI.
 
 ## Extension Points
 

--- a/docs/features/smart-video-annotation.md
+++ b/docs/features/smart-video-annotation.md
@@ -1,0 +1,119 @@
+# Smart video annotation
+
+Smart video mode adds timestamp-accurate annotation without changing the image
+workflow or its file formats. It supports local MP4, MOV, MKV, and AVI sources,
+uses the first playable video stream, applies display rotation, and ignores
+audio.
+
+## Install and open
+
+```bash
+pip install "labelimgplusplus[video]"
+labelimgpp /path/to/clip.mp4
+```
+
+You can also use **File → Open Video…**, `Ctrl+Alt+V`, or pass an existing
+`.labelimgpp.sqlite` project as the normal first positional argument.
+
+Opening is transactional: the source, first frame, and project are validated
+before the current document is replaced. A new project is created only after
+the first frame decodes successfully. Its default path is the sibling
+`<video-filename>.labelimgpp.sqlite`. If that directory is not writable, choose
+another project path or cancel the picker to inspect the video read-only.
+
+The project stores a sampled content fingerprint. Moving a video is safe when
+the fingerprint still matches. Changed content is never combined with the old
+annotations; locate the original source, create a new project, or cancel.
+
+## Navigate the timeline
+
+The bottom timeline contains play/pause, previous/next frame, an exact
+`HH:MM:SS.mmm` entry, a normalized long-duration slider, and 0.25x, 0.5x, 1x,
+and 2x playback. The PTS is exact; the displayed frame number is approximate
+because variable-frame-rate media has no reliable integer frame index.
+
+- `A` and `D` step backward and forward in video mode.
+- `Ctrl+Space` toggles silent playback. `Space` verifies the current frame.
+- Dragging the timeline is debounced; releasing it performs an exact
+  latest-request-wins seek.
+- Drawing or editing pauses playback automatically.
+
+Blue spans show track coverage, green markers show accepted manual anchors,
+amber markers show pending suggestions, and purple markers show verified
+frames.
+
+## Tracks, anchors, and interpolation
+
+Drawing a rectangle or polygon on a video frame creates a UUID-backed track and
+an accepted manual observation at the current PTS. The **Tracks** tab shows the
+track label, span, color, visibility, and pending-review count. Renaming a
+tracked shape renames the track across the video.
+
+Select a track and press `Shift+K` to make the current materialized occurrence
+an editable manual keyframe. Rectangle geometry and compatible keypoints are
+interpolated by presentation time between accepted manual anchors. Polygon
+vertices are never interpolated. Blue dashed shapes are computed interpolation;
+amber dashed shapes are pending tracker suggestions.
+
+Deleting an exact occurrence removes that observation. Deleting an interpolated
+occurrence writes an explicit absence anchor, which ends interpolation until a
+later present anchor. **Tools → Delete Track…** removes all observations after
+confirmation. Video undo history is scoped to the current frame and clears on
+seek.
+
+SAM can create a manual polygon observation on a paused video frame when both
+the `sam` and `video` extras are installed. It is not an automatic video-mask
+tracker.
+
+## Optical-flow tracking and review
+
+Tracking starts from an accepted exact rectangle. Select it, then press `T` or
+`Shift+T`. The endpoint dialog defaults to the next manual anchor in that
+direction, or five seconds when none exists. The worker decodes independently,
+uses bounded-resolution pyramidal Lucas–Kanade flow with forward/backward
+validation and RANSAC, and stops on weak geometry, excessive error, bounds
+loss, or a scene cut.
+
+Suggestions remain pending until reviewed:
+
+- `Shift+Enter` accepts the current suggestion.
+- `Backspace` rejects the current suggestion.
+- The **Tools** menu can accept or reject the visible range or the full latest
+  propagation run.
+
+Accepted tracker observations become exact states but do not become
+interpolation anchors until promoted with `Shift+K`. Rejected suggestions stay
+recorded so they do not immediately reappear. Rerunning a range may replace
+pending or rejected suggestions, but never accepted or manual observations.
+
+## Save and recover
+
+`Ctrl+S` flushes the video project; timer autosave uses the same revisioned
+delta. Saves are serialized in SQLite transactions and retain dirty state on
+failure or external revision conflict. Save As uses SQLite backup rather than a
+file copy. Clean close checkpoints the WAL. Discard reloads the last durable
+project state.
+
+## Export accepted frames
+
+Choose **Tools → Export Video Frames…**. The destination must be new or empty.
+Select the current, annotated, or verified frames, or a time range sampled by
+frames or seconds. JPEG quality 95 is the default; PNG is lossless. Annotation
+output can be Pascal VOC, YOLO, YOLO-seg, COCO, or CreateML.
+
+Only accepted manual/tracker states and accepted rectangle interpolation are
+exported. Pending and rejected suggestions are excluded. Names are stable:
+
+```text
+<video-stem>__s<stream-index>__p<pts>.<extension>
+```
+
+The exporter stages the whole result before publishing it and writes
+`video_export_manifest.json` with the source fingerprint, PTS/time base,
+verification state, and track IDs for every image.
+
+## Scope
+
+Live/network streams, audio playback or editing, multi-stream selection,
+automatic polygon propagation, SAM2 video masks, and native MOT/CVAT-video
+project formats are not included.

--- a/docs/guides/optional-dependencies.md
+++ b/docs/guides/optional-dependencies.md
@@ -1,0 +1,39 @@
+# Optional dependencies
+
+The base `labelimgplusplus` install contains image annotation support and does
+not import video, SAM, or profiling libraries during startup.
+
+## Smart video
+
+```bash
+pip install "labelimgplusplus[video]"
+```
+
+The extra installs the PyAV line supported by the active Python version,
+NumPy, and headless OpenCV. Python 3.8 uses PyAV 12, Python 3.9 uses PyAV 15,
+Python 3.10 uses PyAV 17, and Python 3.11 or newer uses PyAV 18. The accepted
+local-container matrix is MP4, MOV, MKV, and AVI. Other containers supported by
+the installed FFmpeg/PyAV build may work, but are not part of the compatibility
+contract.
+
+## SAM and smart video together
+
+```bash
+pip install "labelimgplusplus[sam,video]"
+```
+
+Both extras resolve to the same `opencv-python-headless>=4.8,<6` distribution.
+SAM remains a paused-frame polygon helper in video documents; it does not run
+temporal mask propagation.
+
+## Profiling tools
+
+```bash
+pip install "labelimgplusplus[video,profile]"
+```
+
+This adds process metrics and native sampling tools used by the local
+workstation gates. See [Local performance profiling](../performance.md).
+
+Packaged base executables intentionally remain optional-feature-free. Install
+the Python package with the desired extra to use smart video or SAM.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ This documentation provides comprehensive guidance for developers working with t
 | [Architecture Overview](architecture.md) | High-level system design and data flow |
 | [Components](components/) | Deep dives into core classes |
 | [Annotation Formats](formats/) | Format specifications and I/O |
+| [Smart Video Annotation](features/smart-video-annotation.md) | PTS-based video projects, tracking, review, and export |
 | [Extension Guides](guides/) | How to extend labelImg++ |
 | [Reference](reference/) | Shortcuts, settings, troubleshooting |
 
@@ -144,6 +145,8 @@ python3 -m unittest discover tests -v
 - [Adding Formats](guides/adding-formats.md) - Create new annotation formats
 - [Adding Features](guides/adding-features.md) - Add new actions and UI
 - [i18n Guide](guides/i18n-guide.md) - Add new languages
+- [Optional Dependencies](guides/optional-dependencies.md) - Install SAM, video, and profiling extras
+- [Smart Video Annotation](features/smart-video-annotation.md) - Annotate and export tracked video frames
 - [Testing Plan](testing-plan.md) - Test audit findings and roadmap
 
 ### Reference

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -39,3 +39,31 @@ navigation below 100 ms p95; first image below one second and a complete 10k
 list below two seconds; background progress within 250 ms and cancellation
 within 500 ms; caches below 128 MiB with less than 10 percent steady-state RSS
 growth.
+
+## Smart-video gate
+
+Generate only the optional deterministic media corpus, then run the dedicated
+profiler:
+
+```bash
+python tools/performance/generate_workload.py /tmp/labelimgpp-video \
+  --video-only --video-profile full
+python tools/performance/profile_video.py /tmp/labelimgpp-video \
+  --output profile-results/video-current
+```
+
+The corpus contains CFR MP4 and AVI, VFR MKV, long-GOP MP4, rotated MOV,
+4K/8K navigation clips, a still image for document switching, and a textured
+multi-frame tracking scene. A `smoke`
+profile with reduced dimensions is available for tests. Media content is
+generated with PyAV; when the `ffmpeg` executable is present it attaches a real
+MOV display matrix for the rotation fixture.
+
+The video profiler performs one warm-up and five measured repetitions. It
+checks first-frame decode below one second, cold seek below 500 ms p95,
+prefetched lookup below 100 ms p95, event-loop latency below 50 ms p95 with no
+pause over 100 ms, progress within 250 ms, cancellation within 500 ms, the
+128 MiB combined cache ceiling, and less than 10 percent steady-state RSS
+growth across navigation, tracking, image-switch, and atomic-export cycles. It
+writes `summary.json`, `resources.csv`, cProfile output, and a
+Markdown comparison and exits nonzero on a failed gate.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -59,11 +59,14 @@ profile with reduced dimensions is available for tests. Media content is
 generated with PyAV; when the `ffmpeg` executable is present it attaches a real
 MOV display matrix for the rotation fixture.
 
-The video profiler performs one warm-up and five measured repetitions. It
-checks first-frame decode below one second, cold seek below 500 ms p95,
-prefetched lookup below 100 ms p95, event-loop latency below 50 ms p95 with no
-pause over 100 ms, progress within 250 ms, cancellation within 500 ms, the
-128 MiB combined cache ceiling, and less than 10 percent steady-state RSS
-growth across navigation, tracking, image-switch, and atomic-export cycles. It
-writes `summary.json`, `resources.csv`, cProfile output, and a
-Markdown comparison and exits nonzero on a failed gate.
+The video profiler performs one warm-up and five measured repetitions. Each
+repetition opens the video through the real `MainWindow`, scrubs through the
+timeline, advances playback, paints the timeline and canvas, and commits a
+drawn track while a Qt timer measures event-loop stalls. It also checks cold
+seek below 500 ms p95, prefetched lookup below 100 ms p95, first-frame open
+below one second, event-loop latency below 50 ms p95 with no pause over 100 ms,
+progress within 250 ms, cancellation within 500 ms, the 128 MiB combined cache
+ceiling, and less than 10 percent steady-state RSS growth across navigation,
+tracking, image-switch, and atomic-export cycles. It writes `summary.json`,
+`resources.csv`, cProfile output, and a Markdown comparison and exits nonzero
+on a failed gate.

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -7,6 +7,7 @@ Complete reference of all keyboard shortcuts in labelImg++.
 | Shortcut | Action | Description |
 |----------|--------|-------------|
 | `Ctrl+O` | Open File | Open single image or label file |
+| `Ctrl+Alt+V` | Open Video | Open local video or LabelImg++ video project |
 | `Ctrl+U` | Open Directory | Load all images from a directory |
 | `Ctrl+R` | Change Save Dir | Set annotation save location |
 | `Ctrl+Shift+O` | Open Annotation | Load specific annotation file |
@@ -22,6 +23,26 @@ Complete reference of all keyboard shortcuts in labelImg++.
 | `D` | Next Image | Go to next image in directory |
 | `A` | Previous Image | Go to previous image in directory |
 | `Space` | Verify Image | Toggle verified status (green background) |
+
+In video mode, `A` and `D` step exact frames and `Space` verifies the current
+frame rather than the whole source.
+
+## Smart Video
+
+| Shortcut | Action | Description |
+|----------|--------|-------------|
+| `Ctrl+Space` | Play/Pause | Toggle silent video playback |
+| `A` | Previous Frame | Use cache history or seek to the predecessor |
+| `D` | Next Frame | Decode the next presentation frame |
+| `Shift+K` | Add Track Keyframe | Promote the selected occurrence to a manual anchor |
+| `T` | Track Forward | Choose an endpoint and propagate the selected rectangle |
+| `Shift+T` | Track Backward | Choose an endpoint and propagate backward |
+| `Shift+Enter` | Accept Suggestion | Accept the current pending tracker state |
+| `Backspace` | Reject Suggestion | Reject the current pending tracker state |
+
+Visible-range and full-run review, Delete Track, and frame export are available
+from **Tools** without default shortcuts. All listed video shortcuts use the
+same **Help → Keyboard Shortcuts** editor as image actions.
 
 ## Annotation Creation
 

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -53,6 +53,53 @@ make qt5py3
 rm ~/.labelImgSettings.pkl
 ```
 
+## Smart Video
+
+### Video action shows an installation hint
+
+Install the optional extra into the same Python environment that launches the
+application:
+
+```bash
+python -m pip install "labelimgplusplus[video]"
+```
+
+For SAM on paused video frames, install `"labelimgplusplus[sam,video]"`.
+
+### Video will not open
+
+- Confirm the source is a local MP4, MOV, MKV, or AVI file.
+- Try opening it with the current PyAV/FFmpeg build. A container extension does
+  not guarantee that its internal codec is available.
+- Corrupt, truncated, empty, and no-video-stream sources are rejected before
+  the current document changes.
+- Only the first playable video stream is selected; audio is ignored.
+
+### Project cannot find its source
+
+Open the `.labelimgpp.sqlite` project and locate the original media. A moved
+file is relinked only when its sampled fingerprint matches. If content changed,
+create a new project; annotations are not applied to a different source.
+
+### Video opened read-only
+
+The source directory could not hold the default sibling project and no alternate
+project path was selected. Reopen the video and choose a writable project
+location. Read-only mode permits navigation but disables editing and saving.
+
+### Project schema or revision error
+
+Unknown SQLite application IDs and project schemas newer than this build are
+left untouched. Upgrade labelImg++, or open the project with the version that
+created it. A revision conflict means another process saved the project; keep
+your current session open, preserve its changes, and reconcile before retrying.
+
+### Export failed or was cancelled
+
+Choose a new or empty destination whose parent directory is writable. Export is
+staged atomically; cancellation removes only LabelImg++'s owned staging tree and
+does not remove an existing non-empty destination.
+
 ## File Operations
 
 ### Annotations Not Saving

--- a/docs/testing-plan.md
+++ b/docs/testing-plan.md
@@ -22,6 +22,24 @@ Linux workstation gate and its deterministic 10k corpora.
 
 - GitHub Actions workflow: `.github/workflows/ci.yaml`
 - Installs `pytest` and runs `pytest tests/ -v` across Python 3.8–3.13.
+- Runs focused `[video]` jobs across Python 3.8–3.13, combined `[sam,video]`
+  jobs on Python 3.8 and 3.13, and decoder/persistence smoke tests on Windows
+  and macOS.
+- Base jobs import the application without PyAV, NumPy, or OpenCV to preserve
+  the optional-dependency boundary.
+
+### Smart-video coverage
+
+`tests/video/` covers PyAV dependency markers, PTS and VFR seeking, rotation,
+MP4/MOV/MKV/AVI decoding, corrupt media, source fingerprints, SQLite schema and
+revision behavior, track precedence/interpolation, frame-aware editing,
+tracking and review, cache/navigation behavior, export formats and atomic
+staging, CLI/project opening, and Qt GUI-thread boundaries.
+
+Temporary smoke workloads cover CFR, VFR, short/long GOP, rotation, reduced
+4K/8K navigation analogues, and optical-flow stress. Timing remains excluded
+from hosted CI; the full-resolution, five-run acceptance gate is local and is
+documented in `docs/performance.md`.
 
 ### Stability / isolation risks
 

--- a/labelImgPlusPlus.py
+++ b/labelImgPlusPlus.py
@@ -21,7 +21,7 @@ try:
     from PyQt5.QtWidgets import (
         QAction, QActionGroup, QApplication, QCheckBox, QComboBox,
         QDialog, QDockWidget, QFileDialog, QHBoxLayout, QLabel,
-        QListWidget, QMainWindow, QMenu, QMessageBox,
+        QInputDialog, QListWidget, QMainWindow, QMenu, QMessageBox,
         QScrollArea, QTabWidget, QToolButton,
         QVBoxLayout, QWidget, QWidgetAction
     )
@@ -36,7 +36,7 @@ except ImportError:
     from PyQt4.QtGui import (
         QColor, QCursor, QImage, QImageReader, QPixmap,
         QAction, QActionGroup, QApplication, QCheckBox, QDockWidget,
-        QFileDialog, QHBoxLayout, QLabel, QListWidget,
+        QFileDialog, QHBoxLayout, QInputDialog, QLabel, QListWidget,
         QMainWindow, QMenu, QMessageBox, QScrollArea,
         QTabWidget, QToolButton, QVBoxLayout, QWidget, QWidgetAction
     )
@@ -84,17 +84,20 @@ from libs.core.profiling import (
 )
 from libs.core.video_decoder import VIDEO_EXTENSIONS, VideoDecoderSession
 from libs.core.video_project import (
+    PROJECT_SUFFIX, VideoSourceChanged, VideoSourceMissing,
     checkpoint_project, default_project_path, save_project_as,
     save_project_delta,
 )
 from libs.core.video_model import VideoProjectModel
 from libs.core.video_export import export_video_frames
 from libs.core.video_tracking import track_optical_flow
-from libs.core.video_session import is_video_project, prepare_video_open
+from libs.core.video_session import (
+    VideoOpenProblem, is_video_project, prepare_video_open,
+)
 from libs.core.video_types import (
     DocumentKind, TrackingRequest, VideoExportRequest, VideoFrameRef,
 )
-from libs.widgets.videoTimelineWidget import parse_timecode
+from libs.widgets.videoTimelineWidget import format_timecode, parse_timecode
 from libs.integrations import segmentation
 
 # Formats
@@ -564,12 +567,16 @@ class MainWindow(QMainWindow, WindowMixin):
             None, 'delete', 'Delete the selected track on every frame',
             enabled=False)
         video_track_forward = action(
-            'Track Forward', self.track_selected_forward,
+            'Track Forward…',
+            lambda _checked=False: self.track_selected_forward(
+                choose_endpoint=True),
             self.shortcut_config.get('video_track_forward'), None,
             'Propagate the selected rectangle forward with optical flow',
             enabled=False)
         video_track_backward = action(
-            'Track Backward', self.track_selected_backward,
+            'Track Backward…',
+            lambda _checked=False: self.track_selected_backward(
+                choose_endpoint=True),
             self.shortcut_config.get('video_track_backward'), None,
             'Propagate the selected rectangle backward with optical flow',
             enabled=False)
@@ -582,6 +589,30 @@ class MainWindow(QMainWindow, WindowMixin):
             'Reject Current Suggestion', self.reject_current_suggestion,
             self.shortcut_config.get('video_reject_suggestion'), 'close',
             'Reject the pending tracker observation on this frame',
+            enabled=False)
+        video_accept_visible = action(
+            'Accept Visible Suggestions',
+            lambda: self.review_visible_suggestions('accepted'),
+            None, 'verify',
+            'Accept pending tracker observations in the visible range',
+            enabled=False)
+        video_reject_visible = action(
+            'Reject Visible Suggestions',
+            lambda: self.review_visible_suggestions('rejected'),
+            None, 'close',
+            'Reject pending tracker observations in the visible range',
+            enabled=False)
+        video_accept_run = action(
+            'Accept Full Propagation',
+            lambda: self.review_full_propagation('accepted'),
+            None, 'verify',
+            'Accept pending observations from the latest propagation run',
+            enabled=False)
+        video_reject_run = action(
+            'Reject Full Propagation',
+            lambda: self.review_full_propagation('rejected'),
+            None, 'close',
+            'Reject pending observations from the latest propagation run',
             enabled=False)
         video_export = action(
             'Export Video Frames…', self.open_video_export_dialog,
@@ -824,6 +855,10 @@ class MainWindow(QMainWindow, WindowMixin):
                               videoTrackBackward=video_track_backward,
                               videoAcceptSuggestion=video_accept_suggestion,
                               videoRejectSuggestion=video_reject_suggestion,
+                              videoAcceptVisible=video_accept_visible,
+                              videoRejectVisible=video_reject_visible,
+                              videoAcceptRun=video_accept_run,
+                              videoRejectRun=video_reject_run,
                               videoExport=video_export,
                               sam_mode=sam_mode_action,
                               delete=delete, edit=edit, copy=copy,
@@ -996,6 +1031,8 @@ class MainWindow(QMainWindow, WindowMixin):
             None, video_play_pause, video_add_keyframe,
             video_track_forward, video_track_backward,
             video_accept_suggestion, video_reject_suggestion,
+            video_accept_visible, video_reject_visible,
+            video_accept_run, video_reject_run,
             video_delete_track, video_export,
             None, sam_mode_action, sam_settings_action))
 
@@ -1457,6 +1494,10 @@ class MainWindow(QMainWindow, WindowMixin):
             self.actions.videoTrackBackward.setEnabled(False)
             self.actions.videoAcceptSuggestion.setEnabled(False)
             self.actions.videoRejectSuggestion.setEnabled(False)
+            self.actions.videoAcceptVisible.setEnabled(False)
+            self.actions.videoRejectVisible.setEnabled(False)
+            self.actions.videoAcceptRun.setEnabled(False)
+            self.actions.videoRejectRun.setEnabled(False)
 
     def _close_video_decoder(self):
         if hasattr(self, '_video_playback_timer'):
@@ -2586,20 +2627,23 @@ class MainWindow(QMainWindow, WindowMixin):
                 return os.path.abspath(chosen), False
         return None, True
 
-    def request_open_video(self, path, project_path=None, skip_prompt=False):
+    def request_open_video(self, path, project_path=None, skip_prompt=False,
+                           source_override=None):
         """Queue a transactional video/project open on the decoder lane."""
         path = os.path.abspath(ustr(path))
         if not skip_prompt and self.dirty:
             if self.auto_saving.isChecked():
                 self.request_save_file(on_success=lambda: self.request_open_video(
-                    path, project_path=project_path, skip_prompt=True))
+                    path, project_path=project_path, skip_prompt=True,
+                    source_override=source_override))
                 return None
             answer = self.discard_changes_dialog()
             if answer == QMessageBox.Cancel:
                 return None
             if answer == QMessageBox.Yes:
                 self.request_save_file(on_success=lambda: self.request_open_video(
-                    path, project_path=project_path, skip_prompt=True))
+                    path, project_path=project_path, skip_prompt=True,
+                    source_override=source_override))
                 return None
 
         target, read_only = self._video_project_target(
@@ -2611,9 +2655,15 @@ class MainWindow(QMainWindow, WindowMixin):
         self._show_loading_veil('Opening video %s…' % os.path.basename(path))
 
         def prepare(handle):
-            prepared = prepare_video_open(
-                path, project_path=target, read_only=read_only,
-                cancelled=handle.is_cancelled)
+            try:
+                prepared = prepare_video_open(
+                    path, project_path=target, read_only=read_only,
+                    cancelled=handle.is_cancelled,
+                    source_override=source_override)
+            except VideoSourceMissing as exc:
+                return VideoOpenProblem('missing', str(exc))
+            except VideoSourceChanged as exc:
+                return VideoOpenProblem('changed', str(exc))
             if handle.is_cancelled():
                 prepared.decoder.close()
                 return None
@@ -2623,8 +2673,10 @@ class MainWindow(QMainWindow, WindowMixin):
             'video', prepare, priority=JobPriority.IMAGE_LOAD,
             key='video-open', latest=True, generation=generation)
         handle.result.connect(
-            lambda prepared, rid=request_id, gen=generation:
-            self._on_video_open_result(prepared, rid, gen))
+            lambda prepared, rid=request_id, gen=generation,
+            requested=path, project=target, override=source_override:
+            self._on_video_open_result(
+                prepared, rid, gen, requested, project, override))
         handle.error.connect(
             lambda message, rid=request_id, gen=generation:
             self._on_video_open_error(message, rid, gen))
@@ -2638,15 +2690,95 @@ class MainWindow(QMainWindow, WindowMixin):
         self.canvas.setEnabled(bool(self.file_path))
         self.status('Error opening video: ' + message, delay=10000)
 
-    def _on_video_open_result(self, prepared, request_id, generation):
+    def _on_video_open_result(self, prepared, request_id, generation,
+                              requested_path=None, project_path=None,
+                              source_override=None):
         if prepared is None:
             return
         if (request_id != self._video_open_request_id
                 or generation != self._dataset_generation):
-            prepared.decoder.close()
+            decoder = getattr(prepared, 'decoder', None)
+            if decoder is not None:
+                decoder.close()
+            return
+        if isinstance(prepared, VideoOpenProblem):
+            self._hide_loading_veil()
+            self._resolve_video_open_problem(
+                prepared, requested_path, project_path, source_override)
             return
         self._commit_video_open(prepared)
         self._hide_loading_veil()
+
+    def _locate_video_source(self, project_path):
+        source, _selected = QFileDialog.getOpenFileName(
+            self, 'Locate original video', os.path.dirname(project_path),
+            'Video files (*.mp4 *.mov *.mkv *.avi);;All files (*)')
+        return os.path.abspath(ustr(source)) if source else None
+
+    def _video_source_changed_choice(self, message):
+        dialog = QMessageBox(self)
+        dialog.setIcon(QMessageBox.Warning)
+        dialog.setWindowTitle('Video source changed')
+        dialog.setText(message)
+        dialog.setInformativeText(
+            'Annotations will not be applied to changed media.')
+        locate = dialog.addButton('Locate Original', QMessageBox.AcceptRole)
+        create = dialog.addButton(
+            'Create New Project', QMessageBox.DestructiveRole)
+        cancel = dialog.addButton(QMessageBox.Cancel)
+        dialog.exec_()
+        clicked = dialog.clickedButton()
+        if clicked is locate:
+            return 'locate'
+        if clicked is create:
+            return 'create'
+        if clicked is cancel:
+            return 'cancel'
+        return 'cancel'
+
+    def _new_video_project_path(self, source_path, old_project_path):
+        suggested = default_project_path(source_path)
+        if os.path.abspath(suggested) == os.path.abspath(old_project_path):
+            suggested = source_path + '.new' + PROJECT_SUFFIX
+        path, _selected = QFileDialog.getSaveFileName(
+            self, 'Create new video project', suggested,
+            'LabelImg++ video project (*.labelimgpp.sqlite)')
+        return os.path.abspath(ustr(path)) if path else None
+
+    def _resolve_video_open_problem(self, problem, requested_path,
+                                    project_path, source_override):
+        if problem.kind == 'missing':
+            located = self._locate_video_source(project_path)
+            if located:
+                self.request_open_video(
+                    project_path, skip_prompt=True,
+                    source_override=located)
+            else:
+                self.status('Video project open cancelled')
+            return
+        choice = self._video_source_changed_choice(problem.message)
+        if choice == 'locate':
+            located = self._locate_video_source(project_path)
+            if located:
+                self.request_open_video(
+                    project_path, skip_prompt=True,
+                    source_override=located)
+            return
+        if choice == 'create':
+            source_path = source_override
+            if source_path is None and not is_video_project(requested_path):
+                source_path = requested_path
+            if source_path is None:
+                source_path = self._locate_video_source(project_path)
+            if source_path:
+                new_project = self._new_video_project_path(
+                    source_path, project_path)
+                if new_project:
+                    self.request_open_video(
+                        source_path, project_path=new_project,
+                        skip_prompt=True)
+            return
+        self.status('Video project open cancelled')
 
     def _commit_video_open(self, prepared):
         """Atomically publish worker data on QApplication.thread()."""
@@ -2961,6 +3093,17 @@ class MainWindow(QMainWindow, WindowMixin):
             for item in model.observations.values())
         self.actions.videoAcceptSuggestion.setEnabled(has_pending)
         self.actions.videoRejectSuggestion.setEnabled(has_pending)
+        has_any_pending = any(
+            item.review_state == 'pending'
+            for item in model.observations.values())
+        has_run_pending = any(
+            key in self._tracking_run_keys
+            and item.review_state == 'pending'
+            for key, item in model.observations.items())
+        self.actions.videoAcceptVisible.setEnabled(has_any_pending)
+        self.actions.videoRejectVisible.setEnabled(has_any_pending)
+        self.actions.videoAcceptRun.setEnabled(has_run_pending)
+        self.actions.videoRejectRun.setEnabled(has_run_pending)
 
     def _refresh_video_track_list(self):
         model = self.video_model
@@ -3060,11 +3203,13 @@ class MainWindow(QMainWindow, WindowMixin):
         self._on_video_model_mutation()
         self._materialize_video_frame(self.current_video_frame_ref.pts)
 
-    def track_selected_forward(self):
-        return self._request_video_tracking(1)
+    def track_selected_forward(self, choose_endpoint=False):
+        return self._request_video_tracking(
+            1, choose_endpoint=choose_endpoint)
 
-    def track_selected_backward(self):
-        return self._request_video_tracking(-1)
+    def track_selected_backward(self, choose_endpoint=False):
+        return self._request_video_tracking(
+            -1, choose_endpoint=choose_endpoint)
 
     def _tracking_endpoint(self, track_id, start_pts, direction):
         anchors = sorted(
@@ -3082,7 +3227,33 @@ class MainWindow(QMainWindow, WindowMixin):
         upper = lower + int(snapshot.duration_pts or five_seconds)
         return max(lower, min(upper, endpoint))
 
-    def _request_video_tracking(self, direction):
+    def _choose_tracking_endpoint(self, default_pts, direction):
+        snapshot = self.video_snapshot
+        start = int(snapshot.start_pts or 0)
+        seconds = (default_pts - start) * snapshot.time_base_num / \
+            snapshot.time_base_den
+        value, accepted = QInputDialog.getText(
+            self, 'Optical-flow endpoint',
+            'Track %s until (HH:MM:SS.mmm):' % (
+                'forward' if direction > 0 else 'backward'),
+            text=format_timecode(seconds))
+        if not accepted:
+            return None
+        try:
+            endpoint = start + int(round(
+                parse_timecode(value) * snapshot.time_base_den /
+                snapshot.time_base_num))
+        except ValueError as exc:
+            self.status('Invalid tracking endpoint: %s' % exc)
+            return None
+        current = self.current_video_frame_ref.pts
+        if (endpoint - current) * direction <= 0:
+            self.status('Tracking endpoint must be in the selected direction')
+            return None
+        upper = start + int(snapshot.duration_pts or max(0, endpoint - start))
+        return max(start, min(upper, endpoint))
+
+    def _request_video_tracking(self, direction, choose_endpoint=False):
         model = self.video_model
         frame_ref = self.current_video_frame_ref
         track_id = self._selected_video_track_id
@@ -3099,6 +3270,10 @@ class MainWindow(QMainWindow, WindowMixin):
             return None
         endpoint = self._tracking_endpoint(
             track_id, frame_ref.pts, direction)
+        if choose_endpoint:
+            endpoint = self._choose_tracking_endpoint(endpoint, direction)
+            if endpoint is None:
+                return None
         if endpoint == frame_ref.pts:
             self.status('No tracking range is available in that direction')
             return None

--- a/labelImgPlusPlus.py
+++ b/labelImgPlusPlus.py
@@ -60,6 +60,7 @@ from libs.widgets.labelCheckerDialog import LabelCheckerDialog
 from libs.widgets.keypointPanel import KeypointPanel
 from libs.widgets import view_scaling
 from libs.widgets.videoTimelineWidget import VideoTimelineWidget
+from libs.widgets.videoExportDialog import VideoExportDialog
 
 # Core
 from libs.core.shape import Shape, ShapeType, DEFAULT_LINE_COLOR, DEFAULT_FILL_COLOR
@@ -87,11 +88,13 @@ from libs.core.video_project import (
     save_project_delta,
 )
 from libs.core.video_model import VideoProjectModel
+from libs.core.video_export import export_video_frames
 from libs.core.video_tracking import track_optical_flow
 from libs.core.video_session import is_video_project, prepare_video_open
 from libs.core.video_types import (
-    DocumentKind, TrackingRequest, VideoFrameRef,
+    DocumentKind, TrackingRequest, VideoExportRequest, VideoFrameRef,
 )
+from libs.widgets.videoTimelineWidget import parse_timecode
 from libs.integrations import segmentation
 
 # Formats
@@ -232,6 +235,7 @@ class MainWindow(QMainWindow, WindowMixin):
         self._active_tracking_request = None
         self._tracking_run_keys = set()
         self._applying_tracking_batch = False
+        self._video_export_handle = None
         self._load_request_id = 0
         self._pending_navigation_index = None
         self._prefetch_handles = {}
@@ -579,6 +583,11 @@ class MainWindow(QMainWindow, WindowMixin):
             self.shortcut_config.get('video_reject_suggestion'), 'close',
             'Reject the pending tracker observation on this frame',
             enabled=False)
+        video_export = action(
+            'Export Video Frames…', self.open_video_export_dialog,
+            None, 'save-as',
+            'Export accepted tracked frames to the selected image format',
+            enabled=False)
         sam_mode_action = action(
             'SAM Segment',
             self.toggle_sam_mode,
@@ -815,6 +824,7 @@ class MainWindow(QMainWindow, WindowMixin):
                               videoTrackBackward=video_track_backward,
                               videoAcceptSuggestion=video_accept_suggestion,
                               videoRejectSuggestion=video_reject_suggestion,
+                              videoExport=video_export,
                               sam_mode=sam_mode_action,
                               delete=delete, edit=edit, copy=copy,
                               copyToClipboard=copy_to_clipboard, pasteFromClipboard=paste_from_clipboard,
@@ -986,7 +996,7 @@ class MainWindow(QMainWindow, WindowMixin):
             None, video_play_pause, video_add_keyframe,
             video_track_forward, video_track_backward,
             video_accept_suggestion, video_reject_suggestion,
-            video_delete_track,
+            video_delete_track, video_export,
             None, sam_mode_action, sam_settings_action))
 
         # Custom context menu for the canvas widget:
@@ -1439,6 +1449,8 @@ class MainWindow(QMainWindow, WindowMixin):
                 self.actions, 'videoPlayPause'):
             self.actions.videoPlayPause.setEnabled(
                 kind == DocumentKind.VIDEO)
+            self.actions.videoExport.setEnabled(
+                kind == DocumentKind.VIDEO)
             self.actions.videoAddKeyframe.setEnabled(False)
             self.actions.videoDeleteTrack.setEnabled(False)
             self.actions.videoTrackForward.setEnabled(False)
@@ -1451,6 +1463,8 @@ class MainWindow(QMainWindow, WindowMixin):
             self.pause_video()
         if hasattr(self, '_tracking_handle'):
             self.cancel_video_tracking()
+        if hasattr(self, '_video_export_handle'):
+            self.cancel_video_export()
         decoder = getattr(self, 'video_decoder', None)
         self.video_decoder = None
         snapshot = getattr(self, 'video_snapshot', None)
@@ -3241,6 +3255,123 @@ class MainWindow(QMainWindow, WindowMixin):
         return self._review_video_keys(
             tuple(self._tracking_run_keys), review_state,
             '%s full tracker propagation' % review_state.title())
+
+    def _video_export_frame_refs(self, values):
+        snapshot = self.video_snapshot
+        selection = values['selection']
+        if selection == 'current':
+            pts_values = [self.current_video_frame_ref.pts]
+        elif selection == 'annotated':
+            pts_values = sorted({
+                item.pts for item in self.video_model.observations.values()
+                if item.present and item.review_state == 'accepted'})
+        elif selection == 'verified':
+            pts_values = sorted({
+                item.pts for item in self.video_model.frame_states.values()
+                if item.verified})
+        else:
+            start_seconds = parse_timecode(values['start_time'])
+            end_seconds = parse_timecode(values['end_time'])
+            if end_seconds < start_seconds:
+                raise ValueError('export range end precedes its start')
+            start_pts = int(snapshot.start_pts or 0) + int(round(
+                start_seconds * snapshot.time_base_den /
+                snapshot.time_base_num))
+            end_pts = int(snapshot.start_pts or 0) + int(round(
+                end_seconds * snapshot.time_base_den /
+                snapshot.time_base_num))
+            media_end = int(snapshot.start_pts or 0) + int(
+                snapshot.duration_pts or max(0, end_pts - start_pts))
+            start_pts = max(int(snapshot.start_pts or 0), start_pts)
+            end_pts = min(media_end, end_pts)
+            if values['sample_unit'] == 'seconds':
+                step = max(1, int(round(
+                    values['sample_seconds'] * snapshot.time_base_den /
+                    snapshot.time_base_num)))
+            else:
+                step = self._video_step_pts() * values['sample_frames']
+            pts_values = list(range(start_pts, end_pts + 1, step))
+        return tuple(VideoFrameRef(
+            snapshot.fingerprint, snapshot.stream_index, int(pts),
+            snapshot.time_base_num, snapshot.time_base_den)
+            for pts in pts_values)
+
+    def open_video_export_dialog(self):
+        if self.document_kind != DocumentKind.VIDEO:
+            return None
+        dialog = VideoExportDialog(self.label_file_format, self)
+        stem = os.path.splitext(
+            os.path.basename(self.video_snapshot.source_path))[0]
+        dialog.destination.setText(os.path.join(
+            os.path.dirname(self.video_snapshot.source_path),
+            stem + '-export'))
+        if dialog.exec_() != QDialog.Accepted:
+            return None
+        values = dialog.values()
+        if not values['destination']:
+            self.status('Choose an export destination')
+            return None
+        try:
+            frame_refs = self._video_export_frame_refs(values)
+        except ValueError as exc:
+            self.status('Invalid video export selection: %s' % exc)
+            return None
+        if not frame_refs:
+            self.status('The selected video export contains no frames')
+            return None
+        state = self.video_model.snapshot_state()
+        request = VideoExportRequest(
+            source_path=self.video_snapshot.source_path,
+            project_path=self.video_snapshot.project_path,
+            destination=os.path.abspath(values['destination']),
+            stream_index=self.video_snapshot.stream_index,
+            frame_refs=frame_refs, observations=state.observations,
+            tracks=state.tracks, frame_states=state.frame_states,
+            annotation_format=values['annotation_format'],
+            image_format=values['image_format'],
+            jpeg_quality=values['jpeg_quality'],
+            class_order=state.classes)
+        return self.request_export_video(request)
+
+    def request_export_video(self, export_request):
+        """Run one cancellable atomic export on an independent decoder."""
+        if not isinstance(export_request, VideoExportRequest):
+            raise TypeError('export_request must be a VideoExportRequest')
+        self.cancel_video_export()
+        generation = self._dataset_generation
+
+        def export(handle):
+            return export_video_frames(export_request, handle)
+
+        handle = self.task_coordinator.submit(
+            'background', export, priority=JobPriority.BULK,
+            key='video-export', latest=True, generation=generation)
+        self._video_export_handle = handle
+        handle.progress.connect(
+            lambda value, gen=generation:
+            self.status('Exporting video frame %s / %s: %s' % value)
+            if gen == self._dataset_generation else None)
+        handle.result.connect(
+            lambda destination, gen=generation:
+            self.status('Exported video frames to %s' % destination)
+            if gen == self._dataset_generation else None)
+        handle.error.connect(
+            lambda message, gen=generation:
+            self.status('Video export failed: ' + message, delay=10000)
+            if gen == self._dataset_generation else None)
+        handle.finished.connect(
+            lambda current=handle: self._clear_video_export_handle(current))
+        return handle
+
+    def _clear_video_export_handle(self, handle):
+        if self._video_export_handle is handle:
+            self._video_export_handle = None
+
+    def cancel_video_export(self):
+        handle = getattr(self, '_video_export_handle', None)
+        if handle is not None:
+            handle.cancel()
+        self._video_export_handle = None
 
     def _video_step_pts(self):
         snapshot = self.video_snapshot

--- a/labelImgPlusPlus.py
+++ b/labelImgPlusPlus.py
@@ -226,6 +226,7 @@ class MainWindow(QMainWindow, WindowMixin):
         self._video_save_active = False
         self._video_save_queued = False
         self._video_save_callbacks = []
+        self._video_close_save_pending = False
         self._video_frame_request_id = 0
         self._video_decode_in_flight = False
         self._video_prefetch_handle = None
@@ -846,7 +847,7 @@ class MainWindow(QMainWindow, WindowMixin):
         }
 
         # Store actions for further handling.
-        self.actions = Struct(save=save, save_format=save_format, saveAs=save_as, open=open, openVideo=open_video, close=close, resetAll=reset_all, deleteImg=delete_image,
+        self.actions = Struct(save=save, save_format=save_format, saveAs=save_as, open=open, openVideo=open_video, close=close, resetAll=reset_all, deleteImg=delete_image, verify=verify,
                               lineColor=color1, create=create, create_polygon=create_polygon,
                               keypoint_mode=keypoint_mode_action,
                               videoAddKeyframe=video_add_keyframe,
@@ -1347,8 +1348,23 @@ class MainWindow(QMainWindow, WindowMixin):
         if self.settings.get(SETTING_TOOLBAR_EXPANDED, False):
             self.tools.set_expanded(True)
 
+    def _video_editable(self):
+        snapshot = getattr(self, 'video_snapshot', None)
+        return not (
+            self.document_kind == DocumentKind.VIDEO
+            and snapshot is not None
+            and snapshot.read_only)
+
+    def _ensure_video_editable(self):
+        if self._video_editable():
+            return True
+        self.status('This video is open read-only; editing is disabled')
+        return False
+
     def set_dirty(self):
         if self.document_kind == DocumentKind.VIDEO:
+            if not self._ensure_video_editable():
+                return
             self.pause_video()
             self.dirty = True
             self.actions.save.setEnabled(True)
@@ -1373,6 +1389,7 @@ class MainWindow(QMainWindow, WindowMixin):
             self.actions.create_polygon.setEnabled(False)
             self.actions.createMode.setEnabled(False)
             self.actions.editMode.setEnabled(False)
+            self.actions.verify.setEnabled(False)
         self.update_save_status(saved=True)
 
     def toggle_actions(self, value=True):
@@ -1482,8 +1499,11 @@ class MainWindow(QMainWindow, WindowMixin):
             if kind != DocumentKind.VIDEO \
                     and self.label_tab_widget.currentIndex() == 2:
                 self.label_tab_widget.setCurrentIndex(0)
+        if kind != DocumentKind.VIDEO and hasattr(self, 'diffc_button'):
+            self.diffc_button.setEnabled(True)
         if hasattr(self, 'actions') and hasattr(
                 self.actions, 'videoPlayPause'):
+            self.actions.verify.setEnabled(kind != DocumentKind.NONE)
             self.actions.videoPlayPause.setEnabled(
                 kind == DocumentKind.VIDEO)
             self.actions.videoExport.setEnabled(
@@ -1499,7 +1519,7 @@ class MainWindow(QMainWindow, WindowMixin):
             self.actions.videoAcceptRun.setEnabled(False)
             self.actions.videoRejectRun.setEnabled(False)
 
-    def _close_video_decoder(self):
+    def _close_video_decoder(self, close_decoder=True):
         if hasattr(self, '_video_playback_timer'):
             self.pause_video()
         if hasattr(self, '_tracking_handle'):
@@ -1515,17 +1535,29 @@ class MainWindow(QMainWindow, WindowMixin):
         self._video_save_active = False
         self._video_save_queued = False
         self._video_save_callbacks = []
+        self._video_close_save_pending = False
         self.current_video_frame_ref = None
         if hasattr(self, 'video_timeline'):
             self.video_timeline.set_session(None)
-        if decoder is not None:
-            decoder.close()
+        if decoder is not None and close_decoder:
+            coordinator = getattr(self, 'task_coordinator', None)
+            if coordinator is not None and not coordinator.is_shutting_down:
+                handle = coordinator.submit(
+                    'video', lambda _handle, session=decoder: session.close(),
+                    priority=JobPriority.IMAGE_LOAD,
+                    generation=self._dataset_generation)
+                # Session teardown must stay ordered behind any active decode,
+                # even if a later document generation cancels ordinary work.
+                handle.begin_non_cancellable()
+            else:
+                decoder.close()
         if (snapshot is not None and snapshot.project_path
                 and not snapshot.read_only and not self.dirty):
             try:
                 checkpoint_project(snapshot.project_path)
             except Exception:
                 pass
+        return decoder
 
     def _restart_workers_if_needed(self):
         coordinator = getattr(self, 'task_coordinator', None)
@@ -1605,12 +1637,18 @@ class MainWindow(QMainWindow, WindowMixin):
 
     def create_shape(self):
         assert self.beginner()
+        if (self.document_kind == DocumentKind.VIDEO
+                and not self._ensure_video_editable()):
+            return
         self.canvas.set_editing(False)
         self.actions.create.setEnabled(False)
         self.actions.create_polygon.setEnabled(True)
 
     def create_polygon_mode(self):
         """Switch to polygon drawing mode."""
+        if (self.document_kind == DocumentKind.VIDEO
+                and not self._ensure_video_editable()):
+            return
         self.canvas.set_polygon_drawing(True)
         self.actions.create.setEnabled(True)
         self.actions.create_polygon.setEnabled(False)
@@ -1620,6 +1658,9 @@ class MainWindow(QMainWindow, WindowMixin):
         """Toggle keypoint annotation mode for the selected shape."""
         from libs.core.keypoint_config import get_template
 
+        if (self.document_kind == DocumentKind.VIDEO
+                and not self._ensure_video_editable()):
+            return
         if self.canvas.mode == self.canvas.KEYPOINT_MODE:
             self.canvas.exit_keypoint_mode()
             self.keypoint_panel.hide()
@@ -1647,6 +1688,9 @@ class MainWindow(QMainWindow, WindowMixin):
 
     def toggle_sam_mode(self):
         """Enter/leave single-click SAM segmentation mode."""
+        if (self.document_kind == DocumentKind.VIDEO
+                and not self._ensure_video_editable()):
+            return
         if not segmentation.sam_available():
             QMessageBox.warning(
                 self, "SAM unavailable",
@@ -1702,6 +1746,10 @@ class MainWindow(QMainWindow, WindowMixin):
     def _on_polygon_vertices_edited(self, shape, old_points):
         """Capture polygon vertex edits for undo support."""
         if self.document_kind == DocumentKind.VIDEO:
+            if not self._ensure_video_editable():
+                self._materialize_video_frame(
+                    self.current_video_frame_ref.pts)
+                return
             before = self.video_model.snapshot_state()
             self._store_video_shape_as_manual(shape)
             after = self.video_model.snapshot_state()
@@ -1718,6 +1766,10 @@ class MainWindow(QMainWindow, WindowMixin):
     def _on_shape_move_finished(self, shape, old_points):
         """Capture whole-shape moves / rectangle resizes for undo support."""
         if self.document_kind == DocumentKind.VIDEO:
+            if not self._ensure_video_editable():
+                self._materialize_video_frame(
+                    self.current_video_frame_ref.pts)
+                return
             before = self.video_model.snapshot_state()
             self._store_video_shape_as_manual(shape)
             after = self.video_model.snapshot_state()
@@ -1733,6 +1785,10 @@ class MainWindow(QMainWindow, WindowMixin):
     def _on_keypoints_edited(self, shape, old_keypoints):
         """Capture keypoint mutations for undo support."""
         if self.document_kind == DocumentKind.VIDEO:
+            if not self._ensure_video_editable():
+                self._materialize_video_frame(
+                    self.current_video_frame_ref.pts)
+                return
             before = self.video_model.snapshot_state()
             self._store_video_shape_as_manual(shape)
             after = self.video_model.snapshot_state()
@@ -1751,17 +1807,21 @@ class MainWindow(QMainWindow, WindowMixin):
         """In the middle of drawing, toggling between modes should be disabled."""
         if drawing and self.document_kind == DocumentKind.VIDEO:
             self.pause_video()
-        self.actions.editMode.setEnabled(not drawing)
-        self.actions.create_polygon.setEnabled(not drawing)
+        editable = self._video_editable()
+        self.actions.editMode.setEnabled(not drawing and editable)
+        self.actions.create_polygon.setEnabled(not drawing and editable)
         if not drawing and self.beginner():
             # Cancel creation.
             print('Cancel creation.')
             self.canvas.set_editing(True)
             self.canvas.restore_cursor()
-            self.actions.create.setEnabled(True)
-            self.actions.create_polygon.setEnabled(True)
+            self.actions.create.setEnabled(editable)
+            self.actions.create_polygon.setEnabled(editable)
 
     def toggle_draw_mode(self, edit=True):
+        if (self.document_kind == DocumentKind.VIDEO
+                and not self._ensure_video_editable()):
+            return
         self.canvas.set_editing(edit)
         self.actions.createMode.setEnabled(edit)
         self.actions.editMode.setEnabled(not edit)
@@ -1769,11 +1829,17 @@ class MainWindow(QMainWindow, WindowMixin):
 
     def set_create_mode(self):
         assert self.advanced()
+        if (self.document_kind == DocumentKind.VIDEO
+                and not self._ensure_video_editable()):
+            return
         self.toggle_draw_mode(False)
         self.actions.create_polygon.setEnabled(True)
 
     def set_edit_mode(self):
         assert self.advanced()
+        if (self.document_kind == DocumentKind.VIDEO
+                and not self._ensure_video_editable()):
+            return
         self.toggle_draw_mode(True)
         self.actions.create_polygon.setEnabled(True)
         self.label_selection_changed()
@@ -1813,6 +1879,9 @@ class MainWindow(QMainWindow, WindowMixin):
             self.menus.labelList.exec_(self.rect_label_list.mapToGlobal(point))
 
     def edit_label(self):
+        if (self.document_kind == DocumentKind.VIDEO
+                and not self._ensure_video_editable()):
+            return
         if not self.canvas.editing():
             return
         item = self.current_item()
@@ -2028,6 +2097,11 @@ class MainWindow(QMainWindow, WindowMixin):
         # Checked and Update
         if difficult != shape.difficult:
             if self.document_kind == DocumentKind.VIDEO:
+                if not self._ensure_video_editable():
+                    blocked = self.diffc_button.blockSignals(True)
+                    self.diffc_button.setChecked(shape.difficult)
+                    self.diffc_button.blockSignals(blocked)
+                    return
                 track_id = getattr(shape, 'video_track_id', None)
                 before = self.video_model.snapshot_state()
                 self.video_model.update_track(
@@ -2058,14 +2132,16 @@ class MainWindow(QMainWindow, WindowMixin):
             else:
                 self.rect_label_list.clearSelection()
                 self.poly_label_list.clearSelection()
-        self.actions.delete.setEnabled(selected)
-        self.actions.copy.setEnabled(selected)
+        editable = self._video_editable()
+        self.actions.delete.setEnabled(selected and editable)
+        self.actions.copy.setEnabled(selected and editable)
         self.actions.copyToClipboard.setEnabled(selected)
-        self.actions.edit.setEnabled(selected)
-        self.actions.shapeLineColor.setEnabled(selected)
-        self.actions.shapeFillColor.setEnabled(selected)
+        self.actions.edit.setEnabled(selected and editable)
+        self.actions.shapeLineColor.setEnabled(selected and editable)
+        self.actions.shapeFillColor.setEnabled(selected and editable)
         # Enable paste if clipboard has shapes
-        self.actions.pasteFromClipboard.setEnabled(len(self.clipboard_shapes) > 0)
+        self.actions.pasteFromClipboard.setEnabled(
+            len(self.clipboard_shapes) > 0 and editable)
         # Enable copy all if there are shapes
         self.actions.copyAllToClipboard.setEnabled(len(self.canvas.shapes) > 0)
 
@@ -2075,7 +2151,7 @@ class MainWindow(QMainWindow, WindowMixin):
         has_template = (shape is not None
                         and shape.shape_type == ShapeType.RECTANGLE
                         and get_template(shape.label) is not None)
-        self.actions.keypoint_mode.setEnabled(has_template)
+        self.actions.keypoint_mode.setEnabled(has_template and editable)
         if has_template and shape.keypoints:
             self.keypoint_panel.load_template(shape.label.lower())
             self.keypoint_panel.set_keypoints(shape.keypoints)
@@ -2314,6 +2390,9 @@ class MainWindow(QMainWindow, WindowMixin):
             return False
 
     def copy_selected_shape(self):
+        if (self.document_kind == DocumentKind.VIDEO
+                and not self._ensure_video_editable()):
+            return
         shape = self.canvas.copy_selected_shape()
         self.add_label(shape)
 
@@ -2342,7 +2421,7 @@ class MainWindow(QMainWindow, WindowMixin):
             return
         # Store a copy of the selected shape
         self.clipboard_shapes = [self.canvas.selected_shape.copy()]
-        self.actions.pasteFromClipboard.setEnabled(True)
+        self.actions.pasteFromClipboard.setEnabled(self._video_editable())
         self.statusBar().showMessage('Copied 1 annotation to clipboard', 3000)
 
     def copy_all_to_clipboard(self):
@@ -2351,11 +2430,14 @@ class MainWindow(QMainWindow, WindowMixin):
             return
         # Store copies of all shapes
         self.clipboard_shapes = [shape.copy() for shape in self.canvas.shapes]
-        self.actions.pasteFromClipboard.setEnabled(True)
+        self.actions.pasteFromClipboard.setEnabled(self._video_editable())
         self.statusBar().showMessage(f'Copied {len(self.clipboard_shapes)} annotations to clipboard', 3000)
 
     def paste_from_clipboard(self):
         """Paste shapes from clipboard to current image."""
+        if (self.document_kind == DocumentKind.VIDEO
+                and not self._ensure_video_editable()):
+            return
         if not self.clipboard_shapes:
             return
         if not self.canvas.pixmap or self.canvas.pixmap.isNull():
@@ -2423,6 +2505,11 @@ class MainWindow(QMainWindow, WindowMixin):
         label = item.text()
         if label != shape.label:
             if self.document_kind == DocumentKind.VIDEO:
+                if not self._ensure_video_editable():
+                    blocked = item.listWidget().blockSignals(True)
+                    item.setText(shape.label)
+                    item.listWidget().blockSignals(blocked)
+                    return
                 track_id = getattr(shape, 'video_track_id', None)
                 if track_id is None:
                     return
@@ -2453,6 +2540,10 @@ class MainWindow(QMainWindow, WindowMixin):
 
         position MUST be in global coordinates.
         """
+        if (self.document_kind == DocumentKind.VIDEO
+                and not self._ensure_video_editable()):
+            self.canvas.reset_all_lines()
+            return
         if not self.use_default_label_checkbox.isChecked():
             if len(self.label_hist) > 0:
                 self.label_dialog = LabelDialog(
@@ -2813,7 +2904,9 @@ class MainWindow(QMainWindow, WindowMixin):
                         if state.verified}
         self.canvas.verified = first.frame_ref.pts in verified_pts
         self.canvas.locked = (
-            self.canvas.verified and self.lock_on_verify_option.isChecked())
+            snapshot.read_only
+            or (self.canvas.verified
+                and self.lock_on_verify_option.isChecked()))
         self.canvas.load_pixmap(QPixmap.fromImage(first.image))
         self.current_video_frame_ref = first.frame_ref
         self.frame_cache.put(first)
@@ -2826,9 +2919,34 @@ class MainWindow(QMainWindow, WindowMixin):
         self.paint_canvas()
         self.toggle_actions(True)
         editable = not snapshot.read_only
-        for action in (self.actions.create, self.actions.create_polygon,
-                       self.actions.createMode, self.actions.editMode):
-            action.setEnabled(editable)
+        mutation_actions = (
+            self.actions.create, self.actions.create_polygon,
+            self.actions.createMode, self.actions.editMode,
+            self.actions.verify, self.actions.delete, self.actions.copy,
+            self.actions.edit, self.actions.pasteFromClipboard,
+            self.actions.keypoint_mode, self.actions.sam_mode,
+            self.actions.shapeLineColor, self.actions.shapeFillColor,
+            self.actions.undo, self.actions.redo,
+            self.actions.videoAddKeyframe,
+            self.actions.videoDeleteTrack,
+            self.actions.videoTrackForward,
+            self.actions.videoTrackBackward,
+            self.actions.videoAcceptSuggestion,
+            self.actions.videoRejectSuggestion,
+            self.actions.videoAcceptVisible,
+            self.actions.videoRejectVisible,
+            self.actions.videoAcceptRun,
+            self.actions.videoRejectRun,
+        )
+        if not editable:
+            for action in mutation_actions:
+                action.setEnabled(False)
+        else:
+            for action in (self.actions.create, self.actions.create_polygon,
+                           self.actions.createMode, self.actions.editMode,
+                           self.actions.verify):
+                action.setEnabled(True)
+        self.diffc_button.setEnabled(editable)
         self.actions.saveAs.setEnabled(bool(snapshot.project_path))
         self.add_recent_file(snapshot.project_path or snapshot.source_path)
         suffix = ' [read-only]' if snapshot.read_only else ''
@@ -2919,6 +3037,8 @@ class MainWindow(QMainWindow, WindowMixin):
 
     def _on_video_save_error(self, message):
         self._video_save_queued = False
+        self._video_save_callbacks = []
+        self._video_close_save_pending = False
         self.status('Error saving video project: ' + message, delay=10000)
 
     def _on_video_save_finished(self):
@@ -2988,6 +3108,8 @@ class MainWindow(QMainWindow, WindowMixin):
         self.video_classes = tuple(model.classes)
 
     def _on_video_model_mutation(self):
+        if not self._ensure_video_editable():
+            return
         if (self._active_tracking_request is not None
                 and not self._applying_tracking_batch):
             self.cancel_video_tracking()
@@ -3021,6 +3143,8 @@ class MainWindow(QMainWindow, WindowMixin):
         return geometry, keypoints
 
     def _store_video_shape_as_manual(self, shape):
+        if not self._video_editable():
+            raise RuntimeError('cannot mutate a read-only video project')
         track_id = getattr(shape, 'video_track_id', None)
         if track_id is None:
             track = self.video_model.create_track(
@@ -3091,8 +3215,9 @@ class MainWindow(QMainWindow, WindowMixin):
         has_pending = any(
             item.pts == int(pts) and item.review_state == 'pending'
             for item in model.observations.values())
-        self.actions.videoAcceptSuggestion.setEnabled(has_pending)
-        self.actions.videoRejectSuggestion.setEnabled(has_pending)
+        editable = self._video_editable()
+        self.actions.videoAcceptSuggestion.setEnabled(has_pending and editable)
+        self.actions.videoRejectSuggestion.setEnabled(has_pending and editable)
         has_any_pending = any(
             item.review_state == 'pending'
             for item in model.observations.values())
@@ -3100,10 +3225,12 @@ class MainWindow(QMainWindow, WindowMixin):
             key in self._tracking_run_keys
             and item.review_state == 'pending'
             for key, item in model.observations.items())
-        self.actions.videoAcceptVisible.setEnabled(has_any_pending)
-        self.actions.videoRejectVisible.setEnabled(has_any_pending)
-        self.actions.videoAcceptRun.setEnabled(has_run_pending)
-        self.actions.videoRejectRun.setEnabled(has_run_pending)
+        self.actions.videoAcceptVisible.setEnabled(
+            has_any_pending and editable)
+        self.actions.videoRejectVisible.setEnabled(
+            has_any_pending and editable)
+        self.actions.videoAcceptRun.setEnabled(has_run_pending and editable)
+        self.actions.videoRejectRun.setEnabled(has_run_pending and editable)
 
     def _refresh_video_track_list(self):
         model = self.video_model
@@ -3145,12 +3272,13 @@ class MainWindow(QMainWindow, WindowMixin):
             return
         track_id = items[0].data(Qt.UserRole)
         self._selected_video_track_id = track_id
-        self.actions.videoAddKeyframe.setEnabled(True)
-        self.actions.videoDeleteTrack.setEnabled(True)
+        editable = self._video_editable()
+        self.actions.videoAddKeyframe.setEnabled(editable)
+        self.actions.videoDeleteTrack.setEnabled(editable)
         track = self.video_model.tracks.get(track_id)
         can_track = track is not None and track.shape_type == 'rectangle'
-        self.actions.videoTrackForward.setEnabled(can_track)
-        self.actions.videoTrackBackward.setEnabled(can_track)
+        self.actions.videoTrackForward.setEnabled(can_track and editable)
+        self.actions.videoTrackBackward.setEnabled(can_track and editable)
         shape = next((item for item in self.canvas.shapes
                       if getattr(item, 'video_track_id', None) == track_id),
                      None)
@@ -3165,6 +3293,8 @@ class MainWindow(QMainWindow, WindowMixin):
                 self.canvas.set_shape_visible(shape, visible)
 
     def add_track_keyframe(self):
+        if not self._ensure_video_editable():
+            return
         model = self.video_model
         track_id = self._selected_video_track_id
         if model is None or track_id is None \
@@ -3183,6 +3313,8 @@ class MainWindow(QMainWindow, WindowMixin):
         self._materialize_video_frame(self.current_video_frame_ref.pts)
 
     def delete_selected_track(self):
+        if not self._ensure_video_editable():
+            return
         model = self.video_model
         track_id = self._selected_video_track_id
         if model is None or track_id not in model.tracks:
@@ -3254,6 +3386,8 @@ class MainWindow(QMainWindow, WindowMixin):
         return max(start, min(upper, endpoint))
 
     def _request_video_tracking(self, direction, choose_endpoint=False):
+        if not self._ensure_video_editable():
+            return None
         model = self.video_model
         frame_ref = self.current_video_frame_ref
         track_id = self._selected_video_track_id
@@ -3309,7 +3443,8 @@ class MainWindow(QMainWindow, WindowMixin):
 
     def _tracking_batch_is_current(self, batch):
         request = self._active_tracking_request
-        if request is None or self.video_model is None:
+        if (request is None or self.video_model is None
+                or not self._video_editable()):
             return False
         track = self.video_model.tracks.get(batch.track_id)
         return (
@@ -3381,6 +3516,8 @@ class MainWindow(QMainWindow, WindowMixin):
         return tuple(values[:1])
 
     def _review_video_keys(self, keys, review_state, description):
+        if not self._ensure_video_editable():
+            return False
         keys = tuple(
             key for key in keys
             if key in self.video_model.observations
@@ -3431,6 +3568,24 @@ class MainWindow(QMainWindow, WindowMixin):
             tuple(self._tracking_run_keys), review_state,
             '%s full tracker propagation' % review_state.title())
 
+    def _video_export_range_bounds(self, values):
+        snapshot = self.video_snapshot
+        start_seconds = parse_timecode(values['start_time'])
+        end_seconds = parse_timecode(values['end_time'])
+        if end_seconds < start_seconds:
+            raise ValueError('export range end precedes its start')
+        start_pts = int(snapshot.start_pts or 0) + int(round(
+            start_seconds * snapshot.time_base_den /
+            snapshot.time_base_num))
+        end_pts = int(snapshot.start_pts or 0) + int(round(
+            end_seconds * snapshot.time_base_den /
+            snapshot.time_base_num))
+        media_end = int(snapshot.start_pts or 0) + int(
+            snapshot.duration_pts or max(0, end_pts - start_pts))
+        start_pts = max(int(snapshot.start_pts or 0), start_pts)
+        end_pts = min(media_end, end_pts)
+        return start_pts, end_pts
+
     def _video_export_frame_refs(self, values):
         snapshot = self.video_snapshot
         selection = values['selection']
@@ -3445,27 +3600,18 @@ class MainWindow(QMainWindow, WindowMixin):
                 item.pts for item in self.video_model.frame_states.values()
                 if item.verified})
         else:
-            start_seconds = parse_timecode(values['start_time'])
-            end_seconds = parse_timecode(values['end_time'])
-            if end_seconds < start_seconds:
-                raise ValueError('export range end precedes its start')
-            start_pts = int(snapshot.start_pts or 0) + int(round(
-                start_seconds * snapshot.time_base_den /
-                snapshot.time_base_num))
-            end_pts = int(snapshot.start_pts or 0) + int(round(
-                end_seconds * snapshot.time_base_den /
-                snapshot.time_base_num))
-            media_end = int(snapshot.start_pts or 0) + int(
-                snapshot.duration_pts or max(0, end_pts - start_pts))
-            start_pts = max(int(snapshot.start_pts or 0), start_pts)
-            end_pts = min(media_end, end_pts)
+            start_pts, end_pts = self._video_export_range_bounds(values)
             if values['sample_unit'] == 'seconds':
                 step = max(1, int(round(
                     values['sample_seconds'] * snapshot.time_base_den /
                     snapshot.time_base_num)))
+                pts_values = list(range(start_pts, end_pts + 1, step))
             else:
-                step = self._video_step_pts() * values['sample_frames']
-            pts_values = list(range(start_pts, end_pts + 1, step))
+                # Actual every-N-frame selection is resolved by the bulk
+                # decoder. A fixed PTS grid cannot represent VFR frame cadence.
+                pts_values = [start_pts]
+                if end_pts != start_pts:
+                    pts_values.append(end_pts)
         return tuple(VideoFrameRef(
             snapshot.fingerprint, snapshot.stream_index, int(pts),
             snapshot.time_base_num, snapshot.time_base_den)
@@ -3488,6 +3634,14 @@ class MainWindow(QMainWindow, WindowMixin):
             return None
         try:
             frame_refs = self._video_export_frame_refs(values)
+            range_start_pts = None
+            range_end_pts = None
+            sample_every_frames = None
+            if (values['selection'] == 'range'
+                    and values['sample_unit'] == 'frames'):
+                range_start_pts, range_end_pts = \
+                    self._video_export_range_bounds(values)
+                sample_every_frames = max(1, int(values['sample_frames']))
         except ValueError as exc:
             self.status('Invalid video export selection: %s' % exc)
             return None
@@ -3505,7 +3659,10 @@ class MainWindow(QMainWindow, WindowMixin):
             annotation_format=values['annotation_format'],
             image_format=values['image_format'],
             jpeg_quality=values['jpeg_quality'],
-            class_order=state.classes)
+            class_order=state.classes,
+            range_start_pts=range_start_pts,
+            range_end_pts=range_end_pts,
+            sample_every_frames=sample_every_frames)
         return self.request_export_video(request)
 
     def request_export_video(self, export_request):
@@ -3585,6 +3742,7 @@ class MainWindow(QMainWindow, WindowMixin):
     def _submit_video_decode(self, operation, playback=False):
         if self.video_decoder is None:
             return None
+        decoder = self.video_decoder
         self._video_frame_request_id += 1
         request_id = self._video_frame_request_id
         generation = self._dataset_generation
@@ -3593,7 +3751,7 @@ class MainWindow(QMainWindow, WindowMixin):
 
         def decode(handle):
             handle.check_cancelled()
-            return operation(self.video_decoder, handle)
+            return operation(decoder, handle)
 
         handle = self.task_coordinator.submit(
             'video', decode, priority=JobPriority.IMAGE_LOAD,
@@ -3649,7 +3807,8 @@ class MainWindow(QMainWindow, WindowMixin):
             for state in self.video_frame_states)
         self.canvas.verified = verified
         self.canvas.locked = (
-            verified and self.lock_on_verify_option.isChecked())
+            not self._video_editable()
+            or (verified and self.lock_on_verify_option.isChecked()))
         # Track materialization is installed by the next delivery slice. Until
         # then a seek must never leak ordinary image shapes across frames.
         materialize = getattr(self, '_materialize_video_frame', None)
@@ -4303,7 +4462,28 @@ class MainWindow(QMainWindow, WindowMixin):
             event.accept()
             return
 
-        if not self.may_continue():
+        if self._video_close_save_pending:
+            event.ignore()
+            return
+
+        if self.document_kind == DocumentKind.VIDEO and self.dirty:
+            answer = self.discard_changes_dialog()
+            if answer == QMessageBox.Cancel:
+                event.ignore()
+                return
+            if answer == QMessageBox.Yes:
+                self._video_close_save_pending = True
+                handle = self.request_save_video_project(
+                    on_success=self._finish_video_close_after_save)
+                if handle is None and self.dirty:
+                    self._video_close_save_pending = False
+                    self._video_save_callbacks = []
+                    self.status(
+                        'Could not save the video project; close cancelled',
+                        delay=10000)
+                event.ignore()
+                return
+        elif not self.may_continue():
             event.ignore()
             return
 
@@ -4349,12 +4529,23 @@ class MainWindow(QMainWindow, WindowMixin):
         settings.save()
         self._shutdown_workers()
 
+    def _finish_video_close_after_save(self):
+        if not self._video_close_save_pending:
+            return
+        self._video_close_save_pending = False
+        QTimer.singleShot(0, self.close)
+
     def _shutdown_workers(self):
         self.annotation_catalog.cancel()
         if hasattr(self, 'sam_controller'):
             self.sam_controller.cancel()
-        self._close_video_decoder()
-        self.task_coordinator.shutdown()
+        decoder = self._close_video_decoder(close_decoder=False)
+        all_done = self.task_coordinator.shutdown()
+        # Never close a PyAV container while its serialized lane may still be
+        # decoding. If cancellation missed the bounded shutdown wait, the
+        # worker retains the final reference and releases it when it finishes.
+        if decoder is not None and all_done:
+            decoder.close()
 
     def load_recent(self, filename):
         self.request_open_file(filename)
@@ -4898,6 +5089,8 @@ class MainWindow(QMainWindow, WindowMixin):
 
     def verify_image(self, _value=False):
         if self.document_kind == DocumentKind.VIDEO:
+            if not self._ensure_video_editable():
+                return False
             if self.current_video_frame_ref is None:
                 return
             self.video_model.set_frame_verified(
@@ -4928,6 +5121,8 @@ class MainWindow(QMainWindow, WindowMixin):
     def request_verify_image(self, _value=False):
         """Toggle verification and persist it through the async save lane."""
         if self.document_kind == DocumentKind.VIDEO:
+            if not self._ensure_video_editable():
+                return None
             if self.current_video_frame_ref is None:
                 return None
             self.video_model.set_frame_verified(
@@ -5387,6 +5582,9 @@ class MainWindow(QMainWindow, WindowMixin):
         return os.path.dirname(self.file_path) if self.file_path else '.'
 
     def choose_color1(self):
+        if (self.document_kind == DocumentKind.VIDEO
+                and not self._ensure_video_editable()):
+            return
         color = self.color_dialog.getColor(self.line_color, u'Choose line color',
                                            default=DEFAULT_LINE_COLOR)
         if color:
@@ -5402,6 +5600,8 @@ class MainWindow(QMainWindow, WindowMixin):
             return
         shape = self.canvas.selected_shape
         if self.document_kind == DocumentKind.VIDEO:
+            if not self._ensure_video_editable():
+                return
             track_id = getattr(shape, 'video_track_id', None)
             if track_id is None:
                 return
@@ -5429,6 +5629,9 @@ class MainWindow(QMainWindow, WindowMixin):
 
     def undo_action(self):
         """Undo the last action."""
+        if (self.document_kind == DocumentKind.VIDEO
+                and not self._ensure_video_editable()):
+            return
         if self.undo_stack.can_undo():
             self.undo_stack.undo()
             self.set_dirty()
@@ -5436,6 +5639,9 @@ class MainWindow(QMainWindow, WindowMixin):
 
     def redo_action(self):
         """Redo the last undone action."""
+        if (self.document_kind == DocumentKind.VIDEO
+                and not self._ensure_video_editable()):
+            return
         if self.undo_stack.can_redo():
             self.undo_stack.redo()
             self.set_dirty()
@@ -5443,8 +5649,11 @@ class MainWindow(QMainWindow, WindowMixin):
 
     def update_undo_redo_actions(self):
         """Update the enabled state of undo/redo actions."""
-        self.actions.undo.setEnabled(self.undo_stack.can_undo())
-        self.actions.redo.setEnabled(self.undo_stack.can_redo())
+        editable = self._video_editable()
+        self.actions.undo.setEnabled(
+            self.undo_stack.can_undo() and editable)
+        self.actions.redo.setEnabled(
+            self.undo_stack.can_redo() and editable)
 
         # Update tooltips with descriptions
         if self.undo_stack.can_undo():
@@ -5460,6 +5669,9 @@ class MainWindow(QMainWindow, WindowMixin):
             self.actions.redo.setToolTip("Redo")
 
     def choose_shape_line_color(self):
+        if (self.document_kind == DocumentKind.VIDEO
+                and not self._ensure_video_editable()):
+            return
         color = self.color_dialog.getColor(self.line_color, u'Choose Line Color',
                                            default=DEFAULT_LINE_COLOR)
         if color:
@@ -5480,6 +5692,9 @@ class MainWindow(QMainWindow, WindowMixin):
             self.set_dirty()
 
     def choose_shape_fill_color(self):
+        if (self.document_kind == DocumentKind.VIDEO
+                and not self._ensure_video_editable()):
+            return
         color = self.color_dialog.getColor(self.fill_color, u'Choose Fill Color',
                                            default=DEFAULT_FILL_COLOR)
         if color:
@@ -5488,6 +5703,9 @@ class MainWindow(QMainWindow, WindowMixin):
             self.set_dirty()
 
     def copy_shape(self):
+        if (self.document_kind == DocumentKind.VIDEO
+                and not self._ensure_video_editable()):
+            return
         if self.canvas.selected_shape is None:
             # True if one accidentally touches the left mouse button before releasing
             return
@@ -5496,6 +5714,9 @@ class MainWindow(QMainWindow, WindowMixin):
         self.set_dirty()
 
     def move_shape(self):
+        if (self.document_kind == DocumentKind.VIDEO
+                and not self._ensure_video_editable()):
+            return
         self.canvas.end_move(copy=False)
         self.set_dirty()
 

--- a/labelImgPlusPlus.py
+++ b/labelImgPlusPlus.py
@@ -87,8 +87,11 @@ from libs.core.video_project import (
     save_project_delta,
 )
 from libs.core.video_model import VideoProjectModel
+from libs.core.video_tracking import track_optical_flow
 from libs.core.video_session import is_video_project, prepare_video_open
-from libs.core.video_types import DocumentKind, VideoFrameRef
+from libs.core.video_types import (
+    DocumentKind, TrackingRequest, VideoFrameRef,
+)
 from libs.integrations import segmentation
 
 # Formats
@@ -224,6 +227,11 @@ class MainWindow(QMainWindow, WindowMixin):
         self._video_playback_speed = 1.0
         self._video_play_started_wall = None
         self._video_play_started_seconds = None
+        self._tracking_request_id = 0
+        self._tracking_handle = None
+        self._active_tracking_request = None
+        self._tracking_run_keys = set()
+        self._applying_tracking_batch = False
         self._load_request_id = 0
         self._pending_navigation_index = None
         self._prefetch_handles = {}
@@ -551,6 +559,26 @@ class MainWindow(QMainWindow, WindowMixin):
             'Delete Track…', self.delete_selected_track,
             None, 'delete', 'Delete the selected track on every frame',
             enabled=False)
+        video_track_forward = action(
+            'Track Forward', self.track_selected_forward,
+            self.shortcut_config.get('video_track_forward'), None,
+            'Propagate the selected rectangle forward with optical flow',
+            enabled=False)
+        video_track_backward = action(
+            'Track Backward', self.track_selected_backward,
+            self.shortcut_config.get('video_track_backward'), None,
+            'Propagate the selected rectangle backward with optical flow',
+            enabled=False)
+        video_accept_suggestion = action(
+            'Accept Current Suggestion', self.accept_current_suggestion,
+            self.shortcut_config.get('video_accept_suggestion'), 'verify',
+            'Accept the pending tracker observation on this frame',
+            enabled=False)
+        video_reject_suggestion = action(
+            'Reject Current Suggestion', self.reject_current_suggestion,
+            self.shortcut_config.get('video_reject_suggestion'), 'close',
+            'Reject the pending tracker observation on this frame',
+            enabled=False)
         sam_mode_action = action(
             'SAM Segment',
             self.toggle_sam_mode,
@@ -771,6 +799,10 @@ class MainWindow(QMainWindow, WindowMixin):
             'edit_label': edit,
             'keypoint_mode': keypoint_mode_action,
             'video_add_keyframe': video_add_keyframe,
+            'video_track_forward': video_track_forward,
+            'video_track_backward': video_track_backward,
+            'video_accept_suggestion': video_accept_suggestion,
+            'video_reject_suggestion': video_reject_suggestion,
         }
 
         # Store actions for further handling.
@@ -779,6 +811,10 @@ class MainWindow(QMainWindow, WindowMixin):
                               keypoint_mode=keypoint_mode_action,
                               videoAddKeyframe=video_add_keyframe,
                               videoDeleteTrack=video_delete_track,
+                              videoTrackForward=video_track_forward,
+                              videoTrackBackward=video_track_backward,
+                              videoAcceptSuggestion=video_accept_suggestion,
+                              videoRejectSuggestion=video_reject_suggestion,
                               sam_mode=sam_mode_action,
                               delete=delete, edit=edit, copy=copy,
                               copyToClipboard=copy_to_clipboard, pasteFromClipboard=paste_from_clipboard,
@@ -948,6 +984,8 @@ class MainWindow(QMainWindow, WindowMixin):
         add_actions(self.menus.tools, (
             check_labels, batch_verify_action, split_dataset_action,
             None, video_play_pause, video_add_keyframe,
+            video_track_forward, video_track_backward,
+            video_accept_suggestion, video_reject_suggestion,
             video_delete_track,
             None, sam_mode_action, sam_settings_action))
 
@@ -1403,10 +1441,16 @@ class MainWindow(QMainWindow, WindowMixin):
                 kind == DocumentKind.VIDEO)
             self.actions.videoAddKeyframe.setEnabled(False)
             self.actions.videoDeleteTrack.setEnabled(False)
+            self.actions.videoTrackForward.setEnabled(False)
+            self.actions.videoTrackBackward.setEnabled(False)
+            self.actions.videoAcceptSuggestion.setEnabled(False)
+            self.actions.videoRejectSuggestion.setEnabled(False)
 
     def _close_video_decoder(self):
         if hasattr(self, '_video_playback_timer'):
             self.pause_video()
+        if hasattr(self, '_tracking_handle'):
+            self.cancel_video_tracking()
         decoder = getattr(self, 'video_decoder', None)
         self.video_decoder = None
         snapshot = getattr(self, 'video_snapshot', None)
@@ -2798,6 +2842,9 @@ class MainWindow(QMainWindow, WindowMixin):
         self.video_classes = tuple(model.classes)
 
     def _on_video_model_mutation(self):
+        if (self._active_tracking_request is not None
+                and not self._applying_tracking_batch):
+            self.cancel_video_tracking()
         self.pause_video()
         self._sync_video_model_views()
         self._document_revision = self.video_model.revision
@@ -2895,6 +2942,11 @@ class MainWindow(QMainWindow, WindowMixin):
                 self.canvas.select_shape(match)
         self._refresh_video_track_list()
         self.update_box_count()
+        has_pending = any(
+            item.pts == int(pts) and item.review_state == 'pending'
+            for item in model.observations.values())
+        self.actions.videoAcceptSuggestion.setEnabled(has_pending)
+        self.actions.videoRejectSuggestion.setEnabled(has_pending)
 
     def _refresh_video_track_list(self):
         model = self.video_model
@@ -2938,6 +2990,10 @@ class MainWindow(QMainWindow, WindowMixin):
         self._selected_video_track_id = track_id
         self.actions.videoAddKeyframe.setEnabled(True)
         self.actions.videoDeleteTrack.setEnabled(True)
+        track = self.video_model.tracks.get(track_id)
+        can_track = track is not None and track.shape_type == 'rectangle'
+        self.actions.videoTrackForward.setEnabled(can_track)
+        self.actions.videoTrackBackward.setEnabled(can_track)
         shape = next((item for item in self.canvas.shapes
                       if getattr(item, 'video_track_id', None) == track_id),
                      None)
@@ -2989,6 +3045,202 @@ class MainWindow(QMainWindow, WindowMixin):
             self, before, after, 'Delete video track'))
         self._on_video_model_mutation()
         self._materialize_video_frame(self.current_video_frame_ref.pts)
+
+    def track_selected_forward(self):
+        return self._request_video_tracking(1)
+
+    def track_selected_backward(self):
+        return self._request_video_tracking(-1)
+
+    def _tracking_endpoint(self, track_id, start_pts, direction):
+        anchors = sorted(
+            item.pts for item in self.video_model.observations.values()
+            if item.track_id == track_id and item.source == 'manual'
+            and item.review_state == 'accepted' and item.anchor
+            and (item.pts - start_pts) * direction > 0)
+        if anchors:
+            return anchors[0] if direction > 0 else anchors[-1]
+        snapshot = self.video_snapshot
+        five_seconds = int(round(
+            5 * snapshot.time_base_den / snapshot.time_base_num))
+        endpoint = start_pts + direction * five_seconds
+        lower = int(snapshot.start_pts or 0)
+        upper = lower + int(snapshot.duration_pts or five_seconds)
+        return max(lower, min(upper, endpoint))
+
+    def _request_video_tracking(self, direction):
+        model = self.video_model
+        frame_ref = self.current_video_frame_ref
+        track_id = self._selected_video_track_id
+        if model is None or frame_ref is None or track_id is None:
+            self.status('Select a rectangle track before tracking')
+            return None
+        track = model.tracks.get(track_id)
+        seed = model.observations.get((track_id, frame_ref.pts))
+        if (track is None or track.shape_type != 'rectangle'
+                or seed is None or not seed.present
+                or seed.review_state != 'accepted'):
+            self.status(
+                'Tracking must start from an accepted exact rectangle')
+            return None
+        endpoint = self._tracking_endpoint(
+            track_id, frame_ref.pts, direction)
+        if endpoint == frame_ref.pts:
+            self.status('No tracking range is available in that direction')
+            return None
+        self.cancel_video_tracking()
+        self._tracking_request_id += 1
+        request = TrackingRequest(
+            request_id=self._tracking_request_id,
+            generation=self._dataset_generation,
+            source_path=self.video_snapshot.source_path,
+            stream_index=self.video_snapshot.stream_index,
+            start_ref=frame_ref, end_pts=endpoint, direction=direction,
+            track=track, seed=seed,
+            seed_track_revision=track.revision,
+            document_revision=model.revision)
+        self._active_tracking_request = request
+        self._tracking_run_keys = set()
+
+        def propagate(handle):
+            return track_optical_flow(request, handle)
+
+        handle = self.task_coordinator.submit(
+            'background', propagate, priority=JobPriority.BULK,
+            key='video-tracking', latest=True,
+            generation=self._dataset_generation)
+        self._tracking_handle = handle
+        handle.progress.connect(self._on_tracking_batch)
+        handle.result.connect(self._on_tracking_result)
+        handle.error.connect(self._on_tracking_error)
+        handle.finished.connect(self._on_tracking_finished)
+        self.status('Tracking %s…' % (
+            'forward' if direction > 0 else 'backward'))
+        return handle
+
+    def _tracking_batch_is_current(self, batch):
+        request = self._active_tracking_request
+        if request is None or self.video_model is None:
+            return False
+        track = self.video_model.tracks.get(batch.track_id)
+        return (
+            batch.request_id == request.request_id
+            and batch.generation == self._dataset_generation
+            and batch.track_id == request.track.track_id
+            and batch.seed_track_revision == request.seed_track_revision
+            and batch.document_revision == request.document_revision
+            and track is not None
+            and track.revision == request.seed_track_revision
+        )
+
+    def _on_tracking_batch(self, batch):
+        if not self._tracking_batch_is_current(batch):
+            return
+        changed = False
+        self._applying_tracking_batch = True
+        try:
+            for observation in batch.observations:
+                value = self.video_model.upsert_tracker(observation)
+                if value.review_state == 'pending':
+                    self._tracking_run_keys.add(
+                        (value.track_id, value.pts))
+                changed = changed or value is not observation \
+                    or value.revision != observation.revision
+            if batch.observations:
+                self._on_video_model_mutation()
+                self._materialize_video_frame(
+                    self.current_video_frame_ref.pts)
+        finally:
+            self._applying_tracking_batch = False
+        if batch.observations:
+            self.status('Tracking: %s to %s PTS' % (
+                batch.start_pts, batch.end_pts))
+        return changed
+
+    def _on_tracking_result(self, batch):
+        if not self._tracking_batch_is_current(batch):
+            return
+        self._on_tracking_batch(batch)
+        self.status('Tracking stopped: %s' % (
+            batch.stop_reason or 'range complete'))
+
+    def _on_tracking_error(self, message):
+        self.status('Video tracking failed: ' + message, delay=10000)
+
+    def _on_tracking_finished(self):
+        self._tracking_handle = None
+        self._active_tracking_request = None
+
+    def cancel_video_tracking(self):
+        handle = getattr(self, '_tracking_handle', None)
+        if handle is not None:
+            handle.cancel()
+        self._tracking_handle = None
+        self._active_tracking_request = None
+
+    def _current_pending_keys(self):
+        if self.video_model is None or self.current_video_frame_ref is None:
+            return ()
+        pts = self.current_video_frame_ref.pts
+        values = [
+            key for key, item in self.video_model.observations.items()
+            if item.pts == pts and item.review_state == 'pending']
+        if self._selected_video_track_id is not None:
+            preferred = (self._selected_video_track_id, pts)
+            if preferred in values:
+                return (preferred,)
+        return tuple(values[:1])
+
+    def _review_video_keys(self, keys, review_state, description):
+        keys = tuple(
+            key for key in keys
+            if key in self.video_model.observations
+            and self.video_model.observations[key].review_state == 'pending')
+        if not keys:
+            return False
+        self.cancel_video_tracking()
+        before = self.video_model.snapshot_state()
+        for track_id, pts in keys:
+            self.video_model.review(track_id, pts, review_state)
+        after = self.video_model.snapshot_state()
+        self.undo_stack.push(VideoModelCommand(
+            self, before, after, description))
+        self._on_video_model_mutation()
+        self._materialize_video_frame(self.current_video_frame_ref.pts)
+        return True
+
+    def accept_current_suggestion(self):
+        return self._review_video_keys(
+            self._current_pending_keys(), 'accepted',
+            'Accept tracker suggestion')
+
+    def reject_current_suggestion(self):
+        return self._review_video_keys(
+            self._current_pending_keys(), 'rejected',
+            'Reject tracker suggestion')
+
+    def review_visible_suggestions(self, review_state, start_pts=None,
+                                   end_pts=None):
+        if self.video_model is None:
+            return False
+        if start_pts is None or end_pts is None:
+            center = self.current_video_frame_ref.pts
+            radius = int(round(
+                2.5 * self.video_snapshot.time_base_den /
+                self.video_snapshot.time_base_num))
+            start_pts, end_pts = center - radius, center + radius
+        keys = tuple(
+            key for key, item in self.video_model.observations.items()
+            if start_pts <= item.pts <= end_pts
+            and item.review_state == 'pending')
+        return self._review_video_keys(
+            keys, review_state,
+            '%s visible tracker suggestions' % review_state.title())
+
+    def review_full_propagation(self, review_state):
+        return self._review_video_keys(
+            tuple(self._tracking_run_keys), review_state,
+            '%s full tracker propagation' % review_state.title())
 
     def _video_step_pts(self):
         snapshot = self.video_snapshot

--- a/labelImgPlusPlus.py
+++ b/labelImgPlusPlus.py
@@ -77,6 +77,12 @@ from libs.core.task_coordinator import JobPriority, TaskCoordinator
 from libs.core.profiling import (
     hash_path, recorder as trace_recorder, trace_span,
 )
+from libs.core.video_decoder import VIDEO_EXTENSIONS
+from libs.core.video_project import (
+    checkpoint_project, default_project_path, save_project_as,
+)
+from libs.core.video_session import is_video_project, prepare_video_open
+from libs.core.video_types import DocumentKind
 from libs.integrations import segmentation
 
 # Formats
@@ -191,6 +197,15 @@ class MainWindow(QMainWindow, WindowMixin):
         # thumbnail galleries (16 MiB each): 96 + 16 + 16 = 128 MiB total.
         self.frame_cache = FrameCache(
             max_images=5, max_bytes=96 * 1024 * 1024)
+        self.document_kind = DocumentKind.NONE
+        self.video_decoder = None
+        self.video_snapshot = None
+        self.video_tracks = ()
+        self.video_observations = ()
+        self.video_frame_states = ()
+        self.video_classes = ()
+        self._video_open_request_id = 0
+        self._video_save_handle = None
         self._load_request_id = 0
         self._pending_navigation_index = None
         self._prefetch_handles = {}
@@ -1250,6 +1265,8 @@ class MainWindow(QMainWindow, WindowMixin):
 
     def reset_state(self):
         self._restart_workers_if_needed()
+        self._close_video_decoder()
+        self._set_document_kind(DocumentKind.NONE)
         self.items_to_shapes.clear()
         self.shapes_to_items.clear()
         self.rect_label_list.clear()
@@ -1266,6 +1283,32 @@ class MainWindow(QMainWindow, WindowMixin):
         # Reset status bar widgets
         self.label_box_count.setText('Boxes: 0')
         self.update_save_status(saved=True)
+
+    def _set_document_kind(self, kind):
+        """Switch cache policy and document-only UI without touching content."""
+        previous = getattr(self, 'document_kind', DocumentKind.NONE)
+        if previous != kind and hasattr(self, 'frame_cache'):
+            self.frame_cache.clear()
+        self.document_kind = kind
+        if hasattr(self, 'frame_cache'):
+            self.frame_cache.max_images = (
+                12 if kind == DocumentKind.VIDEO else 5)
+        if hasattr(self, 'file_dock'):
+            self.file_dock.setVisible(kind != DocumentKind.VIDEO)
+
+    def _close_video_decoder(self):
+        decoder = getattr(self, 'video_decoder', None)
+        self.video_decoder = None
+        snapshot = getattr(self, 'video_snapshot', None)
+        self.video_snapshot = None
+        if decoder is not None:
+            decoder.close()
+        if (snapshot is not None and snapshot.project_path
+                and not snapshot.read_only and not self.dirty):
+            try:
+                checkpoint_project(snapshot.project_path)
+            except Exception:
+                pass
 
     def _restart_workers_if_needed(self):
         coordinator = getattr(self, 'task_coordinator', None)
@@ -2249,9 +2292,211 @@ class MainWindow(QMainWindow, WindowMixin):
         for item, shape in self.items_to_shapes.items():
             item.setCheckState(Qt.Checked if value else Qt.Unchecked)
 
+    def _video_project_target(self, source_path, project_path=None,
+                              allow_dialog=False):
+        """Resolve the default sidecar, falling back to read-only safely."""
+        if is_video_project(source_path):
+            return source_path, False
+        if project_path:
+            return os.path.abspath(ustr(project_path)), False
+        default = default_project_path(source_path)
+        if os.path.exists(default) or os.access(
+                os.path.dirname(default) or '.', os.W_OK):
+            return default, False
+        if allow_dialog:
+            chosen, _selected_filter = QFileDialog.getSaveFileName(
+                self, '%s - Choose Video Project' % __appname__, default,
+                'LabelImg++ video project (*.labelimgpp.sqlite)')
+            if chosen:
+                chosen = ustr(chosen)
+                if not chosen.lower().endswith('.labelimgpp.sqlite'):
+                    chosen += '.labelimgpp.sqlite'
+                return os.path.abspath(chosen), False
+        return None, True
+
+    def request_open_video(self, path, project_path=None, skip_prompt=False):
+        """Queue a transactional video/project open on the decoder lane."""
+        path = os.path.abspath(ustr(path))
+        if not skip_prompt and self.dirty:
+            if self.auto_saving.isChecked():
+                self.request_save_file(on_success=lambda: self.request_open_video(
+                    path, project_path=project_path, skip_prompt=True))
+                return None
+            answer = self.discard_changes_dialog()
+            if answer == QMessageBox.Cancel:
+                return None
+            if answer == QMessageBox.Yes:
+                self.request_save_file(on_success=lambda: self.request_open_video(
+                    path, project_path=project_path, skip_prompt=True))
+                return None
+
+        target, read_only = self._video_project_target(
+            path, project_path=project_path, allow_dialog=True)
+        self._dataset_generation = self.task_coordinator.next_generation()
+        generation = self._dataset_generation
+        self._video_open_request_id += 1
+        request_id = self._video_open_request_id
+        self._show_loading_veil('Opening video %s…' % os.path.basename(path))
+
+        def prepare(handle):
+            prepared = prepare_video_open(
+                path, project_path=target, read_only=read_only,
+                cancelled=handle.is_cancelled)
+            if handle.is_cancelled():
+                prepared.decoder.close()
+                return None
+            return prepared
+
+        handle = self.task_coordinator.submit(
+            'video', prepare, priority=JobPriority.IMAGE_LOAD,
+            key='video-open', latest=True, generation=generation)
+        handle.result.connect(
+            lambda prepared, rid=request_id, gen=generation:
+            self._on_video_open_result(prepared, rid, gen))
+        handle.error.connect(
+            lambda message, rid=request_id, gen=generation:
+            self._on_video_open_error(message, rid, gen))
+        return handle
+
+    def _on_video_open_error(self, message, request_id, generation):
+        if (request_id != self._video_open_request_id
+                or generation != self._dataset_generation):
+            return
+        self._hide_loading_veil()
+        self.canvas.setEnabled(bool(self.file_path))
+        self.status('Error opening video: ' + message, delay=10000)
+
+    def _on_video_open_result(self, prepared, request_id, generation):
+        if prepared is None:
+            return
+        if (request_id != self._video_open_request_id
+                or generation != self._dataset_generation):
+            prepared.decoder.close()
+            return
+        self._commit_video_open(prepared)
+        self._hide_loading_veil()
+
+    def _commit_video_open(self, prepared):
+        """Atomically publish worker data on QApplication.thread()."""
+        assert QApplication.instance().thread() == self.thread()
+        snapshot = prepared.snapshot
+        first = snapshot.initial_frame
+        self.reset_state()
+        self._set_document_kind(DocumentKind.VIDEO)
+        self.video_decoder = prepared.decoder
+        self.video_snapshot = snapshot
+        self.video_tracks = prepared.tracks
+        self.video_observations = prepared.observations
+        self.video_frame_states = prepared.frame_states
+        self.video_classes = prepared.classes
+        self._document_revision = snapshot.revision
+        self.m_img_list = []
+        self._path_to_idx = {}
+        self.img_count = 0
+        self.cur_img_idx = 0
+        self.file_list_widget.clear()
+        self.file_path = snapshot.source_path
+        self.image_data = None
+        self.image = first.image
+        self._image_scale_factor = (
+            first.display_width / snapshot.width if snapshot.width else 1.0)
+        self._original_image_size = QSize(snapshot.width, snapshot.height)
+        verified_pts = {state.pts for state in prepared.frame_states
+                        if state.verified}
+        self.canvas.verified = first.frame_ref.pts in verified_pts
+        self.canvas.locked = (
+            self.canvas.verified and self.lock_on_verify_option.isChecked())
+        self.canvas.load_pixmap(QPixmap.fromImage(first.image))
+        self.frame_cache.put(first)
+        self.set_clean()
+        self.canvas.setEnabled(True)
+        self.adjust_scale(initial=True)
+        self.paint_canvas()
+        self.toggle_actions(True)
+        editable = not snapshot.read_only
+        for action in (self.actions.create, self.actions.create_polygon,
+                       self.actions.createMode, self.actions.editMode):
+            action.setEnabled(editable)
+        self.actions.saveAs.setEnabled(bool(snapshot.project_path))
+        self.add_recent_file(snapshot.project_path or snapshot.source_path)
+        suffix = ' [read-only]' if snapshot.read_only else ''
+        self.setWindowTitle(
+            '%s %s%s' % (__appname__, snapshot.source_path, suffix))
+        self.update_status_bar()
+        self.canvas.setFocus(True)
+        self.status('Opened video %s' % os.path.basename(snapshot.source_path))
+
+    def open_video(self, path, project_path=None):
+        """Synchronous compatibility API for extensions and tests."""
+        if self.dirty and not self.may_continue():
+            return False
+        path = os.path.abspath(ustr(path))
+        target, read_only = self._video_project_target(
+            path, project_path=project_path, allow_dialog=False)
+        try:
+            prepared = prepare_video_open(
+                path, project_path=target, read_only=read_only)
+        except Exception as exc:
+            self.status('Error opening video: %s' % exc, delay=10000)
+            return False
+        self._dataset_generation = self.task_coordinator.next_generation()
+        self._commit_video_open(prepared)
+        return True
+
+    def request_save_video_project(self, _value=False, on_success=None):
+        snapshot = self.video_snapshot
+        if (self.document_kind != DocumentKind.VIDEO or snapshot is None
+                or snapshot.read_only or not snapshot.project_path):
+            return None
+        revision = self._document_revision
+        project_path = snapshot.project_path
+
+        def save(handle):
+            handle.check_cancelled()
+            checkpoint_project(project_path)
+            return project_path
+
+        handle = self.task_coordinator.submit(
+            'background', save, priority=JobPriority.IMAGE_LOAD,
+            key='video-project-save', latest=True,
+            generation=self._dataset_generation)
+        self._video_save_handle = handle
+        handle.result.connect(
+            lambda saved, rev=revision, callback=on_success:
+            self._on_video_save_result(saved, rev, callback))
+        handle.error.connect(
+            lambda message: self.status(
+                'Error saving video project: ' + message, delay=10000))
+        return handle
+
+    def _on_video_save_result(self, path, revision, on_success=None):
+        if path and self._document_revision == revision:
+            self.set_clean()
+        if path:
+            self.status('Saved video project to %s' % path)
+        if path and callable(on_success):
+            on_success()
+
+    def save_video_project(self):
+        snapshot = self.video_snapshot
+        if (self.document_kind != DocumentKind.VIDEO or snapshot is None
+                or snapshot.read_only or not snapshot.project_path):
+            return False
+        try:
+            checkpoint_project(snapshot.project_path)
+        except Exception as exc:
+            self.status('Error saving video project: %s' % exc, delay=10000)
+            return False
+        self.set_clean()
+        return True
+
     def request_open_file(self, file_path, skip_prompt=False):
         """Load a standalone file transactionally if it is outside the dataset."""
         file_path = os.path.abspath(ustr(file_path))
+        if (is_video_project(file_path)
+                or file_path.lower().endswith(VIDEO_EXTENSIONS)):
+            return self.request_open_video(
+                file_path, skip_prompt=skip_prompt)
         if file_path in self._path_to_idx:
             return self.request_load_file(
                 file_path, skip_prompt=skip_prompt)
@@ -2379,8 +2624,8 @@ class MainWindow(QMainWindow, WindowMixin):
             return
         if replacement_snapshot is not None:
             self._commit_dataset_snapshot(replacement_snapshot)
-        self.frame_cache.put(result)
         self._commit_image_result(result)
+        self.frame_cache.put(result)
         self._pending_navigation_index = None
         self._hide_loading_veil()
         self._schedule_prefetch(result.path)
@@ -2393,6 +2638,7 @@ class MainWindow(QMainWindow, WindowMixin):
             trace_started = time.perf_counter_ns()
         assert QApplication.instance().thread() == self.thread()
         self.reset_state()
+        self._set_document_kind(DocumentKind.IMAGE)
         self._image_scale_factor = result.scale_factor
         self._original_image_size = QSize(
             result.original_width, result.original_height)
@@ -2525,6 +2771,13 @@ class MainWindow(QMainWindow, WindowMixin):
 
     def load_file(self, file_path=None):
         """Load the specified file, or the last opened file if None."""
+        requested = (file_path if file_path is not None
+                     else self.settings.get(SETTING_FILENAME))
+        if requested:
+            requested = os.path.abspath(ustr(requested))
+            if (is_video_project(requested)
+                    or requested.lower().endswith(VIDEO_EXTENSIONS)):
+                return self.open_video(requested)
         self.reset_state()
         self.canvas.setEnabled(False)
         if file_path is None:
@@ -2608,6 +2861,7 @@ class MainWindow(QMainWindow, WindowMixin):
 
             self.status("Loaded %s" % os.path.basename(unicode_file_path))
             self.image = image
+            self._set_document_kind(DocumentKind.IMAGE)
             if hasattr(self, 'sam_controller'):
                 self.sam_controller.on_image_changed()
             self.file_path = unicode_file_path
@@ -2783,6 +3037,7 @@ class MainWindow(QMainWindow, WindowMixin):
         self.annotation_catalog.cancel()
         if hasattr(self, 'sam_controller'):
             self.sam_controller.cancel()
+        self._close_video_decoder()
         self.task_coordinator.shutdown()
 
     def load_recent(self, filename):
@@ -3428,6 +3683,8 @@ class MainWindow(QMainWindow, WindowMixin):
     def request_save_file(self, _value=False, on_success=None,
                           annotation_base=None):
         """Queue an immutable, revision-aware save for GUI workflows."""
+        if self.document_kind == DocumentKind.VIDEO:
+            return self.request_save_video_project(on_success=on_success)
         if not self.file_path:
             return None
         degradation_formats = {
@@ -3553,6 +3810,8 @@ class MainWindow(QMainWindow, WindowMixin):
                 self.file_path, snapshot=self.dataset_snapshot)
 
     def save_file(self, _value=False):
+        if self.document_kind == DocumentKind.VIDEO:
+            return self.save_video_project()
         if not self.file_path:
             return False
 
@@ -3576,16 +3835,59 @@ class MainWindow(QMainWindow, WindowMixin):
                                    else self.save_file_dialog(remove_ext=False))
 
     def save_file_as(self, _value=False):
+        if self.document_kind == DocumentKind.VIDEO:
+            target = self._video_project_save_dialog()
+            if not target:
+                return False
+            try:
+                save_project_as(self.video_snapshot.project_path, target)
+            except Exception as exc:
+                self.status('Error saving video project: %s' % exc)
+                return False
+            return True
         assert not self.image.isNull(), "cannot save empty image"
         return self._save_file(self.save_file_dialog())
 
     def request_save_file_as(self, _value=False):
         """Choose a target on the GUI thread and write it asynchronously."""
+        if self.document_kind == DocumentKind.VIDEO:
+            target = self._video_project_save_dialog()
+            if not target:
+                return None
+            source = self.video_snapshot.project_path
+
+            def save_as(handle):
+                handle.check_cancelled()
+                return save_project_as(source, target)
+
+            handle = self.task_coordinator.submit(
+                'background', save_as, priority=JobPriority.IMAGE_LOAD,
+                key='video-project-save-as', latest=True,
+                generation=self._dataset_generation)
+            handle.result.connect(
+                lambda path: self.status('Saved video project to %s' % path))
+            handle.error.connect(
+                lambda message: self.status(
+                    'Error saving video project: ' + message))
+            return handle
         assert not self.image.isNull(), "cannot save empty image"
         annotation_base = self.save_file_dialog()
         if not annotation_base:
             return None
         return self.request_save_file(annotation_base=annotation_base)
+
+    def _video_project_save_dialog(self):
+        snapshot = self.video_snapshot
+        if snapshot is None or not snapshot.project_path:
+            return ''
+        filename, _selected_filter = QFileDialog.getSaveFileName(
+            self, '%s - Save Video Project As' % __appname__,
+            snapshot.project_path,
+            'LabelImg++ video project (*.labelimgpp.sqlite)')
+        filename = ustr(filename)
+        if filename and not filename.lower().endswith('.labelimgpp.sqlite'):
+            filename += '.labelimgpp.sqlite'
+        return filename
 
     def save_file_dialog(self, remove_ext=True):
         caption = '%s - Choose File' % __appname__

--- a/labelImgPlusPlus.py
+++ b/labelImgPlusPlus.py
@@ -7,6 +7,7 @@ import platform
 import shutil
 import sys
 import threading
+import time
 import webbrowser as wb
 from functools import partial
 
@@ -57,6 +58,7 @@ from libs.widgets.statsWidget import StatsWidget
 from libs.widgets.labelCheckerDialog import LabelCheckerDialog
 from libs.widgets.keypointPanel import KeypointPanel
 from libs.widgets import view_scaling
+from libs.widgets.videoTimelineWidget import VideoTimelineWidget
 
 # Core
 from libs.core.shape import Shape, ShapeType, DEFAULT_LINE_COLOR, DEFAULT_FILL_COLOR
@@ -77,12 +79,12 @@ from libs.core.task_coordinator import JobPriority, TaskCoordinator
 from libs.core.profiling import (
     hash_path, recorder as trace_recorder, trace_span,
 )
-from libs.core.video_decoder import VIDEO_EXTENSIONS
+from libs.core.video_decoder import VIDEO_EXTENSIONS, VideoDecoderSession
 from libs.core.video_project import (
     checkpoint_project, default_project_path, save_project_as,
 )
 from libs.core.video_session import is_video_project, prepare_video_open
-from libs.core.video_types import DocumentKind
+from libs.core.video_types import DocumentKind, VideoFrameRef
 from libs.integrations import segmentation
 
 # Formats
@@ -206,6 +208,13 @@ class MainWindow(QMainWindow, WindowMixin):
         self.video_classes = ()
         self._video_open_request_id = 0
         self._video_save_handle = None
+        self._video_frame_request_id = 0
+        self._video_decode_in_flight = False
+        self._video_prefetch_handle = None
+        self.current_video_frame_ref = None
+        self._video_playback_speed = 1.0
+        self._video_play_started_wall = None
+        self._video_play_started_seconds = None
         self._load_request_id = 0
         self._pending_navigation_index = None
         self._prefetch_handles = {}
@@ -405,6 +414,28 @@ class MainWindow(QMainWindow, WindowMixin):
         self.addDockWidget(Qt.RightDockWidgetArea, self.dock)
         self.addDockWidget(Qt.RightDockWidgetArea, self.file_dock)
 
+        self.video_timeline = VideoTimelineWidget(self)
+        self.timeline_dock = QDockWidget('Video Timeline', self)
+        self.timeline_dock.setObjectName('videoTimeline')
+        self.timeline_dock.setWidget(self.video_timeline)
+        self.timeline_dock.setFeatures(
+            QDockWidget.DockWidgetMovable | QDockWidget.DockWidgetFloatable)
+        self.addDockWidget(Qt.BottomDockWidgetArea, self.timeline_dock)
+        self.timeline_dock.hide()
+        self.video_timeline.seekRequested.connect(self.request_video_frame)
+        self.video_timeline.previousRequested.connect(
+            self.request_previous_video_frame)
+        self.video_timeline.nextRequested.connect(
+            self.request_next_video_frame)
+        self.video_timeline.playPauseRequested.connect(
+            self.play_pause_video)
+        self.video_timeline.speedChanged.connect(
+            self._set_video_playback_speed)
+        self._video_playback_timer = QTimer(self)
+        self._video_playback_timer.setTimerType(Qt.PreciseTimer)
+        self._video_playback_timer.setInterval(10)
+        self._video_playback_timer.timeout.connect(self._video_playback_tick)
+
         # Configure dock features - all docks are movable for resizing
         # DockWidgetMovable enables drag-to-rearrange and proper splitter resizing
         self.file_dock.setFeatures(QDockWidget.DockWidgetMovable | QDockWidget.DockWidgetFloatable)
@@ -428,6 +459,11 @@ class MainWindow(QMainWindow, WindowMixin):
         open = action(get_str('openFile'), self.open_file,
                       self.shortcut_config.get('open'), 'open', get_str('openFileDetail'))
 
+        open_video = action(
+            'Open Video…', self.open_video_dialog,
+            self.shortcut_config.get('open_video'), 'file',
+            'Open a local video or LabelImg++ video project')
+
         open_dir = action(get_str('openDir'), self.open_dir_dialog,
                           self.shortcut_config.get('open_dir'), 'open', get_str('openDir'))
 
@@ -446,6 +482,11 @@ class MainWindow(QMainWindow, WindowMixin):
 
         verify = action(get_str('verifyImg'), self.request_verify_image,
                         self.shortcut_config.get('verify'), 'verify', get_str('verifyImgDetail'))
+
+        video_play_pause = action(
+            'Play/Pause Video', self.play_pause_video,
+            self.shortcut_config.get('video_play_pause'), None,
+            'Play or pause the active video without audio', enabled=False)
 
         save = action(get_str('save'), self.request_save_file,
                       self.shortcut_config.get('save'), 'save', get_str('saveDetail'), enabled=False)
@@ -664,6 +705,7 @@ class MainWindow(QMainWindow, WindowMixin):
         self._action_map = {
             'quit': quit,
             'open': open,
+            'open_video': open_video,
             'open_dir': open_dir,
             'change_save_dir': change_save_dir,
             'open_annotation': open_annotation,
@@ -671,6 +713,7 @@ class MainWindow(QMainWindow, WindowMixin):
             'open_next_image': open_next_image,
             'open_prev_image': open_prev_image,
             'verify': verify,
+            'video_play_pause': video_play_pause,
             'save': save,
             'save_format': save_format,
             'save_as': save_as,
@@ -705,7 +748,7 @@ class MainWindow(QMainWindow, WindowMixin):
         }
 
         # Store actions for further handling.
-        self.actions = Struct(save=save, save_format=save_format, saveAs=save_as, open=open, close=close, resetAll=reset_all, deleteImg=delete_image,
+        self.actions = Struct(save=save, save_format=save_format, saveAs=save_as, open=open, openVideo=open_video, close=close, resetAll=reset_all, deleteImg=delete_image,
                               lineColor=color1, create=create, create_polygon=create_polygon,
                               keypoint_mode=keypoint_mode_action,
                               sam_mode=sam_mode_action,
@@ -713,6 +756,7 @@ class MainWindow(QMainWindow, WindowMixin):
                               copyToClipboard=copy_to_clipboard, pasteFromClipboard=paste_from_clipboard,
                               copyAllToClipboard=copy_all_to_clipboard,
                               undo=undo, redo=redo,
+                              videoPlayPause=video_play_pause,
                               createMode=create_mode, editMode=edit_mode, advancedMode=advanced_mode, galleryMode=gallery_mode,
                               shapeLineColor=shape_line_color, shapeFillColor=shape_fill_color,
                               zoom=zoom, zoomIn=zoom_in, zoomOut=zoom_out, zoomOrg=zoom_org,
@@ -721,7 +765,8 @@ class MainWindow(QMainWindow, WindowMixin):
                               lightBrighten=light_brighten, lightDarken=light_darken, lightOrg=light_org,
                               lightActions=light_actions,
                               fileMenuActions=(
-                                  open, open_dir, save, save_as, close, reset_all, quit),
+                                  open, open_video, open_dir, save, save_as,
+                                  close, reset_all, quit),
                               beginner=(), advanced=(),
                               editMenu=(undo, redo, None, edit, copy, copy_to_clipboard,
                                         paste_from_clipboard, copy_all_to_clipboard, delete,
@@ -823,7 +868,10 @@ class MainWindow(QMainWindow, WindowMixin):
             self.icon_size_group.actions()[-1].setChecked(True)
 
         add_actions(self.menus.file,
-                    (open, open_dir, change_save_dir, open_annotation, copy_prev_bounding, self.menus.recentFiles, save, save_format, save_as, close, reset_all, delete_image, quit))
+                    (open, open_video, open_dir, change_save_dir,
+                     open_annotation, copy_prev_bounding,
+                     self.menus.recentFiles, save, save_format, save_as,
+                     close, reset_all, delete_image, quit))
         add_actions(self.menus.help, (help_default, show_info, show_shortcut))
         add_actions(self.menus.view, (
             self.auto_saving,
@@ -870,6 +918,7 @@ class MainWindow(QMainWindow, WindowMixin):
             None, 'file', get_str('splitDatasetDetail'))
         add_actions(self.menus.tools, (
             check_labels, batch_verify_action, split_dataset_action,
+            None, video_play_pause,
             None, sam_mode_action, sam_settings_action))
 
         # Custom context menu for the canvas widget:
@@ -890,7 +939,7 @@ class MainWindow(QMainWindow, WindowMixin):
         file_dropdown = DropdownToolButton(
             text=get_str('openFile'),
             icon=new_icon('file'),
-            actions=[open, open_dir, change_save_dir]
+            actions=[open, open_video, open_dir, change_save_dir]
         )
 
         self.actions.beginner = (
@@ -1184,6 +1233,8 @@ class MainWindow(QMainWindow, WindowMixin):
             self.tools.set_expanded(True)
 
     def set_dirty(self):
+        if self.document_kind == DocumentKind.VIDEO:
+            self.pause_video()
         self._document_revision += 1
         self.dirty = True
         self.actions.save.setEnabled(True)
@@ -1295,12 +1346,23 @@ class MainWindow(QMainWindow, WindowMixin):
                 12 if kind == DocumentKind.VIDEO else 5)
         if hasattr(self, 'file_dock'):
             self.file_dock.setVisible(kind != DocumentKind.VIDEO)
+        if hasattr(self, 'timeline_dock'):
+            self.timeline_dock.setVisible(kind == DocumentKind.VIDEO)
+        if hasattr(self, 'actions') and hasattr(
+                self.actions, 'videoPlayPause'):
+            self.actions.videoPlayPause.setEnabled(
+                kind == DocumentKind.VIDEO)
 
     def _close_video_decoder(self):
+        if hasattr(self, '_video_playback_timer'):
+            self.pause_video()
         decoder = getattr(self, 'video_decoder', None)
         self.video_decoder = None
         snapshot = getattr(self, 'video_snapshot', None)
         self.video_snapshot = None
+        self.current_video_frame_ref = None
+        if hasattr(self, 'video_timeline'):
+            self.video_timeline.set_session(None)
         if decoder is not None:
             decoder.close()
         if (snapshot is not None and snapshot.project_path
@@ -1505,6 +1567,8 @@ class MainWindow(QMainWindow, WindowMixin):
 
     def toggle_drawing_sensitive(self, drawing=True):
         """In the middle of drawing, toggling between modes should be disabled."""
+        if drawing and self.document_kind == DocumentKind.VIDEO:
+            self.pause_video()
         self.actions.editMode.setEnabled(not drawing)
         self.actions.create_polygon.setEnabled(not drawing)
         if not drawing and self.beginner():
@@ -2407,7 +2471,10 @@ class MainWindow(QMainWindow, WindowMixin):
         self.canvas.locked = (
             self.canvas.verified and self.lock_on_verify_option.isChecked())
         self.canvas.load_pixmap(QPixmap.fromImage(first.image))
+        self.current_video_frame_ref = first.frame_ref
         self.frame_cache.put(first)
+        self.video_timeline.set_session(snapshot)
+        self._refresh_video_timeline_markers()
         self.set_clean()
         self.canvas.setEnabled(True)
         self.adjust_scale(initial=True)
@@ -2489,6 +2556,284 @@ class MainWindow(QMainWindow, WindowMixin):
             return False
         self.set_clean()
         return True
+
+    def _refresh_video_timeline_markers(self):
+        if self.video_snapshot is None:
+            return
+        by_track = {}
+        accepted = []
+        pending = []
+        for observation in self.video_observations:
+            by_track.setdefault(observation.track_id, []).append(
+                observation.pts)
+            if (observation.source == 'manual'
+                    and observation.review_state == 'accepted'
+                    and observation.anchor):
+                accepted.append(observation.pts)
+            elif observation.review_state == 'pending':
+                pending.append(observation.pts)
+        spans = tuple(
+            (min(values), max(values)) for values in by_track.values()
+            if values)
+        verified = tuple(
+            state.pts for state in self.video_frame_states if state.verified)
+        self.video_timeline.set_markers(
+            spans=spans, accepted=accepted, pending=pending,
+            verified=verified)
+
+    def _video_step_pts(self):
+        snapshot = self.video_snapshot
+        if snapshot is None:
+            return 1
+        if snapshot.average_rate_num and snapshot.average_rate_den:
+            seconds = (snapshot.average_rate_den /
+                       snapshot.average_rate_num)
+        else:
+            seconds = 1.0 / 30.0
+        return max(1, int(round(
+            seconds * snapshot.time_base_den / snapshot.time_base_num)))
+
+    def request_video_frame(self, frame_ref, playback=False):
+        """Seek by immutable PTS reference with latest-request-wins semantics."""
+        snapshot = self.video_snapshot
+        if (self.document_kind != DocumentKind.VIDEO or snapshot is None
+                or not isinstance(frame_ref, VideoFrameRef)
+                or frame_ref.fingerprint != snapshot.fingerprint
+                or frame_ref.stream_index != snapshot.stream_index):
+            return None
+        if playback and self._video_decode_in_flight:
+            return None
+        if not playback:
+            self.pause_video()
+        cached = self.frame_cache.get(frame_ref)
+        if cached is not None:
+            self._commit_video_frame(cached, playback=playback)
+            return None
+        mode = 'at_or_after' if playback else 'nearest'
+        return self._submit_video_decode(
+            lambda decoder, handle: decoder.seek_pts(
+                frame_ref.pts, mode=mode, cancelled=handle.is_cancelled),
+            playback=playback)
+
+    def _submit_video_decode(self, operation, playback=False):
+        if self.video_decoder is None:
+            return None
+        self._video_frame_request_id += 1
+        request_id = self._video_frame_request_id
+        generation = self._dataset_generation
+        if playback:
+            self._video_decode_in_flight = True
+
+        def decode(handle):
+            handle.check_cancelled()
+            return operation(self.video_decoder, handle)
+
+        handle = self.task_coordinator.submit(
+            'video', decode, priority=JobPriority.IMAGE_LOAD,
+            key='video-frame', latest=True, generation=generation)
+        handle.result.connect(
+            lambda result, rid=request_id, gen=generation, playing=playback:
+            self._on_video_frame_result(result, rid, gen, playing))
+        handle.error.connect(
+            lambda message, rid=request_id:
+            self._on_video_frame_error(message, rid))
+        handle.finished.connect(
+            lambda rid=request_id:
+            self._on_video_decode_finished(rid))
+        return handle
+
+    def _on_video_frame_result(self, result, request_id, generation,
+                               playback=False):
+        snapshot = self.video_snapshot
+        if (request_id != self._video_frame_request_id
+                or generation != self._dataset_generation
+                or snapshot is None):
+            return
+        if result is None:
+            self.pause_video()
+            return
+        if result.frame_ref.fingerprint != snapshot.fingerprint:
+            return
+        self.frame_cache.put(result)
+        self._commit_video_frame(result, playback=playback)
+
+    def _on_video_frame_error(self, message, request_id):
+        if request_id != self._video_frame_request_id:
+            return
+        self.pause_video()
+        self.status('Error decoding video frame: ' + message, delay=10000)
+
+    def _on_video_decode_finished(self, request_id):
+        if request_id == self._video_frame_request_id:
+            self._video_decode_in_flight = False
+
+    def _commit_video_frame(self, result, playback=False):
+        assert QApplication.instance().thread() == self.thread()
+        self.image = result.image
+        self._image_scale_factor = (
+            result.display_width / self.video_snapshot.width
+            if self.video_snapshot.width else 1.0)
+        self._original_image_size = QSize(
+            self.video_snapshot.width, self.video_snapshot.height)
+        self.canvas.load_pixmap(QPixmap.fromImage(result.image))
+        self.current_video_frame_ref = result.frame_ref
+        verified = any(
+            state.pts == result.frame_ref.pts and state.verified
+            for state in self.video_frame_states)
+        self.canvas.verified = verified
+        self.canvas.locked = (
+            verified and self.lock_on_verify_option.isChecked())
+        # Track materialization is installed by the next delivery slice. Until
+        # then a seek must never leak ordinary image shapes across frames.
+        materialize = getattr(self, '_materialize_video_frame', None)
+        if materialize is not None:
+            materialize(result.frame_ref.pts)
+        else:
+            self.items_to_shapes.clear()
+            self.shapes_to_items.clear()
+            self.rect_label_list.clear()
+            self.poly_label_list.clear()
+            self.canvas.load_shapes([])
+        self.undo_stack.clear()
+        self.video_timeline.set_current_frame(result.frame_ref)
+        self.paint_canvas()
+        self.update_status_bar()
+        if not playback:
+            self._schedule_video_prefetch(result.frame_ref)
+
+    def request_next_video_frame(self):
+        if self.current_video_frame_ref is None:
+            return None
+        self.pause_video()
+        self._navigation_direction = 1
+        cached = self.frame_cache.video_neighbor(
+            self.current_video_frame_ref, 1)
+        if cached is not None:
+            self._commit_video_frame(cached)
+            return None
+        return self._submit_video_decode(
+            lambda decoder, handle: decoder.next_frame(
+                cancelled=handle.is_cancelled))
+
+    def request_previous_video_frame(self):
+        if self.current_video_frame_ref is None:
+            return None
+        self.pause_video()
+        self._navigation_direction = -1
+        cached = self.frame_cache.video_neighbor(
+            self.current_video_frame_ref, -1)
+        if cached is not None:
+            self._commit_video_frame(cached)
+            return None
+        current = self.current_video_frame_ref
+        return self._submit_video_decode(
+            lambda decoder, handle: decoder.previous_frame(
+                current, cancelled=handle.is_cancelled))
+
+    def _schedule_video_prefetch(self, frame_ref):
+        snapshot = self.video_snapshot
+        if snapshot is None:
+            return
+        step = self._video_step_pts()
+        offsets = ((-1, -2, 1) if self._navigation_direction < 0
+                   else (1, 2, -1))
+        targets = tuple(VideoFrameRef(
+            snapshot.fingerprint, snapshot.stream_index,
+            frame_ref.pts + offset * step,
+            snapshot.time_base_num, snapshot.time_base_den)
+            for offset in offsets
+            if frame_ref.pts + offset * step >= int(snapshot.start_pts or 0))
+        source_path = snapshot.source_path
+        stream_index = snapshot.stream_index
+        generation = self._dataset_generation
+
+        def prefetch(handle):
+            decoder = VideoDecoderSession(
+                source_path, stream_index=stream_index,
+                cancelled=handle.is_cancelled)
+            results = []
+            try:
+                for target in targets:
+                    handle.check_cancelled()
+                    result = decoder.seek_pts(
+                        target.pts, cancelled=handle.is_cancelled)
+                    if result is not None:
+                        results.append(result)
+                return tuple(results)
+            finally:
+                decoder.close()
+
+        handle = self.task_coordinator.submit(
+            'background', prefetch, priority=JobPriority.BULK,
+            key='video-prefetch', latest=True, generation=generation)
+        self._video_prefetch_handle = handle
+        handle.result.connect(
+            lambda results, gen=generation:
+            self._on_video_prefetch_results(results, gen))
+
+    def _on_video_prefetch_results(self, results, generation):
+        snapshot = self.video_snapshot
+        if generation != self._dataset_generation or snapshot is None:
+            return
+        for result in results:
+            if result.frame_ref.fingerprint == snapshot.fingerprint:
+                self.frame_cache.put(result)
+
+    def play_pause_video(self, _value=False):
+        if self.document_kind != DocumentKind.VIDEO:
+            return
+        if self._video_playback_timer.isActive():
+            self.pause_video()
+            return
+        if self.current_video_frame_ref is None:
+            return
+        self._video_play_started_wall = time.monotonic()
+        self._video_play_started_seconds = \
+            self.current_video_frame_ref.seconds
+        self.video_timeline.set_playing(True)
+        self._video_playback_timer.start()
+
+    def pause_video(self):
+        active = (getattr(self, '_video_decode_in_flight', False)
+                  or (hasattr(self, '_video_playback_timer')
+                      and self._video_playback_timer.isActive()))
+        if hasattr(self, '_video_playback_timer'):
+            self._video_playback_timer.stop()
+        if hasattr(self, 'video_timeline'):
+            self.video_timeline.set_playing(False)
+        self._video_decode_in_flight = False
+        if active and hasattr(self, 'task_coordinator'):
+            self.task_coordinator.cancel_key('video-frame')
+            self._video_frame_request_id += 1
+
+    def _set_video_playback_speed(self, speed):
+        self._video_playback_speed = float(speed)
+        if (hasattr(self, '_video_playback_timer')
+                and self._video_playback_timer.isActive()
+                and self.current_video_frame_ref is not None):
+            self._video_play_started_wall = time.monotonic()
+            self._video_play_started_seconds = \
+                self.current_video_frame_ref.seconds
+
+    def _video_playback_tick(self):
+        snapshot = self.video_snapshot
+        if (snapshot is None or self.current_video_frame_ref is None
+                or self._video_decode_in_flight):
+            return
+        elapsed = time.monotonic() - self._video_play_started_wall
+        target_seconds = (self._video_play_started_seconds
+                          + elapsed * self._video_playback_speed)
+        end_pts = (int(snapshot.start_pts or 0)
+                   + int(snapshot.duration_pts or 0))
+        target_pts = int(round(
+            target_seconds * snapshot.time_base_den /
+            snapshot.time_base_num))
+        if snapshot.duration_pts is not None and target_pts >= end_pts:
+            self.pause_video()
+            return
+        self.request_video_frame(VideoFrameRef(
+            snapshot.fingerprint, snapshot.stream_index, target_pts,
+            snapshot.time_base_num, snapshot.time_base_den), playback=True)
 
     def request_open_file(self, file_path, skip_prompt=False):
         """Load a standalone file transactionally if it is outside the dataset."""
@@ -2698,9 +3043,13 @@ class MainWindow(QMainWindow, WindowMixin):
                       'shapes': len(result.shapes)})
 
     def request_next_image(self, _value=False):
+        if self.document_kind == DocumentKind.VIDEO:
+            return self.request_next_video_frame()
         return self._request_relative_image(1)
 
     def request_previous_image(self, _value=False):
+        if self.document_kind == DocumentKind.VIDEO:
+            return self.request_previous_video_frame()
         return self._request_relative_image(-1)
 
     def _request_relative_image(self, direction):
@@ -3679,6 +4028,18 @@ class MainWindow(QMainWindow, WindowMixin):
             if isinstance(filename, (tuple, list)):
                 filename = filename[0]
             self.request_open_file(filename)
+
+    def open_video_dialog(self, _value=False):
+        path = os.path.dirname(ustr(self.file_path)) if self.file_path else '.'
+        filters = (
+            'Video and LabelImg++ projects '
+            '(*.mp4 *.mov *.mkv *.avi *.labelimgpp.sqlite);;'
+            'All files (*)')
+        filename, _selected_filter = QFileDialog.getOpenFileName(
+            self, '%s - Choose Video or Project' % __appname__,
+            path, filters)
+        if filename:
+            self.request_open_video(ustr(filename))
 
     def request_save_file(self, _value=False, on_success=None,
                           annotation_base=None):

--- a/labelImgPlusPlus.py
+++ b/labelImgPlusPlus.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 import argparse
 import codecs
+from dataclasses import replace
 import os.path
 import platform
 import shutil
@@ -66,6 +67,7 @@ from libs.core.settings import Settings
 from libs.core.commands import (
     UndoStack, CreateShapeCommand, DeleteShapeCommand, MoveShapeCommand,
     EditLabelCommand, EditPolygonVerticesCommand, EditKeypointsCommand,
+    VideoModelCommand,
 )
 from libs.core.shortcut_config import ShortcutConfig
 from libs.core.sam_controller import SamController
@@ -82,7 +84,9 @@ from libs.core.profiling import (
 from libs.core.video_decoder import VIDEO_EXTENSIONS, VideoDecoderSession
 from libs.core.video_project import (
     checkpoint_project, default_project_path, save_project_as,
+    save_project_delta,
 )
+from libs.core.video_model import VideoProjectModel
 from libs.core.video_session import is_video_project, prepare_video_open
 from libs.core.video_types import DocumentKind, VideoFrameRef
 from libs.integrations import segmentation
@@ -206,8 +210,13 @@ class MainWindow(QMainWindow, WindowMixin):
         self.video_observations = ()
         self.video_frame_states = ()
         self.video_classes = ()
+        self.video_model = None
+        self._selected_video_track_id = None
         self._video_open_request_id = 0
         self._video_save_handle = None
+        self._video_save_active = False
+        self._video_save_queued = False
+        self._video_save_callbacks = []
         self._video_frame_request_id = 0
         self._video_decode_in_flight = False
         self._video_prefetch_handle = None
@@ -306,8 +315,11 @@ class MainWindow(QMainWindow, WindowMixin):
         self.label_tab_widget = QTabWidget()
         self.rect_label_list = QListWidget()
         self.poly_label_list = QListWidget()
+        self.track_list_widget = QListWidget()
         self.label_tab_widget.addTab(self.rect_label_list, 'Rectangles (0)')
         self.label_tab_widget.addTab(self.poly_label_list, 'Polygons (0)')
+        self.label_tab_widget.addTab(self.track_list_widget, 'Tracks (0)')
+        self.label_tab_widget.setTabEnabled(2, False)
 
         # Keep self.label_list as alias to rect list for backward compatibility
         self.label_list = self.rect_label_list
@@ -321,6 +333,10 @@ class MainWindow(QMainWindow, WindowMixin):
             lw.itemSelectionChanged.connect(self.label_selection_changed)
             lw.itemDoubleClicked.connect(self.edit_label)
             lw.itemChanged.connect(self.label_item_changed)
+        self.track_list_widget.itemSelectionChanged.connect(
+            self._video_track_selection_changed)
+        self.track_list_widget.itemChanged.connect(
+            self._video_track_item_changed)
 
         list_layout.addWidget(self.label_tab_widget)
 
@@ -525,6 +541,15 @@ class MainWindow(QMainWindow, WindowMixin):
             self.shortcut_config.get('keypoint_mode'),
             'verify',
             get_str('addKeypointsDetail'),
+            enabled=False)
+        video_add_keyframe = action(
+            'Add Track Keyframe', self.add_track_keyframe,
+            self.shortcut_config.get('video_add_keyframe'), 'verify',
+            'Promote the selected track at the current PTS to a manual anchor',
+            enabled=False)
+        video_delete_track = action(
+            'Delete Track…', self.delete_selected_track,
+            None, 'delete', 'Delete the selected track on every frame',
             enabled=False)
         sam_mode_action = action(
             'SAM Segment',
@@ -745,12 +770,15 @@ class MainWindow(QMainWindow, WindowMixin):
             'light_org': light_org,
             'edit_label': edit,
             'keypoint_mode': keypoint_mode_action,
+            'video_add_keyframe': video_add_keyframe,
         }
 
         # Store actions for further handling.
         self.actions = Struct(save=save, save_format=save_format, saveAs=save_as, open=open, openVideo=open_video, close=close, resetAll=reset_all, deleteImg=delete_image,
                               lineColor=color1, create=create, create_polygon=create_polygon,
                               keypoint_mode=keypoint_mode_action,
+                              videoAddKeyframe=video_add_keyframe,
+                              videoDeleteTrack=video_delete_track,
                               sam_mode=sam_mode_action,
                               delete=delete, edit=edit, copy=copy,
                               copyToClipboard=copy_to_clipboard, pasteFromClipboard=paste_from_clipboard,
@@ -771,6 +799,7 @@ class MainWindow(QMainWindow, WindowMixin):
                               editMenu=(undo, redo, None, edit, copy, copy_to_clipboard,
                                         paste_from_clipboard, copy_all_to_clipboard, delete,
                                         None, keypoint_mode_action,
+                                        video_add_keyframe,
                                         None, color1, self.draw_squares_option),
                               beginnerContext=(create, create_polygon, edit, copy, copy_to_clipboard, paste_from_clipboard, delete),
                               advancedContext=(create_mode, edit_mode, edit, copy, copy_to_clipboard,
@@ -918,7 +947,8 @@ class MainWindow(QMainWindow, WindowMixin):
             None, 'file', get_str('splitDatasetDetail'))
         add_actions(self.menus.tools, (
             check_labels, batch_verify_action, split_dataset_action,
-            None, video_play_pause,
+            None, video_play_pause, video_add_keyframe,
+            video_delete_track,
             None, sam_mode_action, sam_settings_action))
 
         # Custom context menu for the canvas widget:
@@ -1235,6 +1265,11 @@ class MainWindow(QMainWindow, WindowMixin):
     def set_dirty(self):
         if self.document_kind == DocumentKind.VIDEO:
             self.pause_video()
+            self.dirty = True
+            self.actions.save.setEnabled(True)
+            self.update_save_status(saved=False)
+            self.update_box_count()
+            return
         self._document_revision += 1
         self.dirty = True
         self.actions.save.setEnabled(True)
@@ -1246,6 +1281,13 @@ class MainWindow(QMainWindow, WindowMixin):
         self.actions.save.setEnabled(False)
         self.actions.create.setEnabled(True)
         self.actions.create_polygon.setEnabled(True)
+        if (self.document_kind == DocumentKind.VIDEO
+                and self.video_snapshot is not None
+                and self.video_snapshot.read_only):
+            self.actions.create.setEnabled(False)
+            self.actions.create_polygon.setEnabled(False)
+            self.actions.createMode.setEnabled(False)
+            self.actions.editMode.setEnabled(False)
         self.update_save_status(saved=True)
 
     def toggle_actions(self, value=True):
@@ -1322,6 +1364,7 @@ class MainWindow(QMainWindow, WindowMixin):
         self.shapes_to_items.clear()
         self.rect_label_list.clear()
         self.poly_label_list.clear()
+        self.track_list_widget.clear()
         self._update_tab_counts()
         self.file_path = None
         self.image_data = None
@@ -1348,10 +1391,18 @@ class MainWindow(QMainWindow, WindowMixin):
             self.file_dock.setVisible(kind != DocumentKind.VIDEO)
         if hasattr(self, 'timeline_dock'):
             self.timeline_dock.setVisible(kind == DocumentKind.VIDEO)
+        if hasattr(self, 'label_tab_widget'):
+            self.label_tab_widget.setTabEnabled(
+                2, kind == DocumentKind.VIDEO)
+            if kind != DocumentKind.VIDEO \
+                    and self.label_tab_widget.currentIndex() == 2:
+                self.label_tab_widget.setCurrentIndex(0)
         if hasattr(self, 'actions') and hasattr(
                 self.actions, 'videoPlayPause'):
             self.actions.videoPlayPause.setEnabled(
                 kind == DocumentKind.VIDEO)
+            self.actions.videoAddKeyframe.setEnabled(False)
+            self.actions.videoDeleteTrack.setEnabled(False)
 
     def _close_video_decoder(self):
         if hasattr(self, '_video_playback_timer'):
@@ -1360,6 +1411,11 @@ class MainWindow(QMainWindow, WindowMixin):
         self.video_decoder = None
         snapshot = getattr(self, 'video_snapshot', None)
         self.video_snapshot = None
+        self.video_model = None
+        self._selected_video_track_id = None
+        self._video_save_active = False
+        self._video_save_queued = False
+        self._video_save_callbacks = []
         self.current_video_frame_ref = None
         if hasattr(self, 'video_timeline'):
             self.video_timeline.set_session(None)
@@ -1546,6 +1602,15 @@ class MainWindow(QMainWindow, WindowMixin):
 
     def _on_polygon_vertices_edited(self, shape, old_points):
         """Capture polygon vertex edits for undo support."""
+        if self.document_kind == DocumentKind.VIDEO:
+            before = self.video_model.snapshot_state()
+            self._store_video_shape_as_manual(shape)
+            after = self.video_model.snapshot_state()
+            self.undo_stack.push(VideoModelCommand(
+                self, before, after, 'Edit video polygon keyframe'))
+            self._on_video_model_mutation()
+            self._materialize_video_frame(self.current_video_frame_ref.pts)
+            return
         cmd = EditPolygonVerticesCommand(
             self, shape, old_points, list(shape.points))
         self.undo_stack.push(cmd)
@@ -1553,12 +1618,30 @@ class MainWindow(QMainWindow, WindowMixin):
 
     def _on_shape_move_finished(self, shape, old_points):
         """Capture whole-shape moves / rectangle resizes for undo support."""
+        if self.document_kind == DocumentKind.VIDEO:
+            before = self.video_model.snapshot_state()
+            self._store_video_shape_as_manual(shape)
+            after = self.video_model.snapshot_state()
+            self.undo_stack.push(VideoModelCommand(
+                self, before, after, 'Edit video track keyframe'))
+            self._on_video_model_mutation()
+            self._materialize_video_frame(self.current_video_frame_ref.pts)
+            return
         cmd = MoveShapeCommand(self, shape, old_points, list(shape.points))
         self.undo_stack.push(cmd)
         self.set_dirty()
 
     def _on_keypoints_edited(self, shape, old_keypoints):
         """Capture keypoint mutations for undo support."""
+        if self.document_kind == DocumentKind.VIDEO:
+            before = self.video_model.snapshot_state()
+            self._store_video_shape_as_manual(shape)
+            after = self.video_model.snapshot_state()
+            self.undo_stack.push(VideoModelCommand(
+                self, before, after, 'Edit video keypoints'))
+            self._on_video_model_mutation()
+            self._materialize_video_frame(self.current_video_frame_ref.pts)
+            return
         cmd = EditKeypointsCommand(
             self, shape, old_keypoints,
             list(shape.keypoints) if shape.keypoints else None)
@@ -1640,7 +1723,8 @@ class MainWindow(QMainWindow, WindowMixin):
         if text is not None:
             item.setText(text)
             item.setBackground(generate_color_by_text(text))
-            self.set_dirty()
+            if self.document_kind != DocumentKind.VIDEO:
+                self.set_dirty()
             self.update_combo_box()
 
     # Tzutalin 20160906 : Add file list and dock to move faster
@@ -1844,6 +1928,18 @@ class MainWindow(QMainWindow, WindowMixin):
 
         # Checked and Update
         if difficult != shape.difficult:
+            if self.document_kind == DocumentKind.VIDEO:
+                track_id = getattr(shape, 'video_track_id', None)
+                before = self.video_model.snapshot_state()
+                self.video_model.update_track(
+                    track_id, difficult=difficult)
+                after = self.video_model.snapshot_state()
+                self.undo_stack.push(VideoModelCommand(
+                    self, before, after, 'Change video track difficulty'))
+                self._on_video_model_mutation()
+                self._materialize_video_frame(
+                    self.current_video_frame_ref.pts)
+                return
             shape.difficult = difficult
             self.set_dirty()
         else:  # User probably changed item visibility
@@ -1856,6 +1952,9 @@ class MainWindow(QMainWindow, WindowMixin):
         else:
             shape = self.canvas.selected_shape
             if shape:
+                if self.document_kind == DocumentKind.VIDEO:
+                    self._selected_video_track_id = getattr(
+                        shape, 'video_track_id', None)
                 self.shapes_to_items[shape].setSelected(True)
             else:
                 self.rect_label_list.clearSelection()
@@ -2015,6 +2114,9 @@ class MainWindow(QMainWindow, WindowMixin):
         poly_count = self.poly_label_list.count()
         self.label_tab_widget.setTabText(0, f'Rectangles ({rect_count})')
         self.label_tab_widget.setTabText(1, f'Polygons ({poly_count})')
+        if hasattr(self, 'track_list_widget'):
+            self.label_tab_widget.setTabText(
+                2, f'Tracks ({self.track_list_widget.count()})')
 
     def _check_polygon_degradation(self, format_name):
         """Warn the user if polygons will be saved as bounding boxes.
@@ -2116,9 +2218,21 @@ class MainWindow(QMainWindow, WindowMixin):
         shape = self.canvas.copy_selected_shape()
         self.add_label(shape)
 
-        # Push command for undo support (shape already created, so just push)
-        cmd = CreateShapeCommand(self, shape)
-        self.undo_stack.push(cmd)
+        if self.document_kind == DocumentKind.VIDEO:
+            before = self.video_model.snapshot_state()
+            if hasattr(shape, 'video_track_id'):
+                del shape.video_track_id
+            track_id = self._store_video_shape_as_manual(shape)
+            self._selected_video_track_id = track_id
+            after = self.video_model.snapshot_state()
+            self.undo_stack.push(VideoModelCommand(
+                self, before, after, 'Duplicate video track'))
+            self._on_video_model_mutation()
+            self._materialize_video_frame(self.current_video_frame_ref.pts)
+        else:
+            # Push command for undo support (shape already created).
+            cmd = CreateShapeCommand(self, shape)
+            self.undo_stack.push(cmd)
 
         # fix copy and delete
         self.shape_selection_changed(True)
@@ -2148,18 +2262,29 @@ class MainWindow(QMainWindow, WindowMixin):
         if not self.canvas.pixmap or self.canvas.pixmap.isNull():
             return
 
+        before = (self.video_model.snapshot_state()
+                  if self.document_kind == DocumentKind.VIDEO else None)
         for clipboard_shape in self.clipboard_shapes:
             # Create a new copy for each paste
             shape = clipboard_shape.copy()
             # Add shape to canvas
             self.canvas.shapes.append(shape)
             self.add_label(shape)
-            # Push command for undo support
-            cmd = CreateShapeCommand(self, shape)
-            self.undo_stack.push(cmd)
+            if self.document_kind == DocumentKind.VIDEO:
+                self._store_video_shape_as_manual(shape)
+            else:
+                cmd = CreateShapeCommand(self, shape)
+                self.undo_stack.push(cmd)
 
         self.canvas.rebuild_spatial_index()
-        self.set_dirty()
+        if self.document_kind == DocumentKind.VIDEO:
+            after = self.video_model.snapshot_state()
+            self.undo_stack.push(VideoModelCommand(
+                self, before, after, 'Paste video tracks'))
+            self._on_video_model_mutation()
+            self._materialize_video_frame(self.current_video_frame_ref.pts)
+        else:
+            self.set_dirty()
         self.canvas.update()
         self.update_box_count()
         self.statusBar().showMessage(f'Pasted {len(self.clipboard_shapes)} annotations', 3000)
@@ -2198,6 +2323,19 @@ class MainWindow(QMainWindow, WindowMixin):
         shape = self.items_to_shapes[item]
         label = item.text()
         if label != shape.label:
+            if self.document_kind == DocumentKind.VIDEO:
+                track_id = getattr(shape, 'video_track_id', None)
+                if track_id is None:
+                    return
+                before = self.video_model.snapshot_state()
+                self.video_model.rename_track(track_id, label)
+                after = self.video_model.snapshot_state()
+                self.undo_stack.push(VideoModelCommand(
+                    self, before, after, 'Rename video track'))
+                self._on_video_model_mutation()
+                self._materialize_video_frame(
+                    self.current_video_frame_ref.pts)
+                return
             old_label = shape.label
             shape.label = item.text()
             shape.line_color = generate_color_by_text(shape.label)
@@ -2240,9 +2378,20 @@ class MainWindow(QMainWindow, WindowMixin):
             shape = self.canvas.set_last_label(text, generate_color)
             self.add_label(shape)
 
-            # Push command for undo support (shape already created, so just push)
-            cmd = CreateShapeCommand(self, shape)
-            self.undo_stack.push(cmd)
+            if self.document_kind == DocumentKind.VIDEO:
+                before = self.video_model.snapshot_state()
+                track_id = self._store_video_shape_as_manual(shape)
+                self._selected_video_track_id = track_id
+                after = self.video_model.snapshot_state()
+                self.undo_stack.push(VideoModelCommand(
+                    self, before, after, 'Create video track'))
+                self._on_video_model_mutation()
+                self._materialize_video_frame(
+                    self.current_video_frame_ref.pts)
+            else:
+                # Shape already exists, so record without re-executing it.
+                cmd = CreateShapeCommand(self, shape)
+                self.undo_stack.push(cmd)
 
             if self.beginner():  # Switch to edit mode.
                 self.canvas.set_editing(True)
@@ -2251,7 +2400,8 @@ class MainWindow(QMainWindow, WindowMixin):
             else:
                 self.actions.editMode.setEnabled(True)
                 self.actions.create_polygon.setEnabled(True)
-            self.set_dirty()
+            if self.document_kind != DocumentKind.VIDEO:
+                self.set_dirty()
             self._update_current_image_stats()
 
             if text not in self.label_hist:
@@ -2453,6 +2603,10 @@ class MainWindow(QMainWindow, WindowMixin):
         self.video_observations = prepared.observations
         self.video_frame_states = prepared.frame_states
         self.video_classes = prepared.classes
+        self.video_model = VideoProjectModel(
+            snapshot.revision, tracks=prepared.tracks,
+            observations=prepared.observations,
+            frame_states=prepared.frame_states, classes=prepared.classes)
         self._document_revision = snapshot.revision
         self.m_img_list = []
         self._path_to_idx = {}
@@ -2475,6 +2629,7 @@ class MainWindow(QMainWindow, WindowMixin):
         self.frame_cache.put(first)
         self.video_timeline.set_session(snapshot)
         self._refresh_video_timeline_markers()
+        self._materialize_video_frame(first.frame_ref.pts)
         self.set_clean()
         self.canvas.setEnabled(True)
         self.adjust_scale(initial=True)
@@ -2515,34 +2670,79 @@ class MainWindow(QMainWindow, WindowMixin):
         if (self.document_kind != DocumentKind.VIDEO or snapshot is None
                 or snapshot.read_only or not snapshot.project_path):
             return None
-        revision = self._document_revision
-        project_path = snapshot.project_path
+        if callable(on_success):
+            self._video_save_callbacks.append(on_success)
+        if self._video_save_active:
+            self._video_save_queued = True
+            return self._video_save_handle
+        model = self.video_model
+        if model is None or not model.dirty:
+            try:
+                checkpoint_project(snapshot.project_path)
+            except Exception as exc:
+                self.status(
+                    'Error saving video project: %s' % exc, delay=10000)
+                return None
+            self.set_clean()
+            callbacks, self._video_save_callbacks = \
+                self._video_save_callbacks, []
+            for callback in callbacks:
+                callback()
+            return None
+        request = model.build_save_request(snapshot.project_path)
+        generation = self._dataset_generation
 
         def save(handle):
             handle.check_cancelled()
-            checkpoint_project(project_path)
-            return project_path
+            return save_project_delta(
+                request, cancelled=handle.is_cancelled,
+                begin_commit=handle.begin_non_cancellable)
 
         handle = self.task_coordinator.submit(
             'background', save, priority=JobPriority.IMAGE_LOAD,
-            key='video-project-save', latest=True,
-            generation=self._dataset_generation)
+            generation=generation)
         self._video_save_handle = handle
+        self._video_save_active = True
+        self._video_save_queued = False
         handle.result.connect(
-            lambda saved, rev=revision, callback=on_success:
-            self._on_video_save_result(saved, rev, callback))
+            lambda revision, req=request, gen=generation:
+            self._on_video_save_result(revision, req, gen))
         handle.error.connect(
-            lambda message: self.status(
-                'Error saving video project: ' + message, delay=10000))
+            self._on_video_save_error)
+        handle.finished.connect(self._on_video_save_finished)
         return handle
 
-    def _on_video_save_result(self, path, revision, on_success=None):
-        if path and self._document_revision == revision:
+    def _on_video_save_result(self, revision, request, generation):
+        if (revision is None or generation != self._dataset_generation
+                or self.video_model is None
+                or self.video_snapshot is None
+                or request.project_path != self.video_snapshot.project_path):
+            return
+        self.video_model.mark_saved(revision)
+        self.video_snapshot = replace(
+            self.video_snapshot, revision=revision)
+        if not self.video_model.dirty:
             self.set_clean()
-        if path:
-            self.status('Saved video project to %s' % path)
-        if path and callable(on_success):
-            on_success()
+        else:
+            self._video_save_queued = True
+        self.status('Saved video project to %s' % request.project_path)
+
+    def _on_video_save_error(self, message):
+        self._video_save_queued = False
+        self.status('Error saving video project: ' + message, delay=10000)
+
+    def _on_video_save_finished(self):
+        self._video_save_active = False
+        self._video_save_handle = None
+        if (self.video_model is not None and self.video_model.dirty
+                and self._video_save_queued):
+            self.request_save_video_project()
+            return
+        if self.video_model is not None and not self.video_model.dirty:
+            callbacks, self._video_save_callbacks = \
+                self._video_save_callbacks, []
+            for callback in callbacks:
+                callback()
 
     def save_video_project(self):
         snapshot = self.video_snapshot
@@ -2550,6 +2750,13 @@ class MainWindow(QMainWindow, WindowMixin):
                 or snapshot.read_only or not snapshot.project_path):
             return False
         try:
+            if self.video_model is not None and self.video_model.dirty:
+                request = self.video_model.build_save_request(
+                    snapshot.project_path)
+                revision = save_project_delta(request)
+                self.video_model.mark_saved(revision)
+                self.video_snapshot = replace(
+                    self.video_snapshot, revision=revision)
             checkpoint_project(snapshot.project_path)
         except Exception as exc:
             self.status('Error saving video project: %s' % exc, delay=10000)
@@ -2580,6 +2787,208 @@ class MainWindow(QMainWindow, WindowMixin):
         self.video_timeline.set_markers(
             spans=spans, accepted=accepted, pending=pending,
             verified=verified)
+
+    def _sync_video_model_views(self):
+        model = self.video_model
+        if model is None:
+            return
+        self.video_tracks = tuple(model.tracks.values())
+        self.video_observations = tuple(model.observations.values())
+        self.video_frame_states = tuple(model.frame_states.values())
+        self.video_classes = tuple(model.classes)
+
+    def _on_video_model_mutation(self):
+        self.pause_video()
+        self._sync_video_model_views()
+        self._document_revision = self.video_model.revision
+        self.dirty = self.video_model.dirty
+        self.actions.save.setEnabled(self.dirty)
+        self.update_save_status(saved=not self.dirty)
+        self._refresh_video_timeline_markers()
+        self._refresh_video_track_list()
+        self.update_box_count()
+
+    def _shape_geometry(self, shape):
+        inverse = (1.0 / self._image_scale_factor
+                   if self._image_scale_factor else 1.0)
+        points = [(point.x() * inverse, point.y() * inverse)
+                  for point in shape.points]
+        if shape.shape_type == ShapeType.RECTANGLE:
+            xs = [point[0] for point in points]
+            ys = [point[1] for point in points]
+            geometry = [min(xs), min(ys), max(xs), max(ys)]
+        else:
+            geometry = [[point[0], point[1]] for point in points]
+        keypoints = None
+        if shape.keypoints is not None:
+            keypoints = [
+                ([item[0] * inverse, item[1] * inverse, item[2]]
+                 if item is not None else None)
+                for item in shape.keypoints]
+        return geometry, keypoints
+
+    def _store_video_shape_as_manual(self, shape):
+        track_id = getattr(shape, 'video_track_id', None)
+        if track_id is None:
+            track = self.video_model.create_track(
+                shape.label, shape.shape_type.value,
+                shape.line_color.getRgb(), difficult=shape.difficult)
+            track_id = track.track_id
+            shape.video_track_id = track_id
+        geometry, keypoints = self._shape_geometry(shape)
+        self.video_model.upsert_manual(
+            track_id, self.current_video_frame_ref.pts,
+            geometry, keypoints=keypoints)
+        return track_id
+
+    def _shape_for_materialized(self, materialized):
+        track = materialized.track
+        observation = materialized.observation
+        shape_type = (ShapeType.POLYGON if track.shape_type == 'polygon'
+                      else ShapeType.RECTANGLE)
+        shape = Shape(
+            label=track.label, line_color=QColor(*track.color),
+            difficult=track.difficult, shape_type=shape_type)
+        scale = self._image_scale_factor
+        geometry = observation.geometry
+        if shape_type == ShapeType.RECTANGLE:
+            xmin, ymin, xmax, ymax = geometry
+            points = ((xmin, ymin), (xmax, ymin),
+                      (xmax, ymax), (xmin, ymax))
+        else:
+            points = geometry
+        for x, y in points:
+            shape.add_point(QPointF(x * scale, y * scale))
+        shape.close()
+        if observation.keypoints is not None:
+            shape.keypoints = [
+                ([item[0] * scale, item[1] * scale, item[2]]
+                 if item is not None else None)
+                for item in observation.keypoints]
+        shape.video_track_id = track.track_id
+        shape.video_render_state = materialized.render_state
+        return shape
+
+    def _materialize_video_frame(self, pts):
+        model = self.video_model
+        if model is None:
+            return
+        selected = self._selected_video_track_id
+        shapes = [self._shape_for_materialized(item)
+                  for item in model.materialize(int(pts))]
+        for widget in (self.rect_label_list, self.poly_label_list):
+            widget.blockSignals(True)
+            widget.clear()
+        self.items_to_shapes.clear()
+        self.shapes_to_items.clear()
+        self.canvas.load_shapes(shapes)
+        for shape in shapes:
+            self.add_label(shape, refresh=False)
+        for widget in (self.rect_label_list, self.poly_label_list):
+            widget.blockSignals(False)
+        self._update_tab_counts()
+        self.update_combo_box()
+        if selected:
+            match = next((shape for shape in shapes
+                          if shape.video_track_id == selected), None)
+            if match is not None:
+                self.canvas.select_shape(match)
+        self._refresh_video_track_list()
+        self.update_box_count()
+
+    def _refresh_video_track_list(self):
+        model = self.video_model
+        if model is None or not hasattr(self, 'track_list_widget'):
+            return
+        selected = self._selected_video_track_id
+        self.track_list_widget.blockSignals(True)
+        self.track_list_widget.clear()
+        for track in model.tracks.values():
+            observations = [
+                item for item in model.observations.values()
+                if item.track_id == track.track_id]
+            pending = sum(item.review_state == 'pending'
+                          for item in observations)
+            if observations:
+                span = '%s–%s' % (
+                    min(item.pts for item in observations),
+                    max(item.pts for item in observations))
+            else:
+                span = 'empty'
+            text = '%s  [%s]  · %s pending' % (
+                track.label, span, pending)
+            item = HashableQListWidgetItem(text)
+            item.setData(Qt.UserRole, track.track_id)
+            item.setFlags((item.flags() | Qt.ItemIsUserCheckable)
+                          & ~Qt.ItemIsEditable)
+            item.setCheckState(Qt.Checked)
+            item.setForeground(QColor(*track.color))
+            self.track_list_widget.addItem(item)
+            if track.track_id == selected:
+                item.setSelected(True)
+                self.track_list_widget.setCurrentItem(item)
+        self.track_list_widget.blockSignals(False)
+        self._update_tab_counts()
+
+    def _video_track_selection_changed(self):
+        items = self.track_list_widget.selectedItems()
+        if not items:
+            return
+        track_id = items[0].data(Qt.UserRole)
+        self._selected_video_track_id = track_id
+        self.actions.videoAddKeyframe.setEnabled(True)
+        self.actions.videoDeleteTrack.setEnabled(True)
+        shape = next((item for item in self.canvas.shapes
+                      if getattr(item, 'video_track_id', None) == track_id),
+                     None)
+        if shape is not None:
+            self.canvas.select_shape(shape)
+
+    def _video_track_item_changed(self, item):
+        track_id = item.data(Qt.UserRole)
+        visible = item.checkState() == Qt.Checked
+        for shape in self.canvas.shapes:
+            if getattr(shape, 'video_track_id', None) == track_id:
+                self.canvas.set_shape_visible(shape, visible)
+
+    def add_track_keyframe(self):
+        model = self.video_model
+        track_id = self._selected_video_track_id
+        if model is None or track_id is None \
+                or self.current_video_frame_ref is None:
+            return
+        before = model.snapshot_state()
+        observation = model.promote_to_manual(
+            track_id, self.current_video_frame_ref.pts)
+        if observation is None:
+            self.status('Selected track is not present on this frame')
+            return
+        after = model.snapshot_state()
+        self.undo_stack.push(VideoModelCommand(
+            self, before, after, 'Add video track keyframe'))
+        self._on_video_model_mutation()
+        self._materialize_video_frame(self.current_video_frame_ref.pts)
+
+    def delete_selected_track(self):
+        model = self.video_model
+        track_id = self._selected_video_track_id
+        if model is None or track_id not in model.tracks:
+            return
+        track = model.tracks[track_id]
+        answer = QMessageBox.question(
+            self, 'Delete Track',
+            'Delete track "%s" and all of its observations?' % track.label,
+            QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
+        if answer != QMessageBox.Yes:
+            return
+        before = model.snapshot_state()
+        model.delete_track(track_id)
+        after = model.snapshot_state()
+        self._selected_video_track_id = None
+        self.undo_stack.push(VideoModelCommand(
+            self, before, after, 'Delete video track'))
+        self._on_video_model_mutation()
+        self._materialize_video_frame(self.current_video_frame_ref.pts)
 
     def _video_step_pts(self):
         snapshot = self.video_snapshot
@@ -3930,6 +4339,15 @@ class MainWindow(QMainWindow, WindowMixin):
             self._loading_veil.hide()
 
     def verify_image(self, _value=False):
+        if self.document_kind == DocumentKind.VIDEO:
+            if self.current_video_frame_ref is None:
+                return
+            self.video_model.set_frame_verified(
+                self.current_video_frame_ref.pts,
+                not bool(self.canvas.verified))
+            self.canvas.verified = not bool(self.canvas.verified)
+            self._on_video_model_mutation()
+            return self.save_video_project()
         # Proceeding next image without dialog if having any label
         if self.file_path is not None:
             try:
@@ -3951,6 +4369,18 @@ class MainWindow(QMainWindow, WindowMixin):
 
     def request_verify_image(self, _value=False):
         """Toggle verification and persist it through the async save lane."""
+        if self.document_kind == DocumentKind.VIDEO:
+            if self.current_video_frame_ref is None:
+                return None
+            self.video_model.set_frame_verified(
+                self.current_video_frame_ref.pts,
+                not bool(self.canvas.verified))
+            self.canvas.verified = not bool(self.canvas.verified)
+            if self.lock_on_verify_option.isChecked():
+                self.canvas.locked = self.canvas.verified
+            self._on_video_model_mutation()
+            self.paint_canvas()
+            return self.request_save_video_project()
         if self.file_path is None:
             return None
         if self.label_file is None:
@@ -4200,6 +4630,8 @@ class MainWindow(QMainWindow, WindowMixin):
             target = self._video_project_save_dialog()
             if not target:
                 return False
+            if self.video_model.dirty and not self.save_video_project():
+                return False
             try:
                 save_project_as(self.video_snapshot.project_path, target)
             except Exception as exc:
@@ -4215,27 +4647,35 @@ class MainWindow(QMainWindow, WindowMixin):
             target = self._video_project_save_dialog()
             if not target:
                 return None
-            source = self.video_snapshot.project_path
+            if self.video_model.dirty:
+                return self.request_save_video_project(
+                    on_success=lambda: self._request_video_project_backup(
+                        target))
+            return self._request_video_project_backup(target)
 
-            def save_as(handle):
-                handle.check_cancelled()
-                return save_project_as(source, target)
-
-            handle = self.task_coordinator.submit(
-                'background', save_as, priority=JobPriority.IMAGE_LOAD,
-                key='video-project-save-as', latest=True,
-                generation=self._dataset_generation)
-            handle.result.connect(
-                lambda path: self.status('Saved video project to %s' % path))
-            handle.error.connect(
-                lambda message: self.status(
-                    'Error saving video project: ' + message))
-            return handle
         assert not self.image.isNull(), "cannot save empty image"
         annotation_base = self.save_file_dialog()
         if not annotation_base:
             return None
         return self.request_save_file(annotation_base=annotation_base)
+
+    def _request_video_project_backup(self, target):
+        source = self.video_snapshot.project_path
+
+        def save_as(handle):
+            handle.check_cancelled()
+            return save_project_as(source, target)
+
+        handle = self.task_coordinator.submit(
+            'background', save_as, priority=JobPriority.IMAGE_LOAD,
+            key='video-project-save-as', latest=True,
+            generation=self._dataset_generation)
+        handle.result.connect(
+            lambda path: self.status('Saved video project to %s' % path))
+        handle.error.connect(
+            lambda message: self.status(
+                'Error saving video project: ' + message))
+        return handle
 
     def _video_project_save_dialog(self):
         snapshot = self.video_snapshot
@@ -4403,6 +4843,19 @@ class MainWindow(QMainWindow, WindowMixin):
         if self.canvas.selected_shape is None:
             return
         shape = self.canvas.selected_shape
+        if self.document_kind == DocumentKind.VIDEO:
+            track_id = getattr(shape, 'video_track_id', None)
+            if track_id is None:
+                return
+            before = self.video_model.snapshot_state()
+            self.video_model.delete_occurrence(
+                track_id, self.current_video_frame_ref.pts)
+            after = self.video_model.snapshot_state()
+            self.undo_stack.push(VideoModelCommand(
+                self, before, after, 'Delete video occurrence'))
+            self._on_video_model_mutation()
+            self._materialize_video_frame(self.current_video_frame_ref.pts)
+            return
         index = self.canvas.shapes.index(shape) if shape in self.canvas.shapes else None
 
         # Create and push command (command handles the actual deletion)
@@ -4452,6 +4905,18 @@ class MainWindow(QMainWindow, WindowMixin):
         color = self.color_dialog.getColor(self.line_color, u'Choose Line Color',
                                            default=DEFAULT_LINE_COLOR)
         if color:
+            if self.document_kind == DocumentKind.VIDEO:
+                shape = self.canvas.selected_shape
+                track_id = getattr(shape, 'video_track_id', None)
+                before = self.video_model.snapshot_state()
+                self.video_model.update_track(track_id, color=color.getRgb())
+                after = self.video_model.snapshot_state()
+                self.undo_stack.push(VideoModelCommand(
+                    self, before, after, 'Change video track color'))
+                self._on_video_model_mutation()
+                self._materialize_video_frame(
+                    self.current_video_frame_ref.pts)
+                return
             self.canvas.selected_shape.line_color = color
             self.canvas.update()
             self.set_dirty()

--- a/libs/core/commands.py
+++ b/libs/core/commands.py
@@ -43,6 +43,32 @@ class Command(ABC):
         return "Command"
 
 
+class VideoModelCommand(Command):
+    """Undo a video-domain mutation by restoring immutable model states."""
+
+    def __init__(self, main_window, before, after, description):
+        self.main_window = main_window
+        self.before = before
+        self.after = after
+        self._description = description
+
+    def _restore(self, state):
+        self.main_window.video_model.restore_state(state)
+        self.main_window._on_video_model_mutation()
+        pts = self.main_window.current_video_frame_ref.pts
+        self.main_window._materialize_video_frame(pts)
+
+    def execute(self):
+        self._restore(self.after)
+
+    def undo(self):
+        self._restore(self.before)
+
+    @property
+    def description(self):
+        return self._description
+
+
 class CreateShapeCommand(Command):
     """Command for creating a new shape.
 

--- a/libs/core/image_pipeline.py
+++ b/libs/core/image_pipeline.py
@@ -267,3 +267,20 @@ class FrameCache:
     def clear(self):
         self._entries.clear()
         self._bytes = 0
+
+    def video_neighbor(self, frame_ref, direction):
+        """Return the closest cached PTS before/after *frame_ref*."""
+        direction = 1 if direction > 0 else -1
+        candidates = []
+        for entry in self._entries.values():
+            other = getattr(entry, 'frame_ref', None)
+            if other is None:
+                continue
+            if (other.fingerprint != frame_ref.fingerprint
+                    or other.stream_index != frame_ref.stream_index):
+                continue
+            delta = other.pts - frame_ref.pts
+            if delta * direction > 0:
+                candidates.append((abs(delta), entry))
+        return min(candidates, key=lambda item: item[0])[1] \
+            if candidates else None

--- a/libs/core/image_pipeline.py
+++ b/libs/core/image_pipeline.py
@@ -186,7 +186,7 @@ def load_image_result(path, resolver=None, image_list=None, save_dir=None,
 
 
 class FrameCache:
-    """Fingerprint-aware LRU capped by both frame count and image bytes."""
+    """Image/video LRU capped by both frame count and detached image bytes."""
 
     def __init__(self, max_images=5, max_bytes=128 * 1024 * 1024):
         self.max_images = max(1, int(max_images))
@@ -201,11 +201,29 @@ class FrameCache:
     def __len__(self):
         return len(self._entries)
 
-    def get(self, path):
-        path = os.path.abspath(os.fspath(path))
-        entry = self._entries.get(path)
+    @staticmethod
+    def _key(value):
+        cache_key = getattr(value, 'cache_key', None)
+        if cache_key is not None:
+            return cache_key
+        if hasattr(value, 'path'):
+            return os.path.abspath(os.fspath(value.path))
+        if isinstance(value, tuple) and value[:1] == ('video',):
+            return value
+        return os.path.abspath(os.fspath(value))
+
+    def get(self, key):
+        key = self._key(key)
+        entry = self._entries.get(key)
         if entry is None:
             return None
+        # Video cache entries are session-scoped and cleared on document
+        # replacement. Re-hashing multi-gigabyte media on every lookup would
+        # defeat interactive seeks.
+        if hasattr(entry, 'frame_ref'):
+            self._entries.move_to_end(key)
+            return entry
+        path = entry.path
         try:
             if entry.fingerprint != file_fingerprint(path):
                 self.remove(path)
@@ -226,22 +244,23 @@ class FrameCache:
         except OSError:
             self.remove(path)
             return None
-        self._entries.move_to_end(path)
+        self._entries.move_to_end(key)
         return entry
 
     def put(self, result):
-        self.remove(result.path)
+        key = self._key(result)
+        self.remove(key)
         if result.byte_size > self.max_bytes:
             return
-        self._entries[result.path] = result
+        self._entries[key] = result
         self._bytes += result.byte_size
         while (len(self._entries) > self.max_images
                or self._bytes > self.max_bytes):
             _path, evicted = self._entries.popitem(last=False)
             self._bytes -= evicted.byte_size
 
-    def remove(self, path):
-        entry = self._entries.pop(os.path.abspath(os.fspath(path)), None)
+    def remove(self, key):
+        entry = self._entries.pop(self._key(key), None)
         if entry is not None:
             self._bytes -= entry.byte_size
 

--- a/libs/core/save_pipeline.py
+++ b/libs/core/save_pipeline.py
@@ -79,7 +79,9 @@ def write_save_request(request, cancelled=None, begin_commit=None):
 
         if cancelled is not None and cancelled():
             return None
-        with open(temporary, 'rb') as output:
+        # Windows requires a writable descriptor for fsync even though no
+        # additional bytes are written here.
+        with open(temporary, 'rb+') as output:
             os.fsync(output.fileno())
         if begin_commit is not None:
             begin_commit()

--- a/libs/core/shape.py
+++ b/libs/core/shape.py
@@ -6,10 +6,10 @@ from enum import Enum
 
 try:
     from PyQt5.QtGui import QColor, QPen, QPainterPath, QFont
-    from PyQt5.QtCore import QPointF
+    from PyQt5.QtCore import QPointF, Qt
 except ImportError:
     from PyQt4.QtGui import QColor, QPen, QPainterPath, QFont
-    from PyQt4.QtCore import QPointF
+    from PyQt4.QtCore import QPointF, Qt
 
 from libs.utils import distance
 import sys
@@ -243,8 +243,15 @@ class Shape(object):
     def _draw_shape(self, painter, line_path, vertex_path):
         """Draw the shape outline and vertices."""
         color = self.select_line_color if self.selected else self.line_color
+        render_state = getattr(self, 'video_render_state', None)
+        if not self.selected and render_state == 'interpolation':
+            color = QColor(40, 130, 230, 230)
+        elif not self.selected and render_state == 'pending':
+            color = QColor(235, 165, 35, 230)
         pen = QPen(color)
         pen.setWidth(max(1, int(round(2.0 / self.scale))))
+        if render_state in ('interpolation', 'pending'):
+            pen.setStyle(Qt.DashLine)
         painter.setPen(pen)
 
         painter.drawPath(line_path)

--- a/libs/core/shortcut_config.py
+++ b/libs/core/shortcut_config.py
@@ -49,6 +49,10 @@ DEFAULT_SHORTCUTS = {
     'create_polygon': 'P',
     'keypoint_mode': 'K',
     'video_add_keyframe': 'Shift+K',
+    'video_track_forward': 'T',
+    'video_track_backward': 'Shift+T',
+    'video_accept_suggestion': 'Shift+Enter',
+    'video_reject_suggestion': 'Backspace',
 }
 
 

--- a/libs/core/shortcut_config.py
+++ b/libs/core/shortcut_config.py
@@ -7,6 +7,7 @@ import json
 DEFAULT_SHORTCUTS = {
     'quit': 'Ctrl+Q',
     'open': 'Ctrl+O',
+    'open_video': 'Ctrl+Alt+V',
     'open_dir': 'Ctrl+U',
     'change_save_dir': 'Ctrl+R',
     'open_annotation': 'Ctrl+Shift+O',
@@ -14,6 +15,7 @@ DEFAULT_SHORTCUTS = {
     'open_next_image': 'D',
     'open_prev_image': 'A',
     'verify': 'Space',
+    'video_play_pause': 'Ctrl+Space',
     'save': 'Ctrl+S',
     'save_format': 'Ctrl+Y',
     'save_as': 'Ctrl+Shift+S',

--- a/libs/core/shortcut_config.py
+++ b/libs/core/shortcut_config.py
@@ -48,6 +48,7 @@ DEFAULT_SHORTCUTS = {
     'show_grid': 'Ctrl+Shift+G',
     'create_polygon': 'P',
     'keypoint_mode': 'K',
+    'video_add_keyframe': 'Shift+K',
 }
 
 

--- a/libs/core/task_coordinator.py
+++ b/libs/core/task_coordinator.py
@@ -202,9 +202,11 @@ class TaskCoordinator(QObject):
     def shutdown(self, wait_ms=500):
         self._shutting_down = True
         self.cancel_all()
+        all_done = True
         for lane in self._lanes.values():
             lane.pool.clear()
-            lane.pool.waitForDone(wait_ms)
+            all_done = lane.pool.waitForDone(wait_ms) and all_done
+        return all_done
 
     def _drop_cancelled(self, lane):
         if not lane.pending:

--- a/libs/core/task_coordinator.py
+++ b/libs/core/task_coordinator.py
@@ -119,6 +119,10 @@ class TaskCoordinator(QObject):
             'interactive': _Lane('interactive', interactive),
             'background': _Lane('background', background),
             'sam': _Lane('sam', 1),
+            # The active PyAV container is session-owned and never touched by
+            # two workers concurrently. Tracking/export open independent
+            # containers on the background lane.
+            'video': _Lane('video', 1),
         }
         self._sequence = itertools.count()
         self._generation = 0

--- a/libs/core/video_decoder.py
+++ b/libs/core/video_decoder.py
@@ -3,7 +3,9 @@
 from dataclasses import dataclass
 from fractions import Fraction
 import importlib
+import math
 import os
+import struct
 
 from PyQt5.QtGui import QImage
 
@@ -47,13 +49,60 @@ def _fraction_parts(value):
     return int(value.numerator), int(value.denominator)
 
 
-def _rotation_for_stream(stream):
-    value = stream.metadata.get('rotate', 0)
+def _normalized_rotation(value, fallback=0):
     try:
         value = int(round(float(value))) % 360
     except (TypeError, ValueError):
-        value = 0
-    return value if value in (0, 90, 180, 270) else 0
+        value = int(fallback) % 360
+    return value if value in (0, 90, 180, 270) else int(fallback) % 360
+
+
+def _rotation_for_stream(stream):
+    """Read rotation from old PyAV stream side data or metadata."""
+    side_data = getattr(stream, 'side_data', None)
+    if side_data is not None:
+        try:
+            value = side_data.get('DISPLAYMATRIX')
+        except AttributeError:
+            value = None
+        if value is not None:
+            return _normalized_rotation(value)
+    metadata = getattr(stream, 'metadata', {})
+    return _normalized_rotation(metadata.get('rotate', 0))
+
+
+def _frame_display_matrix_rotation(frame):
+    """Decode raw DISPLAYMATRIX side data used by PyAV 13 through 16."""
+    for item in getattr(frame, 'side_data', ()):
+        item_type = getattr(item, 'type', None)
+        name = getattr(item_type, 'name', str(item_type))
+        if str(name).split('.')[-1] != 'DISPLAYMATRIX':
+            continue
+        try:
+            matrix = struct.unpack('=9i', bytes(item)[:36])
+        except (TypeError, ValueError, struct.error):
+            return None
+        if matrix[0] == 0 and matrix[1] == 0:
+            return None
+        return _normalized_rotation(
+            -math.degrees(math.atan2(matrix[1], matrix[0])))
+    return None
+
+
+def _rotation_for_frame(frame, fallback=0):
+    """Read FFmpeg display-matrix rotation when PyAV exposes it."""
+    matrix_rotation = _frame_display_matrix_rotation(frame)
+    if matrix_rotation is not None:
+        return matrix_rotation
+    try:
+        value = _normalized_rotation(frame.rotation, fallback)
+    except (AttributeError, TypeError, ValueError):
+        return _normalized_rotation(fallback)
+    # PyAV 17+ returns zero when no display matrix is attached. Preserve an
+    # older stream-level rotation in that case.
+    if value == 0 and _normalized_rotation(fallback) != 0:
+        return _normalized_rotation(fallback)
+    return value
 
 
 def _oriented_array(frame, rotation, np):
@@ -133,7 +182,14 @@ class VideoDecoderSession:
     def _result(self, frame):
         if frame.pts is None:
             raise VideoDecodeError('decoded frame has no presentation timestamp')
-        array = _oriented_array(frame, self.rotation, self._np)
+        rotation = _rotation_for_frame(frame, self.rotation)
+        if rotation != self.rotation:
+            self.rotation = rotation
+            self.oriented_width = (
+                self.height if rotation in (90, 270) else self.width)
+            self.oriented_height = (
+                self.width if rotation in (90, 270) else self.height)
+        array = _oriented_array(frame, rotation, self._np)
         height, width = array.shape[:2]
         image = QImage(
             array.data, width, height, int(array.strides[0]),
@@ -145,7 +201,7 @@ class VideoDecoderSession:
             image, 'sizeInBytes') else int(image.byteCount())
         result = VideoFrameResult(
             frame_ref, image, width, height, self.width, self.height,
-            self.rotation, byte_size,
+            rotation, byte_size,
             '%s:%s:%s' % (self.fingerprint.sampled_sha256,
                           self.stream_index, frame.pts))
         self._history.append(result)
@@ -242,4 +298,3 @@ class VideoDecoderSession:
         self._iterator = iter(())
         if container is not None:
             container.close()
-

--- a/libs/core/video_decoder.py
+++ b/libs/core/video_decoder.py
@@ -1,0 +1,245 @@
+"""Lazy PyAV compatibility adapter and frame-accurate video decoder."""
+
+from dataclasses import dataclass
+from fractions import Fraction
+import importlib
+import os
+
+from PyQt5.QtGui import QImage
+
+from libs.core.video_project import fingerprint_video
+from libs.core.video_types import (
+    VideoFrameRef, VideoFrameResult, VideoSessionSnapshot,
+)
+
+
+VIDEO_EXTENSIONS = ('.mp4', '.mov', '.mkv', '.avi')
+VIDEO_INSTALL_HINT = (
+    'Smart video annotation requires optional dependencies. Install them with '
+    '`pip install "labelimgplusplus[video]"`.')
+
+
+class VideoDependencyError(RuntimeError):
+    pass
+
+
+class VideoDecodeError(RuntimeError):
+    pass
+
+
+def load_video_dependencies():
+    """Import optional modules only after a video operation is requested."""
+    try:
+        av = importlib.import_module('av')
+        np = importlib.import_module('numpy')
+    except ImportError as exc:
+        raise VideoDependencyError('%s (%s)' % (VIDEO_INSTALL_HINT, exc))
+    return av, np
+
+
+def pyav_major():
+    av, _np = load_video_dependencies()
+    return int(av.__version__.split('.', 1)[0])
+
+
+def _fraction_parts(value):
+    value = Fraction(value)
+    return int(value.numerator), int(value.denominator)
+
+
+def _rotation_for_stream(stream):
+    value = stream.metadata.get('rotate', 0)
+    try:
+        value = int(round(float(value))) % 360
+    except (TypeError, ValueError):
+        value = 0
+    return value if value in (0, 90, 180, 270) else 0
+
+
+def _oriented_array(frame, rotation, np):
+    array = frame.to_ndarray(format='rgb24')
+    if rotation == 90:
+        array = np.rot90(array, 3)
+    elif rotation == 180:
+        array = np.rot90(array, 2)
+    elif rotation == 270:
+        array = np.rot90(array, 1)
+    return np.ascontiguousarray(array)
+
+
+@dataclass(frozen=True)
+class PreparedVideoOpen:
+    snapshot: VideoSessionSnapshot
+    decoder: object
+    tracks: tuple
+    observations: tuple
+    frame_states: tuple
+    classes: tuple
+
+
+class VideoDecoderSession:
+    """One decoder context serialized by TaskCoordinator's video lane."""
+
+    def __init__(self, source_path, stream_index=None, cancelled=None):
+        av, np = load_video_dependencies()
+        self._av = av
+        self._np = np
+        self.source_path = os.path.abspath(os.fspath(source_path))
+        self.fingerprint = fingerprint_video(
+            self.source_path, cancelled=cancelled)
+        if self.fingerprint is None:
+            raise VideoDecodeError('video opening was cancelled')
+        self.container = av.open(self.source_path, mode='r')
+        streams = list(self.container.streams.video)
+        if stream_index is None:
+            stream = next((item for item in streams
+                           if item.codec_context is not None), None)
+        else:
+            stream = next((item for item in streams
+                           if item.index == stream_index), None)
+        if stream is None:
+            self.close()
+            raise VideoDecodeError('no playable video stream found')
+        self.stream = stream
+        self.stream_index = int(stream.index)
+        self.time_base = Fraction(stream.time_base)
+        self.time_base_num, self.time_base_den = _fraction_parts(
+            self.time_base)
+        self.rotation = _rotation_for_stream(stream)
+        self.width = int(stream.codec_context.width or stream.width or 0)
+        self.height = int(stream.codec_context.height or stream.height or 0)
+        if self.width <= 0 or self.height <= 0:
+            self.close()
+            raise VideoDecodeError('video stream has invalid dimensions')
+        self.oriented_width = (
+            self.height if self.rotation in (90, 270) else self.width)
+        self.oriented_height = (
+            self.width if self.rotation in (90, 270) else self.height)
+        self.duration_pts = (
+            int(stream.duration) if stream.duration is not None else None)
+        self.start_pts = (
+            int(stream.start_time) if stream.start_time is not None else None)
+        self.codec = str(getattr(stream.codec_context, 'name', '') or
+                         getattr(stream.codec, 'name', '') or 'unknown')
+        rate = getattr(stream, 'average_rate', None)
+        if rate is not None:
+            self.average_rate_num, self.average_rate_den = _fraction_parts(rate)
+        else:
+            self.average_rate_num = self.average_rate_den = None
+        self._iterator = iter(self.container.decode(self.stream))
+        self._history = []
+        self._closed = False
+
+    def _result(self, frame):
+        if frame.pts is None:
+            raise VideoDecodeError('decoded frame has no presentation timestamp')
+        array = _oriented_array(frame, self.rotation, self._np)
+        height, width = array.shape[:2]
+        image = QImage(
+            array.data, width, height, int(array.strides[0]),
+            QImage.Format_RGB888).copy()
+        frame_ref = VideoFrameRef(
+            self.fingerprint, self.stream_index, int(frame.pts),
+            self.time_base_num, self.time_base_den)
+        byte_size = int(image.sizeInBytes()) if hasattr(
+            image, 'sizeInBytes') else int(image.byteCount())
+        result = VideoFrameResult(
+            frame_ref, image, width, height, self.width, self.height,
+            self.rotation, byte_size,
+            '%s:%s:%s' % (self.fingerprint.sampled_sha256,
+                          self.stream_index, frame.pts))
+        self._history.append(result)
+        if len(self._history) > 24:
+            del self._history[:-24]
+        return result
+
+    def decode_first(self, cancelled=None):
+        for frame in self._iterator:
+            if cancelled is not None and cancelled():
+                raise VideoDecodeError('video opening was cancelled')
+            if frame.pts is not None:
+                return self._result(frame)
+        raise VideoDecodeError('video stream contains no decodable frames')
+
+    def next_frame(self, cancelled=None):
+        for frame in self._iterator:
+            if cancelled is not None and cancelled():
+                return None
+            if frame.pts is not None:
+                return self._result(frame)
+        return None
+
+    def seek_pts(self, target_pts, mode='nearest', cancelled=None):
+        """Seek to a stream PTS and decode forward from a keyframe."""
+        target_pts = int(target_pts)
+        self.container.seek(
+            target_pts, stream=self.stream, backward=True, any_frame=False)
+        self._iterator = iter(self.container.decode(self.stream))
+        previous = None
+        for frame in self._iterator:
+            if cancelled is not None and cancelled():
+                return None
+            if frame.pts is None:
+                continue
+            pts = int(frame.pts)
+            result = self._result(frame)
+            if mode == 'at_or_after':
+                if pts >= target_pts:
+                    return result
+            elif pts >= target_pts:
+                if previous is None:
+                    return result
+                if abs(previous.frame_ref.pts - target_pts) <= abs(
+                        pts - target_pts):
+                    return previous
+                return result
+            previous = result
+        return previous
+
+    def previous_frame(self, current_ref, cancelled=None):
+        for result in reversed(self._history[:-1]):
+            if result.frame_ref.pts < current_ref.pts:
+                return result
+        rate = (self.average_rate_num / self.average_rate_den
+                if self.average_rate_num and self.average_rate_den else 30.0)
+        step_pts = max(1, int(round(1.0 / rate / float(self.time_base))))
+        target = max(self.start_pts or 0, current_ref.pts - step_pts * 3)
+        candidate = self.seek_pts(target, mode='at_or_after', cancelled=cancelled)
+        previous = None
+        while candidate is not None and candidate.frame_ref.pts < current_ref.pts:
+            previous = candidate
+            candidate = self.next_frame(cancelled=cancelled)
+        return previous
+
+    def snapshot(self, project_path, initial_frame, revision=0,
+                 read_only=False):
+        return VideoSessionSnapshot(
+            source_path=self.source_path,
+            project_path=project_path,
+            fingerprint=self.fingerprint,
+            stream_index=self.stream_index,
+            time_base_num=self.time_base_num,
+            time_base_den=self.time_base_den,
+            width=self.oriented_width,
+            height=self.oriented_height,
+            rotation=self.rotation,
+            codec=self.codec,
+            duration_pts=self.duration_pts,
+            start_pts=self.start_pts,
+            average_rate_num=self.average_rate_num,
+            average_rate_den=self.average_rate_den,
+            revision=revision,
+            initial_frame=initial_frame,
+            read_only=read_only,
+        )
+
+    def close(self):
+        if getattr(self, '_closed', False):
+            return
+        self._closed = True
+        container = getattr(self, 'container', None)
+        self.container = None
+        self._iterator = iter(())
+        if container is not None:
+            container.close()
+

--- a/libs/core/video_decoder.py
+++ b/libs/core/video_decoder.py
@@ -177,6 +177,7 @@ class VideoDecoderSession:
             self.average_rate_num = self.average_rate_den = None
         self._iterator = iter(self.container.decode(self.stream))
         self._history = []
+        self._lookahead = []
         self._closed = False
 
     def _result(self, frame):
@@ -218,6 +219,10 @@ class VideoDecoderSession:
         raise VideoDecodeError('video stream contains no decodable frames')
 
     def next_frame(self, cancelled=None):
+        if self._lookahead:
+            if cancelled is not None and cancelled():
+                return None
+            return self._lookahead.pop(0)
         for frame in self._iterator:
             if cancelled is not None and cancelled():
                 return None
@@ -228,6 +233,7 @@ class VideoDecoderSession:
     def seek_pts(self, target_pts, mode='nearest', cancelled=None):
         """Seek to a stream PTS and decode forward from a keyframe."""
         target_pts = int(target_pts)
+        self._lookahead = []
         self.container.seek(
             target_pts, stream=self.stream, backward=True, any_frame=False)
         self._iterator = iter(self.container.decode(self.stream))
@@ -247,6 +253,10 @@ class VideoDecoderSession:
                     return result
                 if abs(previous.frame_ref.pts - target_pts) <= abs(
                         pts - target_pts):
+                    # Decoding the right-hand candidate advanced PyAV's
+                    # iterator. Preserve it so sequential Next returns the
+                    # actual successor of the frame selected by this seek.
+                    self._lookahead.append(result)
                     return previous
                 return result
             previous = result
@@ -296,5 +306,6 @@ class VideoDecoderSession:
         container = getattr(self, 'container', None)
         self.container = None
         self._iterator = iter(())
+        self._lookahead = []
         if container is not None:
             container.close()

--- a/libs/core/video_export.py
+++ b/libs/core/video_export.py
@@ -86,11 +86,24 @@ def _coco_document(frames, classes):
                 annotation['keypoints'] = flat
                 annotation['num_keypoints'] = count
             annotations.append(annotation)
+    has_keypoints = any(
+        observation.keypoints is not None
+        for frame in frames
+        for _track, observation in frame['accepted'])
+    categories = [
+        {'id': category_ids[name], 'name': name} for name in classes]
+    if has_keypoints:
+        from libs.core.keypoint_config import COCO_KEYPOINT_NAMES, COCO_SKELETON
+        for category in categories:
+            if category['name'].lower() == 'person':
+                category['keypoints'] = list(COCO_KEYPOINT_NAMES)
+                category['skeleton'] = [
+                    [start + 1, end + 1]
+                    for start, end in COCO_SKELETON]
     return {
         'images': images,
         'annotations': annotations,
-        'categories': [
-            {'id': category_ids[name], 'name': name} for name in classes],
+        'categories': categories,
     }
 
 
@@ -129,6 +142,41 @@ def _validate_destination(destination):
                 'export destination must be new or empty')
 
 
+def _requested_frames(decoder, request, handle):
+    """Yield exact decoded frames for the immutable export selection."""
+    every = request.sample_every_frames
+    if every is not None:
+        every = int(every)
+        if every <= 0:
+            raise VideoExportError('frame sampling interval must be positive')
+        if (request.range_start_pts is None
+                or request.range_end_pts is None):
+            raise VideoExportError(
+                'frame sampling requires a PTS range')
+        start_pts = int(request.range_start_pts)
+        end_pts = int(request.range_end_pts)
+        if end_pts < start_pts:
+            raise VideoExportError(
+                'frame sampling range end precedes its start')
+        result = decoder.seek_pts(
+            start_pts, mode='at_or_after', cancelled=handle.is_cancelled)
+        frame_index = 0
+        while result is not None and result.frame_ref.pts <= end_pts:
+            handle.check_cancelled()
+            if frame_index % every == 0:
+                yield result
+            frame_index += 1
+            result = decoder.next_frame(cancelled=handle.is_cancelled)
+        return
+
+    for frame_ref in request.frame_refs:
+        handle.check_cancelled()
+        result = decoder.seek_pts(
+            frame_ref.pts, mode='nearest', cancelled=handle.is_cancelled)
+        if result is not None:
+            yield result
+
+
 def export_video_frames(request, handle):
     """Stage all output and publish only after every frame succeeds."""
     destination = os.path.abspath(request.destination)
@@ -160,13 +208,11 @@ def export_video_frames(request, handle):
                      else 'jpg')
         staged_frames = []
         seen_pts = set()
-        total = len(request.frame_refs)
-        for index, frame_ref in enumerate(request.frame_refs, 1):
-            handle.check_cancelled()
-            result = decoder.seek_pts(
-                frame_ref.pts, mode='nearest',
-                cancelled=handle.is_cancelled)
-            if result is None or result.frame_ref.pts in seen_pts:
+        total = ('?' if request.sample_every_frames is not None
+                 else len(request.frame_refs))
+        for index, result in enumerate(
+                _requested_frames(decoder, request, handle), 1):
+            if result.frame_ref.pts in seen_pts:
                 continue
             seen_pts.add(result.frame_ref.pts)
             name = frame_export_name(
@@ -226,11 +272,9 @@ def export_video_frames(request, handle):
             'schema_version': 1,
             'source': {
                 'path': os.path.basename(request.source_path),
-                'size': request.frame_refs[0].fingerprint.size
-                if request.frame_refs else 0,
-                'sampled_sha256': (
-                    request.frame_refs[0].fingerprint.sampled_sha256
-                    if request.frame_refs else None),
+                'size': decoder.fingerprint.size,
+                'mtime_ns': decoder.fingerprint.mtime_ns,
+                'sampled_sha256': decoder.fingerprint.sampled_sha256,
                 'stream_index': request.stream_index,
             },
             'frames': [{

--- a/libs/core/video_export.py
+++ b/libs/core/video_export.py
@@ -1,0 +1,262 @@
+"""Atomic tracked-frame export through existing annotation contracts."""
+
+import json
+import os
+import tempfile
+
+from libs.core.save_pipeline import (
+    SaveRequest, target_path, write_save_request,
+)
+from libs.core.video_decoder import VideoDecoderSession
+from libs.core.video_model import VideoProjectModel
+from libs.formats.labelFile import LabelFileFormat
+
+
+class VideoExportError(RuntimeError):
+    pass
+
+
+def frame_export_name(video_stem, stream_index, pts, extension):
+    return '%s__s%s__p%s.%s' % (
+        video_stem, int(stream_index), int(pts), extension.lower())
+
+
+def _shape_dict(track, observation):
+    if track.shape_type == 'rectangle':
+        xmin, ymin, xmax, ymax = observation.geometry
+        points = ((xmin, ymin), (xmax, ymin),
+                  (xmax, ymax), (xmin, ymax))
+    else:
+        points = tuple(tuple(point) for point in observation.geometry)
+    values = {
+        'label': track.label,
+        'points': points,
+        'difficult': track.difficult,
+        'shape_type': track.shape_type,
+        'line_color': track.color,
+        'fill_color': track.color,
+    }
+    if observation.keypoints is not None:
+        values['keypoints'] = tuple(
+            tuple(item) if item is not None else None
+            for item in observation.keypoints)
+    return values
+
+
+def _serialize_shape(track, observation):
+    return tuple(_shape_dict(track, observation).items())
+
+
+def _coco_document(frames, classes):
+    category_ids = {name: index + 1 for index, name in enumerate(classes)}
+    images = []
+    annotations = []
+    annotation_id = 1
+    for image_id, frame in enumerate(frames, 1):
+        images.append({
+            'id': image_id, 'file_name': frame['name'],
+            'width': frame['width'], 'height': frame['height'],
+        })
+        for track, observation in frame['accepted']:
+            shape = _shape_dict(track, observation)
+            category_id = category_ids[track.label]
+            points = shape['points']
+            xs = [point[0] for point in points]
+            ys = [point[1] for point in points]
+            annotation = {
+                'id': annotation_id, 'image_id': image_id,
+                'category_id': category_id,
+                'bbox': [min(xs), min(ys),
+                         max(xs) - min(xs), max(ys) - min(ys)],
+                'iscrowd': 0, 'difficult': int(track.difficult),
+            }
+            annotation_id += 1
+            if track.shape_type == 'polygon':
+                annotation['segmentation'] = [[
+                    value for point in points for value in point]]
+            if observation.keypoints is not None:
+                flat = []
+                count = 0
+                for item in observation.keypoints:
+                    if item is not None and item[2] > 0:
+                        flat.extend(item)
+                        count += 1
+                    else:
+                        flat.extend((0, 0, 0))
+                annotation['keypoints'] = flat
+                annotation['num_keypoints'] = count
+            annotations.append(annotation)
+    return {
+        'images': images,
+        'annotations': annotations,
+        'categories': [
+            {'id': category_ids[name], 'name': name} for name in classes],
+    }
+
+
+def _create_ml_document(frames):
+    document = []
+    for frame in frames:
+        annotations = []
+        for track, observation in frame['accepted']:
+            shape = _shape_dict(track, observation)
+            xs = [point[0] for point in shape['points']]
+            ys = [point[1] for point in shape['points']]
+            width = max(xs) - min(xs)
+            height = max(ys) - min(ys)
+            annotations.append({
+                'label': track.label,
+                'coordinates': {
+                    'x': min(xs) + width / 2,
+                    'y': min(ys) + height / 2,
+                    'width': width, 'height': height,
+                },
+            })
+        document.append({
+            'image': frame['name'],
+            'verified': frame['verified'],
+            'annotations': annotations,
+        })
+    return document
+
+
+def _validate_destination(destination):
+    if os.path.exists(destination):
+        if not os.path.isdir(destination):
+            raise VideoExportError('export destination is not a directory')
+        if os.listdir(destination):
+            raise VideoExportError(
+                'export destination must be new or empty')
+
+
+def export_video_frames(request, handle):
+    """Stage all output and publish only after every frame succeeds."""
+    destination = os.path.abspath(request.destination)
+    _validate_destination(destination)
+    parent = os.path.dirname(destination) or '.'
+    if not os.path.isdir(parent):
+        raise VideoExportError('export destination parent does not exist')
+    staging = tempfile.mkdtemp(prefix='.labelimgpp-export-', dir=parent)
+    decoder = None
+    try:
+        model = VideoProjectModel(
+            tracks=request.tracks,
+            observations=tuple(
+                item for item in request.observations
+                if item.review_state == 'accepted'),
+            frame_states=request.frame_states, classes=request.class_order)
+        class_order = list(request.class_order)
+        for track in request.tracks:
+            if track.label not in class_order:
+                class_order.append(track.label)
+        verified_pts = {
+            item.pts for item in request.frame_states if item.verified}
+        decoder = VideoDecoderSession(
+            request.source_path, stream_index=request.stream_index,
+            cancelled=handle.is_cancelled)
+        video_stem = os.path.splitext(
+            os.path.basename(request.source_path))[0]
+        extension = ('png' if request.image_format.lower() == 'png'
+                     else 'jpg')
+        staged_frames = []
+        seen_pts = set()
+        total = len(request.frame_refs)
+        for index, frame_ref in enumerate(request.frame_refs, 1):
+            handle.check_cancelled()
+            result = decoder.seek_pts(
+                frame_ref.pts, mode='nearest',
+                cancelled=handle.is_cancelled)
+            if result is None or result.frame_ref.pts in seen_pts:
+                continue
+            seen_pts.add(result.frame_ref.pts)
+            name = frame_export_name(
+                video_stem, result.frame_ref.stream_index,
+                result.frame_ref.pts, extension)
+            image_path = os.path.join(staging, name)
+            if extension == 'png':
+                saved = result.image.save(image_path, 'PNG')
+            else:
+                saved = result.image.save(
+                    image_path, 'JPEG', int(request.jpeg_quality))
+            if not saved:
+                raise VideoExportError('failed to encode frame %s' % name)
+            materialized = model.materialize(result.frame_ref.pts)
+            accepted = tuple(
+                (item.track, item.observation) for item in materialized
+                if item.render_state != 'pending'
+                and item.observation.review_state == 'accepted')
+            verified = result.frame_ref.pts in verified_pts
+            staged_frames.append({
+                'name': name, 'path': image_path,
+                'width': result.display_width,
+                'height': result.display_height,
+                'ref': result.frame_ref,
+                'accepted': accepted,
+                'verified': verified,
+            })
+            if request.annotation_format not in (
+                    LabelFileFormat.COCO, LabelFileFormat.CREATE_ML):
+                serialized = tuple(
+                    _serialize_shape(track, observation)
+                    for track, observation in accepted)
+                write_save_request(SaveRequest(
+                    image_path=image_path,
+                    annotation_path=target_path(
+                        os.path.splitext(image_path)[0],
+                        request.annotation_format),
+                    label_file_format=request.annotation_format,
+                    shapes=serialized, class_list=tuple(class_order),
+                    verified=verified, revision=0),
+                    cancelled=handle.is_cancelled)
+            handle.report_progress((index, total, name))
+
+        handle.check_cancelled()
+        if request.annotation_format == LabelFileFormat.COCO:
+            shared = _coco_document(staged_frames, class_order)
+            with open(os.path.join(staging, 'annotations.json'), 'w',
+                      encoding='utf-8') as output:
+                json.dump(shared, output, indent=2)
+        elif request.annotation_format == LabelFileFormat.CREATE_ML:
+            shared = _create_ml_document(staged_frames)
+            with open(os.path.join(staging, 'annotations.json'), 'w',
+                      encoding='utf-8') as output:
+                json.dump(shared, output, indent=2)
+
+        manifest = {
+            'schema_version': 1,
+            'source': {
+                'path': os.path.basename(request.source_path),
+                'size': request.frame_refs[0].fingerprint.size
+                if request.frame_refs else 0,
+                'sampled_sha256': (
+                    request.frame_refs[0].fingerprint.sampled_sha256
+                    if request.frame_refs else None),
+                'stream_index': request.stream_index,
+            },
+            'frames': [{
+                'file': frame['name'],
+                'pts': frame['ref'].pts,
+                'time_base': [frame['ref'].time_base_num,
+                              frame['ref'].time_base_den],
+                'verified': frame['verified'],
+                'track_ids': [track.track_id
+                              for track, _observation in frame['accepted']],
+            } for frame in staged_frames],
+        }
+        with open(os.path.join(staging, 'video_export_manifest.json'), 'w',
+                  encoding='utf-8') as output:
+            json.dump(manifest, output, indent=2)
+        handle.check_cancelled()
+        handle.begin_non_cancellable()
+        if os.path.isdir(destination):
+            os.rmdir(destination)  # It was verified empty; races fail safely.
+        os.replace(staging, destination)
+        staging = None
+        return destination
+    finally:
+        if decoder is not None:
+            decoder.close()
+        if staging is not None and os.path.basename(staging).startswith(
+                '.labelimgpp-export-'):
+            import shutil
+            shutil.rmtree(staging, ignore_errors=True)

--- a/libs/core/video_model.py
+++ b/libs/core/video_model.py
@@ -1,0 +1,345 @@
+"""In-memory track domain, materialization, and coalesced save deltas."""
+
+from dataclasses import dataclass, replace
+import uuid
+
+from libs.core.video_types import (
+    FrameStateRecord, ObservationRecord, TrackRecord, VideoSaveRequest,
+)
+
+
+@dataclass(frozen=True)
+class MaterializedTrack:
+    track: TrackRecord
+    observation: ObservationRecord
+    render_state: str  # exact, interpolation, or pending
+
+
+@dataclass(frozen=True)
+class VideoModelState:
+    tracks: tuple
+    observations: tuple
+    frame_states: tuple
+    classes: tuple
+
+
+def _interpolate_keypoints(left, right, ratio):
+    if left is None or right is None or len(left) != len(right):
+        return None
+    result = []
+    nearest = left if ratio < .5 else right
+    for index, (first, second) in enumerate(zip(left, right)):
+        if first is None or second is None:
+            result.append(nearest[index])
+            continue
+        result.append([
+            first[0] + (second[0] - first[0]) * ratio,
+            first[1] + (second[1] - first[1]) * ratio,
+            nearest[index][2],
+        ])
+    return result
+
+
+def interpolate_rectangle(left, right, pts):
+    if not left.present or not right.present:
+        return None
+    if left.geometry is None or right.geometry is None:
+        return None
+    if len(left.geometry) != 4 or len(right.geometry) != 4:
+        return None
+    if right.pts <= left.pts or not left.pts < pts < right.pts:
+        return None
+    ratio = (pts - left.pts) / (right.pts - left.pts)
+    geometry = [
+        first + (second - first) * ratio
+        for first, second in zip(left.geometry, right.geometry)
+    ]
+    return ObservationRecord(
+        track_id=left.track_id, pts=int(pts), geometry=geometry,
+        keypoints=_interpolate_keypoints(
+            left.keypoints, right.keypoints, ratio),
+        present=True, source='manual', review_state='accepted',
+        anchor=False, quality=None,
+        revision=max(left.revision, right.revision))
+
+
+class VideoProjectModel:
+    """Mutable only on the GUI thread; workers receive immutable deltas."""
+
+    def __init__(self, revision=0, tracks=(), observations=(),
+                 frame_states=(), classes=()):
+        self.durable_revision = int(revision)
+        self.revision = int(revision)
+        self.tracks = {item.track_id: item for item in tracks}
+        self.observations = {
+            (item.track_id, int(item.pts)): item for item in observations}
+        self.frame_states = {int(item.pts): item for item in frame_states}
+        self.classes = list(classes)
+        self._changed_tracks = {}
+        self._changed_observations = {}
+        self._changed_frames = {}
+        self._deleted_observations = {}
+        self._deleted_tracks = {}
+        self._classes_changed_revision = None
+
+    @property
+    def dirty(self):
+        return self.revision != self.durable_revision
+
+    def snapshot_state(self):
+        return VideoModelState(
+            tuple(self.tracks.values()),
+            tuple(sorted(self.observations.values(),
+                         key=lambda item: (item.pts, item.track_id))),
+            tuple(sorted(self.frame_states.values(),
+                         key=lambda item: item.pts)),
+            tuple(self.classes))
+
+    def restore_state(self, state):
+        self._advance()
+        revision = self.revision
+        old_track_ids = set(self.tracks)
+        old_observation_keys = set(self.observations)
+        self.tracks = {
+            item.track_id: replace(item, revision=revision)
+            for item in state.tracks}
+        self.observations = {
+            (item.track_id, item.pts): replace(item, revision=revision)
+            for item in state.observations}
+        self.frame_states = {
+            item.pts: replace(item, revision=revision)
+            for item in state.frame_states}
+        self.classes = list(state.classes)
+        self._changed_tracks.update(self.tracks)
+        self._changed_observations.update(self.observations)
+        self._changed_frames.update(self.frame_states)
+        for track_id in old_track_ids - set(self.tracks):
+            self._deleted_tracks[track_id] = revision
+        for key in old_observation_keys - set(self.observations):
+            self._deleted_observations[key] = revision
+        self._classes_changed_revision = revision
+
+    def _advance(self):
+        self.revision += 1
+        return self.revision
+
+    def create_track(self, label, shape_type, color, difficult=False,
+                     track_id=None):
+        revision = self._advance()
+        track = TrackRecord(
+            track_id or str(uuid.uuid4()), label, shape_type, tuple(color),
+            bool(difficult), revision)
+        self.tracks[track.track_id] = track
+        self._changed_tracks[track.track_id] = track
+        self._deleted_tracks.pop(track.track_id, None)
+        if label not in self.classes:
+            self.classes.append(label)
+            self._classes_changed_revision = revision
+        return track
+
+    def rename_track(self, track_id, label):
+        track = self.tracks[track_id]
+        if track.label == label:
+            return track
+        revision = self._advance()
+        track = replace(track, label=label, revision=revision)
+        self.tracks[track_id] = track
+        self._changed_tracks[track_id] = track
+        if label not in self.classes:
+            self.classes.append(label)
+            self._classes_changed_revision = revision
+        return track
+
+    def update_track(self, track_id, color=None, difficult=None):
+        track = self.tracks[track_id]
+        revision = self._advance()
+        track = replace(
+            track,
+            color=(tuple(color) if color is not None else track.color),
+            difficult=(bool(difficult) if difficult is not None
+                       else track.difficult),
+            revision=revision)
+        self.tracks[track_id] = track
+        self._changed_tracks[track_id] = track
+        return track
+
+    def upsert_manual(self, track_id, pts, geometry, keypoints=None,
+                      present=True):
+        revision = self._advance()
+        observation = ObservationRecord(
+            track_id, int(pts), geometry, keypoints=keypoints,
+            present=bool(present), source='manual',
+            review_state='accepted', anchor=True, revision=revision)
+        key = (track_id, int(pts))
+        self.observations[key] = observation
+        self._changed_observations[key] = observation
+        self._deleted_observations.pop(key, None)
+        track = self.tracks.get(track_id)
+        if track is not None:
+            track = replace(track, revision=revision)
+            self.tracks[track_id] = track
+            self._changed_tracks[track_id] = track
+        return observation
+
+    def upsert_tracker(self, observation, replace_reviewed=False):
+        key = (observation.track_id, int(observation.pts))
+        existing = self.observations.get(key)
+        if existing is not None:
+            if existing.source == 'manual' or (
+                    existing.review_state == 'accepted'
+                    and not replace_reviewed):
+                return existing
+        revision = self._advance()
+        value = replace(
+            observation, source='tracker', anchor=False,
+            revision=revision)
+        self.observations[key] = value
+        self._changed_observations[key] = value
+        self._deleted_observations.pop(key, None)
+        return value
+
+    def review(self, track_id, pts, review_state):
+        if review_state not in ('accepted', 'pending', 'rejected'):
+            raise ValueError('invalid review state: %s' % review_state)
+        key = (track_id, int(pts))
+        current = self.observations[key]
+        if current.source != 'tracker':
+            return current
+        revision = self._advance()
+        value = replace(
+            current, review_state=review_state, anchor=False,
+            revision=revision)
+        self.observations[key] = value
+        self._changed_observations[key] = value
+        return value
+
+    def promote_to_manual(self, track_id, pts):
+        current = self.materialize_one(track_id, pts)
+        if current is None:
+            return None
+        return self.upsert_manual(
+            track_id, pts, current.observation.geometry,
+            keypoints=current.observation.keypoints,
+            present=current.observation.present)
+
+    def delete_occurrence(self, track_id, pts):
+        key = (track_id, int(pts))
+        if key in self.observations:
+            revision = self._advance()
+            del self.observations[key]
+            self._changed_observations.pop(key, None)
+            self._deleted_observations[key] = revision
+            if not any(item.track_id == track_id
+                       for item in self.observations.values()):
+                self.delete_track(track_id)
+            return
+        if self.materialize_one(track_id, pts) is not None:
+            self.upsert_manual(track_id, pts, None, present=False)
+
+    def delete_track(self, track_id):
+        if track_id not in self.tracks:
+            return
+        revision = self._advance()
+        del self.tracks[track_id]
+        self._changed_tracks.pop(track_id, None)
+        self._deleted_tracks[track_id] = revision
+        for key in tuple(self.observations):
+            if key[0] == track_id:
+                del self.observations[key]
+                self._changed_observations.pop(key, None)
+                self._deleted_observations[key] = revision
+
+    def set_frame_verified(self, pts, verified):
+        revision = self._advance()
+        state = FrameStateRecord(int(pts), bool(verified), revision)
+        self.frame_states[int(pts)] = state
+        self._changed_frames[int(pts)] = state
+        return state
+
+    def materialize_one(self, track_id, pts):
+        track = self.tracks.get(track_id)
+        if track is None:
+            return None
+        exact = self.observations.get((track_id, int(pts)))
+        if exact is not None and exact.review_state != 'rejected':
+            if not exact.present:
+                return None
+            render = ('pending' if exact.review_state == 'pending'
+                      else 'exact')
+            return MaterializedTrack(track, exact, render)
+        if track.shape_type != 'rectangle':
+            return None
+        anchors = sorted(
+            (item for item in self.observations.values()
+             if item.track_id == track_id and item.source == 'manual'
+             and item.review_state == 'accepted' and item.anchor),
+            key=lambda item: item.pts)
+        left = next((item for item in reversed(anchors)
+                     if item.pts < pts), None)
+        right = next((item for item in anchors if item.pts > pts), None)
+        if left is None or right is None:
+            return None
+        interpolated = interpolate_rectangle(left, right, int(pts))
+        if interpolated is None:
+            return None
+        return MaterializedTrack(track, interpolated, 'interpolation')
+
+    def materialize(self, pts):
+        values = []
+        for track_id in self.tracks:
+            value = self.materialize_one(track_id, int(pts))
+            if value is not None:
+                values.append(value)
+        return tuple(values)
+
+    def build_save_request(self, project_path):
+        target = self.revision
+        tracks = tuple(
+            value for value in self._changed_tracks.values()
+            if value.revision <= target)
+        observations = tuple(
+            value for value in self._changed_observations.values()
+            if value.revision <= target)
+        frames = tuple(
+            value for value in self._changed_frames.values()
+            if value.revision <= target)
+        deleted_observations = tuple(
+            key for key, revision in self._deleted_observations.items()
+            if revision <= target)
+        deleted_tracks = tuple(
+            key for key, revision in self._deleted_tracks.items()
+            if revision <= target)
+        touched = set(item.track_id for item in observations)
+        touched.update(item.track_id for item in tracks)
+        touched.update(key[0] for key in deleted_observations)
+        classes = (tuple(self.classes)
+                   if self._classes_changed_revision is not None
+                   and self._classes_changed_revision <= target else ())
+        return VideoSaveRequest(
+            project_path, self.durable_revision, target,
+            tracks=tracks, observations=observations,
+            deleted_observations=deleted_observations,
+            deleted_tracks=deleted_tracks, frame_states=frames,
+            classes=classes, touched_tracks=tuple(sorted(touched)))
+
+    def mark_saved(self, target_revision):
+        target_revision = int(target_revision)
+        self.durable_revision = target_revision
+        self._changed_tracks = {
+            key: value for key, value in self._changed_tracks.items()
+            if value.revision > target_revision}
+        self._changed_observations = {
+            key: value for key, value in self._changed_observations.items()
+            if value.revision > target_revision}
+        self._changed_frames = {
+            key: value for key, value in self._changed_frames.items()
+            if value.revision > target_revision}
+        self._deleted_observations = {
+            key: value for key, value in self._deleted_observations.items()
+            if value > target_revision}
+        self._deleted_tracks = {
+            key: value for key, value in self._deleted_tracks.items()
+            if value > target_revision}
+        if (self._classes_changed_revision is not None
+                and self._classes_changed_revision <= target_revision):
+            self._classes_changed_revision = None

--- a/libs/core/video_project.py
+++ b/libs/core/video_project.py
@@ -1,0 +1,471 @@
+"""Versioned SQLite project storage for smart-video annotations."""
+
+from dataclasses import dataclass
+import hashlib
+import json
+import os
+import shutil
+import sqlite3
+
+from libs.core.video_types import (
+    FrameStateRecord, ObservationRecord, TrackRecord, VideoFingerprint,
+)
+
+
+PROJECT_SUFFIX = '.labelimgpp.sqlite'
+APPLICATION_ID = 0x4C495050  # ASCII-ish "LIPP", stored in SQLite's header.
+SCHEMA_VERSION = 1
+SAMPLE_BYTES = 1024 * 1024
+
+
+class VideoProjectError(Exception):
+    pass
+
+
+class UnknownProjectError(VideoProjectError):
+    pass
+
+
+class NewerSchemaError(VideoProjectError):
+    pass
+
+
+class ProjectRevisionConflict(VideoProjectError):
+    pass
+
+
+class VideoSourceMissing(VideoProjectError):
+    pass
+
+
+class VideoSourceChanged(VideoProjectError):
+    pass
+
+
+@dataclass(frozen=True)
+class ProjectContents:
+    revision: int
+    tracks: tuple
+    observations: tuple
+    frame_states: tuple
+    classes: tuple
+
+
+@dataclass(frozen=True)
+class ProjectSource:
+    relative_path: object
+    absolute_path: str
+    fingerprint: VideoFingerprint
+    stream_index: int
+    time_base_num: int
+    time_base_den: int
+
+
+def default_project_path(source_path):
+    return os.path.abspath(os.fspath(source_path)) + PROJECT_SUFFIX
+
+
+def fingerprint_video(path, cancelled=None):
+    """Hash bounded samples while retaining cheap source stat metadata."""
+    path = os.path.abspath(os.fspath(path))
+    stat = os.stat(path)
+    size = int(stat.st_size)
+    offsets = (0, max(0, (size - SAMPLE_BYTES) // 2),
+               max(0, size - SAMPLE_BYTES))
+    digest = hashlib.sha256()
+    with open(path, 'rb') as stream:
+        for offset in offsets:
+            if cancelled is not None and cancelled():
+                return None
+            stream.seek(offset)
+            digest.update(stream.read(SAMPLE_BYTES))
+    return VideoFingerprint(size, int(stat.st_mtime_ns), digest.hexdigest())
+
+
+def _connect(path):
+    connection = sqlite3.connect(path, timeout=5.0)
+    connection.execute('PRAGMA foreign_keys=ON')
+    connection.execute('PRAGMA busy_timeout=5000')
+    connection.execute('PRAGMA synchronous=FULL')
+    return connection
+
+
+def _validate_existing(path):
+    uri = 'file:%s?mode=ro' % os.path.abspath(path)
+    connection = sqlite3.connect(uri, uri=True, timeout=5.0)
+    try:
+        application_id = connection.execute(
+            'PRAGMA application_id').fetchone()[0]
+        version = connection.execute('PRAGMA user_version').fetchone()[0]
+    finally:
+        connection.close()
+    if application_id != APPLICATION_ID:
+        raise UnknownProjectError(
+            'not a LabelImg++ video project (application id %s)' %
+            application_id)
+    if version > SCHEMA_VERSION:
+        raise NewerSchemaError(
+            'project schema %s is newer than supported schema %s' %
+            (version, SCHEMA_VERSION))
+    if version != SCHEMA_VERSION:
+        raise UnknownProjectError(
+            'unsupported LabelImg++ video project schema %s' % version)
+
+
+def _schema_sql():
+    return """
+    CREATE TABLE project_meta (
+        singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+        schema_version INTEGER NOT NULL,
+        durable_revision INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE TABLE video_source (
+        singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+        relative_path TEXT,
+        absolute_path TEXT NOT NULL,
+        fingerprint_size INTEGER NOT NULL,
+        fingerprint_mtime_ns INTEGER NOT NULL,
+        fingerprint_sha256 TEXT NOT NULL,
+        stream_index INTEGER NOT NULL,
+        time_base_num INTEGER NOT NULL,
+        time_base_den INTEGER NOT NULL,
+        duration_pts INTEGER,
+        width INTEGER NOT NULL,
+        height INTEGER NOT NULL,
+        rotation INTEGER NOT NULL,
+        codec TEXT NOT NULL
+    );
+    CREATE TABLE classes (
+        class_index INTEGER PRIMARY KEY,
+        label TEXT NOT NULL UNIQUE
+    );
+    CREATE TABLE tracks (
+        track_id TEXT PRIMARY KEY,
+        label TEXT NOT NULL,
+        shape_type TEXT NOT NULL CHECK (shape_type IN ('rectangle', 'polygon')),
+        color_json TEXT NOT NULL,
+        difficult INTEGER NOT NULL DEFAULT 0 CHECK (difficult IN (0, 1)),
+        revision INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE TABLE observations (
+        track_id TEXT NOT NULL REFERENCES tracks(track_id) ON DELETE CASCADE,
+        pts INTEGER NOT NULL,
+        geometry_json TEXT,
+        keypoints_json TEXT,
+        present INTEGER NOT NULL DEFAULT 1 CHECK (present IN (0, 1)),
+        source TEXT NOT NULL CHECK (source IN ('manual', 'tracker')),
+        review_state TEXT NOT NULL CHECK (
+            review_state IN ('accepted', 'pending', 'rejected')),
+        anchor INTEGER NOT NULL DEFAULT 0 CHECK (anchor IN (0, 1)),
+        quality REAL,
+        revision INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (track_id, pts)
+    );
+    CREATE TABLE interpolation_segments (
+        track_id TEXT NOT NULL REFERENCES tracks(track_id) ON DELETE CASCADE,
+        start_pts INTEGER NOT NULL,
+        end_pts INTEGER NOT NULL,
+        PRIMARY KEY (track_id, start_pts, end_pts)
+    );
+    CREATE TABLE frame_state (
+        pts INTEGER PRIMARY KEY,
+        verified INTEGER NOT NULL DEFAULT 0 CHECK (verified IN (0, 1)),
+        revision INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE INDEX observations_pts_idx ON observations(pts);
+    CREATE INDEX observations_review_idx
+        ON observations(review_state, pts);
+    """
+
+
+def initialize_project(path, session):
+    """Create schema v1 after a source and its first frame were decoded."""
+    path = os.path.abspath(os.fspath(path))
+    if os.path.exists(path):
+        _validate_existing(path)
+        return load_project(path)
+    parent = os.path.dirname(path) or '.'
+    os.makedirs(parent, exist_ok=True)
+    connection = _connect(path)
+    try:
+        connection.execute('PRAGMA journal_mode=WAL')
+        connection.execute('BEGIN IMMEDIATE')
+        connection.executescript(_schema_sql())
+        connection.execute('PRAGMA application_id=%d' % APPLICATION_ID)
+        connection.execute('PRAGMA user_version=%d' % SCHEMA_VERSION)
+        connection.execute(
+            'INSERT INTO project_meta '
+            '(singleton, schema_version, durable_revision) VALUES (1, ?, 0)',
+            (SCHEMA_VERSION,))
+        source = os.path.abspath(session.source_path)
+        try:
+            relative = os.path.relpath(source, os.path.dirname(path))
+        except ValueError:
+            relative = None
+        connection.execute(
+            'INSERT INTO video_source ('
+            'singleton, relative_path, absolute_path, fingerprint_size, '
+            'fingerprint_mtime_ns, fingerprint_sha256, stream_index, '
+            'time_base_num, time_base_den, duration_pts, width, height, '
+            'rotation, codec) VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            (relative, source, session.fingerprint.size,
+             session.fingerprint.mtime_ns,
+             session.fingerprint.sampled_sha256, session.stream_index,
+             session.time_base_num, session.time_base_den,
+             session.duration_pts, session.width, session.height,
+             session.rotation, session.codec))
+        connection.commit()
+    except Exception:
+        connection.rollback()
+        connection.close()
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+        raise
+    finally:
+        if connection:
+            connection.close()
+    return load_project(path)
+
+
+def validate_project_source(path, source_path, fingerprint, update_path=True):
+    """Validate content and optionally repair a moved source path."""
+    _validate_existing(path)
+    connection = _connect(path)
+    try:
+        row = connection.execute(
+            'SELECT fingerprint_size, fingerprint_mtime_ns, '
+            'fingerprint_sha256, absolute_path FROM video_source '
+            'WHERE singleton=1').fetchone()
+        stored = VideoFingerprint(int(row[0]), int(row[1]), row[2])
+        if not stored.content_matches(fingerprint):
+            raise VideoSourceChanged(
+                'video content does not match the project fingerprint')
+        source_path = os.path.abspath(source_path)
+        if update_path and source_path != os.path.abspath(row[3]):
+            relative = os.path.relpath(source_path, os.path.dirname(path))
+            with connection:
+                connection.execute(
+                    'UPDATE video_source SET relative_path=?, '
+                    'absolute_path=?, fingerprint_mtime_ns=? '
+                    'WHERE singleton=1',
+                    (relative, source_path, fingerprint.mtime_ns))
+    finally:
+        connection.close()
+
+
+def read_project_source(path):
+    _validate_existing(path)
+    connection = _connect(path)
+    try:
+        row = connection.execute(
+            'SELECT relative_path, absolute_path, fingerprint_size, '
+            'fingerprint_mtime_ns, fingerprint_sha256, stream_index, '
+            'time_base_num, time_base_den FROM video_source '
+            'WHERE singleton=1').fetchone()
+    finally:
+        connection.close()
+    if row is None:
+        raise UnknownProjectError('project has no video source')
+    relative_path, absolute_path = row[0], row[1]
+    candidates = []
+    if relative_path:
+        candidates.append(os.path.abspath(os.path.join(
+            os.path.dirname(path), relative_path)))
+    candidates.append(os.path.abspath(absolute_path))
+    source_path = next((item for item in candidates if os.path.isfile(item)),
+                       candidates[0])
+    return ProjectSource(
+        relative_path, source_path,
+        VideoFingerprint(int(row[2]), int(row[3]), row[4]),
+        int(row[5]), int(row[6]), int(row[7]))
+
+
+def _track_from_row(row):
+    return TrackRecord(
+        track_id=row[0], label=row[1], shape_type=row[2],
+        color=tuple(json.loads(row[3])), difficult=bool(row[4]),
+        revision=int(row[5]))
+
+
+def _observation_from_row(row):
+    return ObservationRecord(
+        track_id=row[0], pts=int(row[1]),
+        geometry=(json.loads(row[2]) if row[2] is not None else None),
+        keypoints=(json.loads(row[3]) if row[3] is not None else None),
+        present=bool(row[4]), source=row[5], review_state=row[6],
+        anchor=bool(row[7]), quality=row[8], revision=int(row[9]))
+
+
+def load_project(path):
+    _validate_existing(path)
+    connection = _connect(path)
+    try:
+        revision = int(connection.execute(
+            'SELECT durable_revision FROM project_meta WHERE singleton=1'
+        ).fetchone()[0])
+        tracks = tuple(_track_from_row(row) for row in connection.execute(
+            'SELECT track_id, label, shape_type, color_json, difficult, '
+            'revision FROM tracks ORDER BY rowid'))
+        observations = tuple(_observation_from_row(row) for row in
+                             connection.execute(
+            'SELECT track_id, pts, geometry_json, keypoints_json, present, '
+            'source, review_state, anchor, quality, revision '
+            'FROM observations ORDER BY pts, track_id'))
+        frame_states = tuple(FrameStateRecord(int(row[0]), bool(row[1]),
+                                              int(row[2])) for row in
+                             connection.execute(
+            'SELECT pts, verified, revision FROM frame_state ORDER BY pts'))
+        classes = tuple(row[0] for row in connection.execute(
+            'SELECT label FROM classes ORDER BY class_index'))
+        return ProjectContents(
+            revision, tracks, observations, frame_states, classes)
+    finally:
+        connection.close()
+
+
+def _rebuild_segments(connection, track_id):
+    connection.execute(
+        'DELETE FROM interpolation_segments WHERE track_id=?', (track_id,))
+    rows = connection.execute(
+        "SELECT pts, present FROM observations WHERE track_id=? "
+        "AND source='manual' AND review_state='accepted' AND anchor=1 "
+        'ORDER BY pts', (track_id,)).fetchall()
+    for previous, current in zip(rows, rows[1:]):
+        if bool(previous[1]) and bool(current[1]):
+            connection.execute(
+                'INSERT INTO interpolation_segments '
+                '(track_id, start_pts, end_pts) VALUES (?, ?, ?)',
+                (track_id, int(previous[0]), int(current[0])))
+
+
+def save_project_delta(request, cancelled=None, begin_commit=None):
+    """Apply one immutable revision delta in a guarded transaction."""
+    _validate_existing(request.project_path)
+    if cancelled is not None and cancelled():
+        return None
+    connection = _connect(request.project_path)
+    try:
+        connection.execute('PRAGMA journal_mode=WAL')
+        connection.execute('BEGIN IMMEDIATE')
+        revision = int(connection.execute(
+            'SELECT durable_revision FROM project_meta WHERE singleton=1'
+        ).fetchone()[0])
+        if revision != request.expected_durable_revision:
+            raise ProjectRevisionConflict(
+                'expected durable revision %s, found %s' %
+                (request.expected_durable_revision, revision))
+        for track_id, pts in request.deleted_observations:
+            connection.execute(
+                'DELETE FROM observations WHERE track_id=? AND pts=?',
+                (track_id, int(pts)))
+        for track_id in request.deleted_tracks:
+            connection.execute(
+                'DELETE FROM tracks WHERE track_id=?', (track_id,))
+        for track in request.tracks:
+            connection.execute(
+                'INSERT INTO tracks (track_id, label, shape_type, '
+                'color_json, difficult, revision) VALUES (?, ?, ?, ?, ?, ?) '
+                'ON CONFLICT(track_id) DO UPDATE SET label=excluded.label, '
+                'shape_type=excluded.shape_type, color_json=excluded.color_json, '
+                'difficult=excluded.difficult, revision=excluded.revision',
+                (track.track_id, track.label, track.shape_type,
+                 json.dumps(list(track.color), separators=(',', ':')),
+                 int(track.difficult), int(track.revision)))
+        for observation in request.observations:
+            connection.execute(
+                'INSERT INTO observations (track_id, pts, geometry_json, '
+                'keypoints_json, present, source, review_state, anchor, '
+                'quality, revision) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) '
+                'ON CONFLICT(track_id, pts) DO UPDATE SET '
+                'geometry_json=excluded.geometry_json, '
+                'keypoints_json=excluded.keypoints_json, '
+                'present=excluded.present, source=excluded.source, '
+                'review_state=excluded.review_state, anchor=excluded.anchor, '
+                'quality=excluded.quality, revision=excluded.revision',
+                (observation.track_id, int(observation.pts),
+                 (json.dumps(observation.geometry, separators=(',', ':'))
+                  if observation.geometry is not None else None),
+                 (json.dumps(observation.keypoints, separators=(',', ':'))
+                  if observation.keypoints is not None else None),
+                 int(observation.present), observation.source,
+                 observation.review_state, int(observation.anchor),
+                 observation.quality, int(observation.revision)))
+        for state in request.frame_states:
+            connection.execute(
+                'INSERT INTO frame_state (pts, verified, revision) '
+                'VALUES (?, ?, ?) ON CONFLICT(pts) DO UPDATE SET '
+                'verified=excluded.verified, revision=excluded.revision',
+                (int(state.pts), int(state.verified), int(state.revision)))
+        if request.classes:
+            connection.execute('DELETE FROM classes')
+            connection.executemany(
+                'INSERT INTO classes (class_index, label) VALUES (?, ?)',
+                tuple(enumerate(request.classes)))
+        touched = set(request.touched_tracks)
+        touched.update(item.track_id for item in request.observations)
+        touched.update(item.track_id for item in request.tracks)
+        for track_id in sorted(touched):
+            if connection.execute(
+                    'SELECT 1 FROM tracks WHERE track_id=?',
+                    (track_id,)).fetchone():
+                _rebuild_segments(connection, track_id)
+        connection.execute(
+            'UPDATE project_meta SET durable_revision=? WHERE singleton=1',
+            (int(request.target_revision),))
+        if cancelled is not None and cancelled():
+            connection.rollback()
+            return None
+        if begin_commit is not None:
+            begin_commit()
+        connection.commit()
+        return request.target_revision
+    except Exception:
+        connection.rollback()
+        raise
+    finally:
+        connection.close()
+
+
+def checkpoint_project(path):
+    _validate_existing(path)
+    connection = _connect(path)
+    try:
+        connection.execute('PRAGMA wal_checkpoint(TRUNCATE)').fetchall()
+    finally:
+        connection.close()
+
+
+def save_project_as(source, destination):
+    """Use SQLite backup so a live WAL project is copied consistently."""
+    _validate_existing(source)
+    destination = os.path.abspath(destination)
+    if os.path.exists(destination):
+        raise VideoProjectError('destination project already exists')
+    os.makedirs(os.path.dirname(destination) or '.', exist_ok=True)
+    source_connection = _connect(source)
+    destination_connection = _connect(destination)
+    try:
+        source_connection.backup(destination_connection)
+    except Exception:
+        destination_connection.close()
+        try:
+            os.remove(destination)
+        except OSError:
+            pass
+        raise
+    finally:
+        source_connection.close()
+        try:
+            destination_connection.close()
+        except Exception:
+            pass
+    _validate_existing(destination)
+    return destination
+
+
+def remove_owned_staging_tree(path):
+    """Small shared helper; only explicitly owned staging trees are removed."""
+    if os.path.basename(path).startswith('.labelimgpp-export-'):
+        shutil.rmtree(path, ignore_errors=True)

--- a/libs/core/video_session.py
+++ b/libs/core/video_session.py
@@ -1,5 +1,6 @@
 """Transactional video/project opening orchestration."""
 
+from dataclasses import dataclass
 import os
 
 from libs.core.video_decoder import PreparedVideoOpen, VideoDecoderSession
@@ -10,18 +11,25 @@ from libs.core.video_project import (
 )
 
 
+@dataclass(frozen=True)
+class VideoOpenProblem:
+    kind: str
+    message: str
+
+
 def is_video_project(path):
     return os.fspath(path).lower().endswith(PROJECT_SUFFIX)
 
 
 def prepare_video_open(path, project_path=None, read_only=False,
-                       cancelled=None):
+                       cancelled=None, source_override=None):
     """Fully prepare a new session without mutating application state."""
     requested = os.path.abspath(os.fspath(path))
     if is_video_project(requested):
         project_path = requested
         source = read_project_source(project_path)
-        source_path = source.absolute_path
+        source_path = (os.path.abspath(os.fspath(source_override))
+                       if source_override else source.absolute_path)
         if not os.path.isfile(source_path):
             raise VideoSourceMissing(
                 'video source is missing: %s' % source_path)

--- a/libs/core/video_session.py
+++ b/libs/core/video_session.py
@@ -1,0 +1,63 @@
+"""Transactional video/project opening orchestration."""
+
+import os
+
+from libs.core.video_decoder import PreparedVideoOpen, VideoDecoderSession
+from libs.core.video_project import (
+    PROJECT_SUFFIX, VideoSourceMissing, default_project_path,
+    initialize_project, load_project, read_project_source,
+    validate_project_source,
+)
+
+
+def is_video_project(path):
+    return os.fspath(path).lower().endswith(PROJECT_SUFFIX)
+
+
+def prepare_video_open(path, project_path=None, read_only=False,
+                       cancelled=None):
+    """Fully prepare a new session without mutating application state."""
+    requested = os.path.abspath(os.fspath(path))
+    if is_video_project(requested):
+        project_path = requested
+        source = read_project_source(project_path)
+        source_path = source.absolute_path
+        if not os.path.isfile(source_path):
+            raise VideoSourceMissing(
+                'video source is missing: %s' % source_path)
+        stream_index = source.stream_index
+    else:
+        source_path = requested
+        stream_index = None
+        if project_path is None and not read_only:
+            project_path = default_project_path(source_path)
+    decoder = VideoDecoderSession(
+        source_path, stream_index=stream_index, cancelled=cancelled)
+    try:
+        initial = decoder.decode_first(cancelled=cancelled)
+        if cancelled is not None and cancelled():
+            raise RuntimeError('video opening was cancelled')
+        if project_path is None:
+            contents = None
+            revision = 0
+        elif os.path.exists(project_path):
+            validate_project_source(
+                project_path, source_path, decoder.fingerprint,
+                update_path=not read_only)
+            contents = load_project(project_path)
+            revision = contents.revision
+        else:
+            draft = decoder.snapshot(project_path, initial, read_only=read_only)
+            contents = initialize_project(project_path, draft)
+            revision = contents.revision
+        snapshot = decoder.snapshot(
+            project_path, initial, revision=revision, read_only=read_only)
+        return PreparedVideoOpen(
+            snapshot=snapshot, decoder=decoder,
+            tracks=contents.tracks if contents else (),
+            observations=contents.observations if contents else (),
+            frame_states=contents.frame_states if contents else (),
+            classes=contents.classes if contents else ())
+    except Exception:
+        decoder.close()
+        raise

--- a/libs/core/video_tracking.py
+++ b/libs/core/video_tracking.py
@@ -1,0 +1,284 @@
+"""Cancellable rectangle propagation using standard OpenCV optical flow."""
+
+import math
+import time
+
+from libs.core.video_decoder import (
+    _oriented_array, _rotation_for_stream, load_video_dependencies,
+)
+from libs.core.video_types import ObservationRecord, TrackingBatch
+
+
+MAX_WORKING_EDGE = 1280
+MAX_FEATURES = 100
+MAX_FB_ERROR = 2.0
+MIN_INLIERS = 8
+MIN_INLIER_RATIO = .5
+MIN_HISTOGRAM_CORRELATION = .5
+BACKWARD_CHUNK_SECONDS = 2.0
+
+
+def _working_frame(frame, rotation, cv2, np):
+    array = _oriented_array(frame, rotation, np)
+    height, width = array.shape[:2]
+    scale = min(1.0, MAX_WORKING_EDGE / max(width, height))
+    if scale < 1.0:
+        array = cv2.resize(
+            array, (max(1, int(round(width * scale))),
+                    max(1, int(round(height * scale)))),
+            interpolation=cv2.INTER_AREA)
+    gray = cv2.cvtColor(array, cv2.COLOR_RGB2GRAY)
+    return gray, scale, width, height
+
+
+def _histogram(gray, cv2):
+    histogram = cv2.calcHist([gray], [0], None, [64], [0, 256])
+    return cv2.normalize(histogram, histogram).flatten()
+
+
+def _feature_points(gray, rectangle, cv2, np):
+    xmin, ymin, xmax, ymax = rectangle
+    height, width = gray.shape[:2]
+    x0 = max(0, min(width, int(math.floor(xmin))))
+    y0 = max(0, min(height, int(math.floor(ymin))))
+    x1 = max(0, min(width, int(math.ceil(xmax))))
+    y1 = max(0, min(height, int(math.ceil(ymax))))
+    if x1 - x0 < 4 or y1 - y0 < 4:
+        return None
+    mask = np.zeros_like(gray, dtype=np.uint8)
+    mask[y0:y1, x0:x1] = 255
+    return cv2.goodFeaturesToTrack(
+        gray, mask=mask, maxCorners=MAX_FEATURES,
+        qualityLevel=.01, minDistance=3, blockSize=3)
+
+
+def _transform_rectangle(rectangle, matrix, cv2, np):
+    xmin, ymin, xmax, ymax = rectangle
+    corners = np.asarray([[
+        [xmin, ymin], [xmax, ymin], [xmax, ymax], [xmin, ymax],
+    ]], dtype=np.float32)
+    transformed = cv2.transform(corners, matrix)[0]
+    return [
+        float(transformed[:, 0].min()),
+        float(transformed[:, 1].min()),
+        float(transformed[:, 0].max()),
+        float(transformed[:, 1].max()),
+    ]
+
+
+def _inside_ratio(rectangle, width, height):
+    xmin, ymin, xmax, ymax = rectangle
+    area = max(0.0, xmax - xmin) * max(0.0, ymax - ymin)
+    if area <= 0:
+        return 0.0
+    inside = max(0.0, min(width, xmax) - max(0.0, xmin)) * \
+        max(0.0, min(height, ymax) - max(0.0, ymin))
+    return inside / area
+
+
+def _transform_keypoints(keypoints, matrix, scale, cv2, np):
+    if keypoints is None:
+        return None
+    result = list(keypoints)
+    valid = [(index, item) for index, item in enumerate(keypoints)
+             if item is not None]
+    if not valid:
+        return result
+    points = np.asarray([[[item[0] * scale, item[1] * scale]
+                          for _index, item in valid]], dtype=np.float32)
+    transformed = cv2.transform(points, matrix)[0]
+    for output, (index, item) in zip(transformed, valid):
+        result[index] = [float(output[0] / scale),
+                         float(output[1] / scale), item[2]]
+    return result
+
+
+def _propagate_pair(previous_gray, current_gray, rectangle, points,
+                    cv2, np):
+    if points is None or len(points) < MIN_INLIERS:
+        return None, 'insufficient features'
+    forward, status_forward, _error = cv2.calcOpticalFlowPyrLK(
+        previous_gray, current_gray, points, None,
+        winSize=(21, 21), maxLevel=3,
+        criteria=(cv2.TERM_CRITERIA_EPS | cv2.TERM_CRITERIA_COUNT,
+                  30, .01))
+    if forward is None:
+        return None, 'optical flow failed'
+    backward, status_backward, _error = cv2.calcOpticalFlowPyrLK(
+        current_gray, previous_gray, forward, None,
+        winSize=(21, 21), maxLevel=3,
+        criteria=(cv2.TERM_CRITERIA_EPS | cv2.TERM_CRITERIA_COUNT,
+                  30, .01))
+    if backward is None:
+        return None, 'backward optical flow failed'
+    fb_error = np.linalg.norm(points - backward, axis=2).reshape(-1)
+    valid = ((status_forward.reshape(-1) == 1)
+             & (status_backward.reshape(-1) == 1)
+             & (fb_error <= MAX_FB_ERROR))
+    source = points.reshape(-1, 2)[valid]
+    target = forward.reshape(-1, 2)[valid]
+    if len(source) < MIN_INLIERS:
+        return None, 'insufficient forward/backward matches'
+    matrix, inlier_mask = cv2.estimateAffinePartial2D(
+        source, target, method=cv2.RANSAC,
+        ransacReprojThreshold=2.0, maxIters=2000,
+        confidence=.99, refineIters=10)
+    if matrix is None or inlier_mask is None:
+        return None, 'affine estimation failed'
+    inliers = int(inlier_mask.sum())
+    ratio = inliers / len(source)
+    if inliers < MIN_INLIERS or ratio < MIN_INLIER_RATIO:
+        return None, 'insufficient affine inliers'
+    median_error = float(np.median(fb_error[valid]))
+    if median_error > MAX_FB_ERROR:
+        return None, 'median flow error exceeded 2 pixels'
+    scale = math.sqrt(matrix[0, 0] ** 2 + matrix[0, 1] ** 2)
+    if not .7 <= scale <= 1.4:
+        return None, 'per-step scale left 0.7-1.4'
+    transformed = _transform_rectangle(rectangle, matrix, cv2, np)
+    quality = max(0.0, min(1.0, ratio *
+                           (1.0 - median_error / (MAX_FB_ERROR + 1e-9))))
+    return (transformed, matrix, target.reshape(-1, 1, 2), quality), None
+
+
+def _decoded_frames(container, stream, start_pts, end_pts, rotation,
+                    cv2, np, handle):
+    container.seek(
+        int(start_pts), stream=stream, backward=True, any_frame=False)
+    for frame in container.decode(stream):
+        handle.check_cancelled()
+        if frame.pts is None or frame.pts < start_pts:
+            continue
+        if frame.pts > end_pts:
+            break
+        gray, scale, width, height = _working_frame(
+            frame, rotation, cv2, np)
+        yield int(frame.pts), gray, scale, width, height
+
+
+def _ordered_frames(container, stream, request, rotation, cv2, np, handle):
+    if request.direction > 0:
+        yield from _decoded_frames(
+            container, stream, request.start_ref.pts, request.end_pts,
+            rotation, cv2, np, handle)
+        return
+    time_base = float(stream.time_base)
+    chunk_pts = max(1, int(round(BACKWARD_CHUNK_SECONDS / time_base)))
+    cursor = request.start_ref.pts
+    first_chunk = True
+    while cursor > request.end_pts:
+        handle.check_cancelled()
+        chunk_start = max(request.end_pts, cursor - chunk_pts)
+        frames = list(_decoded_frames(
+            container, stream, chunk_start, cursor, rotation,
+            cv2, np, handle))
+        for value in reversed(frames):
+            if value[0] < cursor or (first_chunk and value[0] == cursor):
+                yield value
+        first_chunk = False
+        cursor = chunk_start
+
+
+def track_optical_flow(request, handle):
+    """Run one propagation and return/emit non-overlapping pending batches."""
+    av, np = load_video_dependencies()
+    try:
+        import cv2
+    except ImportError as exc:
+        raise RuntimeError(
+            'Optical-flow tracking requires labelimgplusplus[video]: %s' %
+            exc)
+    if request.track.shape_type != 'rectangle' \
+            or not request.seed.present \
+            or request.seed.geometry is None \
+            or len(request.seed.geometry) != 4:
+        raise ValueError('tracking requires an accepted rectangle seed')
+    cv2.setRNGSeed(0)
+    container = av.open(request.source_path, mode='r')
+    try:
+        stream = next((item for item in container.streams.video
+                       if item.index == request.stream_index), None)
+        if stream is None:
+            raise ValueError('video stream is no longer available')
+        rotation = _rotation_for_stream(stream)
+        frames = _ordered_frames(
+            container, stream, request, rotation, cv2, np, handle)
+        first = next(frames, None)
+        if first is None:
+            return TrackingBatch(
+                request.request_id, request.generation,
+                request.track.track_id, request.seed_track_revision,
+                request.document_revision, request.start_ref.pts,
+                request.start_ref.pts, (), finished=True,
+                stop_reason='no frames in range')
+        _first_pts, previous_gray, working_scale, width, height = first
+        rectangle = [float(value) * working_scale
+                     for value in request.seed.geometry]
+        keypoints = request.seed.keypoints
+        points = _feature_points(previous_gray, rectangle, cv2, np)
+        previous_histogram = _histogram(previous_gray, cv2)
+        pending = []
+        batch_start = request.start_ref.pts
+        last_emit = time.monotonic()
+        stop_reason = 'end of range'
+        step_index = 0
+        last_pts = request.start_ref.pts
+        for pts, current_gray, scale, width, height in frames:
+            handle.check_cancelled()
+            if pts == request.start_ref.pts:
+                continue
+            if abs(scale - working_scale) > 1e-9:
+                stop_reason = 'working scale changed'
+                break
+            correlation = cv2.compareHist(
+                previous_histogram, _histogram(current_gray, cv2),
+                cv2.HISTCMP_CORREL)
+            if correlation < MIN_HISTOGRAM_CORRELATION:
+                stop_reason = 'scene cut'
+                break
+            propagated, reason = _propagate_pair(
+                previous_gray, current_gray, rectangle, points, cv2, np)
+            if propagated is None:
+                stop_reason = reason
+                break
+            rectangle, matrix, points, quality = propagated
+            if rectangle[2] - rectangle[0] < 4 \
+                    or rectangle[3] - rectangle[1] < 4:
+                stop_reason = 'rectangle became smaller than 4 pixels'
+                break
+            if _inside_ratio(rectangle, current_gray.shape[1],
+                             current_gray.shape[0]) < .5:
+                stop_reason = 'less than half the rectangle remains in frame'
+                break
+            keypoints = _transform_keypoints(
+                keypoints, matrix, working_scale, cv2, np)
+            observation = ObservationRecord(
+                request.track.track_id, pts,
+                [value / working_scale for value in rectangle],
+                keypoints=keypoints, present=True, source='tracker',
+                review_state='pending', anchor=False, quality=quality,
+                revision=request.document_revision)
+            pending.append(observation)
+            last_pts = pts
+            step_index += 1
+            previous_gray = current_gray
+            previous_histogram = _histogram(current_gray, cv2)
+            if step_index % 5 == 0:
+                points = _feature_points(
+                    current_gray, rectangle, cv2, np)
+            if time.monotonic() - last_emit >= .25:
+                handle.report_progress(TrackingBatch(
+                    request.request_id, request.generation,
+                    request.track.track_id, request.seed_track_revision,
+                    request.document_revision, batch_start, last_pts,
+                    tuple(pending)))
+                pending = []
+                batch_start = last_pts
+                last_emit = time.monotonic()
+        return TrackingBatch(
+            request.request_id, request.generation,
+            request.track.track_id, request.seed_track_revision,
+            request.document_revision, batch_start, last_pts,
+            tuple(pending), finished=True, stop_reason=stop_reason)
+    finally:
+        container.close()

--- a/libs/core/video_tracking.py
+++ b/libs/core/video_tracking.py
@@ -4,7 +4,8 @@ import math
 import time
 
 from libs.core.video_decoder import (
-    _oriented_array, _rotation_for_stream, load_video_dependencies,
+    _oriented_array, _rotation_for_frame, _rotation_for_stream,
+    load_video_dependencies,
 )
 from libs.core.video_types import ObservationRecord, TrackingBatch
 
@@ -151,8 +152,9 @@ def _decoded_frames(container, stream, start_pts, end_pts, rotation,
             continue
         if frame.pts > end_pts:
             break
+        frame_rotation = _rotation_for_frame(frame, rotation)
         gray, scale, width, height = _working_frame(
-            frame, rotation, cv2, np)
+            frame, frame_rotation, cv2, np)
         yield int(frame.pts), gray, scale, width, height
 
 
@@ -266,7 +268,9 @@ def track_optical_flow(request, handle):
             if step_index % 5 == 0:
                 points = _feature_points(
                     current_gray, rectangle, cv2, np)
-            if time.monotonic() - last_emit >= .25:
+            # Leave scheduling headroom so observers receive progress at
+            # least once per 250 ms rather than just after that boundary.
+            if time.monotonic() - last_emit >= .20:
                 handle.report_progress(TrackingBatch(
                     request.request_id, request.generation,
                     request.track.track_id, request.seed_track_revision,

--- a/libs/core/video_types.py
+++ b/libs/core/video_types.py
@@ -1,0 +1,180 @@
+"""Immutable contracts shared by smart-video workers and the Qt UI.
+
+This module intentionally imports no optional video dependency.  Base installs
+can import the application, inspect projects, and show a useful installation
+hint without importing PyAV, NumPy, or OpenCV.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class DocumentKind(Enum):
+    NONE = 'none'
+    IMAGE = 'image'
+    VIDEO = 'video'
+
+
+@dataclass(frozen=True)
+class VideoFingerprint:
+    size: int
+    mtime_ns: int
+    sampled_sha256: str
+
+    def content_matches(self, other):
+        """Return whether *other* is the same sampled media content."""
+        return (
+            isinstance(other, VideoFingerprint)
+            and self.size == other.size
+            and self.sampled_sha256 == other.sampled_sha256
+        )
+
+
+@dataclass(frozen=True)
+class VideoFrameRef:
+    fingerprint: VideoFingerprint
+    stream_index: int
+    pts: int
+    time_base_num: int
+    time_base_den: int
+
+    @property
+    def seconds(self):
+        return self.pts * self.time_base_num / self.time_base_den
+
+    @property
+    def cache_key(self):
+        return (
+            'video', self.fingerprint.size,
+            self.fingerprint.sampled_sha256, self.stream_index,
+            self.pts, self.time_base_num, self.time_base_den,
+        )
+
+
+@dataclass(frozen=True)
+class VideoFrameResult:
+    frame_ref: VideoFrameRef
+    image: object
+    display_width: int
+    display_height: int
+    original_width: int
+    original_height: int
+    rotation: int
+    byte_size: int
+    decode_fingerprint: str
+
+    @property
+    def cache_key(self):
+        return self.frame_ref.cache_key
+
+
+@dataclass(frozen=True)
+class VideoSessionSnapshot:
+    source_path: str
+    project_path: object
+    fingerprint: VideoFingerprint
+    stream_index: int
+    time_base_num: int
+    time_base_den: int
+    width: int
+    height: int
+    rotation: int
+    codec: str
+    duration_pts: object
+    start_pts: object
+    average_rate_num: object
+    average_rate_den: object
+    revision: int
+    initial_frame: VideoFrameResult
+    read_only: bool = False
+
+
+@dataclass(frozen=True)
+class TrackRecord:
+    track_id: str
+    label: str
+    shape_type: str
+    color: tuple
+    difficult: bool = False
+    revision: int = 0
+
+
+@dataclass(frozen=True)
+class ObservationRecord:
+    track_id: str
+    pts: int
+    geometry: object
+    keypoints: object = None
+    present: bool = True
+    source: str = 'manual'
+    review_state: str = 'accepted'
+    anchor: bool = True
+    quality: object = None
+    revision: int = 0
+
+
+@dataclass(frozen=True)
+class FrameStateRecord:
+    pts: int
+    verified: bool
+    revision: int = 0
+
+
+@dataclass(frozen=True)
+class VideoSaveRequest:
+    project_path: str
+    expected_durable_revision: int
+    target_revision: int
+    tracks: tuple = ()
+    observations: tuple = ()
+    deleted_observations: tuple = ()
+    deleted_tracks: tuple = ()
+    frame_states: tuple = ()
+    classes: tuple = ()
+    touched_tracks: tuple = ()
+
+
+@dataclass(frozen=True)
+class TrackingRequest:
+    request_id: int
+    generation: int
+    source_path: str
+    stream_index: int
+    start_ref: VideoFrameRef
+    end_pts: int
+    direction: int
+    track: TrackRecord
+    seed: ObservationRecord
+    seed_track_revision: int
+    document_revision: int
+
+
+@dataclass(frozen=True)
+class TrackingBatch:
+    request_id: int
+    generation: int
+    track_id: str
+    seed_track_revision: int
+    document_revision: int
+    start_pts: int
+    end_pts: int
+    observations: tuple
+    finished: bool = False
+    stop_reason: object = None
+
+
+@dataclass(frozen=True)
+class VideoExportRequest:
+    source_path: str
+    project_path: str
+    destination: str
+    stream_index: int
+    frame_refs: tuple
+    observations: tuple
+    tracks: tuple
+    frame_states: tuple
+    annotation_format: object
+    image_format: str = 'jpg'
+    jpeg_quality: int = 95
+    class_order: tuple = ()
+

--- a/libs/core/video_types.py
+++ b/libs/core/video_types.py
@@ -177,4 +177,6 @@ class VideoExportRequest:
     image_format: str = 'jpg'
     jpeg_quality: int = 95
     class_order: tuple = ()
-
+    range_start_pts: object = None
+    range_end_pts: object = None
+    sample_every_frames: object = None

--- a/libs/widgets/__init__.py
+++ b/libs/widgets/__init__.py
@@ -17,3 +17,6 @@ __all__ = [
     'LabelDialog', 'ColorDialog', 'ZoomWidget', 'LightWidget',
     'ComboBox', 'DefaultLabelComboBox',
 ]
+from libs.widgets.videoTimelineWidget import VideoTimelineWidget
+
+__all__ = ['VideoTimelineWidget']

--- a/libs/widgets/videoExportDialog.py
+++ b/libs/widgets/videoExportDialog.py
@@ -1,0 +1,116 @@
+"""Export selection dialog for smart-video projects."""
+
+from PyQt5.QtWidgets import (
+    QComboBox, QDialog, QDialogButtonBox, QFileDialog, QFormLayout,
+    QHBoxLayout, QLineEdit, QPushButton, QSpinBox, QDoubleSpinBox,
+    QVBoxLayout, QWidget,
+)
+
+from libs.formats.labelFile import LabelFileFormat
+
+
+class VideoExportDialog(QDialog):
+    def __init__(self, current_format, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle('Export Video Frames')
+        self.destination = QLineEdit()
+        browse = QPushButton('Browse…')
+        browse.clicked.connect(self._browse)
+        destination_row = QWidget()
+        destination_layout = QHBoxLayout(destination_row)
+        destination_layout.setContentsMargins(0, 0, 0, 0)
+        destination_layout.addWidget(self.destination)
+        destination_layout.addWidget(browse)
+
+        self.selection = QComboBox()
+        self.selection.addItem('Current frame', 'current')
+        self.selection.addItem('Annotated frames', 'annotated')
+        self.selection.addItem('Verified frames', 'verified')
+        self.selection.addItem('Time range', 'range')
+        self.selection.setCurrentIndex(1)
+        self.start_time = QLineEdit('00:00:00.000')
+        self.end_time = QLineEdit('00:00:05.000')
+        self.sample_unit = QComboBox()
+        self.sample_unit.addItem('frames', 'frames')
+        self.sample_unit.addItem('seconds', 'seconds')
+        self.sample_frames = QSpinBox()
+        self.sample_frames.setRange(1, 1000000)
+        self.sample_frames.setValue(1)
+        self.sample_seconds = QDoubleSpinBox()
+        self.sample_seconds.setRange(.001, 86400)
+        self.sample_seconds.setDecimals(3)
+        self.sample_seconds.setValue(1.0)
+
+        self.image_format = QComboBox()
+        self.image_format.addItem('JPEG (quality 95)', 'jpg')
+        self.image_format.addItem('PNG (lossless)', 'png')
+        self.jpeg_quality = QSpinBox()
+        self.jpeg_quality.setRange(1, 100)
+        self.jpeg_quality.setValue(95)
+        self.annotation_format = QComboBox()
+        formats = (
+            ('Pascal VOC', LabelFileFormat.PASCAL_VOC),
+            ('YOLO', LabelFileFormat.YOLO),
+            ('YOLO segmentation', LabelFileFormat.YOLO_SEG),
+            ('COCO', LabelFileFormat.COCO),
+            ('CreateML', LabelFileFormat.CREATE_ML),
+        )
+        for name, value in formats:
+            self.annotation_format.addItem(name, value)
+            if value == current_format:
+                self.annotation_format.setCurrentIndex(
+                    self.annotation_format.count() - 1)
+
+        form = QFormLayout()
+        form.addRow('Destination', destination_row)
+        form.addRow('Frames', self.selection)
+        form.addRow('Range start', self.start_time)
+        form.addRow('Range end', self.end_time)
+        form.addRow('Sample unit', self.sample_unit)
+        form.addRow('Every N frames', self.sample_frames)
+        form.addRow('Every N seconds', self.sample_seconds)
+        form.addRow('Images', self.image_format)
+        form.addRow('JPEG quality', self.jpeg_quality)
+        form.addRow('Annotations', self.annotation_format)
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout = QVBoxLayout(self)
+        layout.addLayout(form)
+        layout.addWidget(buttons)
+        self.selection.currentIndexChanged.connect(self._update_enabled)
+        self.sample_unit.currentIndexChanged.connect(self._update_enabled)
+        self.image_format.currentIndexChanged.connect(self._update_enabled)
+        self._update_enabled()
+
+    def _browse(self):
+        path = QFileDialog.getExistingDirectory(
+            self, 'Choose new or empty export directory')
+        if path:
+            self.destination.setText(path)
+
+    def _update_enabled(self, _value=None):
+        ranged = self.selection.currentData() == 'range'
+        self.start_time.setEnabled(ranged)
+        self.end_time.setEnabled(ranged)
+        self.sample_unit.setEnabled(ranged)
+        frames = ranged and self.sample_unit.currentData() == 'frames'
+        self.sample_frames.setEnabled(frames)
+        self.sample_seconds.setEnabled(ranged and not frames)
+        self.jpeg_quality.setEnabled(
+            self.image_format.currentData() == 'jpg')
+
+    def values(self):
+        return {
+            'destination': self.destination.text().strip(),
+            'selection': self.selection.currentData(),
+            'start_time': self.start_time.text().strip(),
+            'end_time': self.end_time.text().strip(),
+            'sample_unit': self.sample_unit.currentData(),
+            'sample_frames': self.sample_frames.value(),
+            'sample_seconds': self.sample_seconds.value(),
+            'image_format': self.image_format.currentData(),
+            'jpeg_quality': self.jpeg_quality.value(),
+            'annotation_format': self.annotation_format.currentData(),
+        }

--- a/libs/widgets/videoTimelineWidget.py
+++ b/libs/widgets/videoTimelineWidget.py
@@ -1,0 +1,240 @@
+"""PTS-based controls and marker strip for smart-video documents."""
+
+from PyQt5.QtCore import Qt, QTimer, pyqtSignal
+from PyQt5.QtGui import QColor, QPainter, QPen
+from PyQt5.QtWidgets import (
+    QComboBox, QHBoxLayout, QLabel, QLineEdit, QPushButton, QSlider,
+    QStyle, QVBoxLayout, QWidget,
+)
+
+from libs.core.video_types import VideoFrameRef
+
+
+TIMELINE_MAX = 1_000_000
+
+
+def format_timecode(seconds):
+    milliseconds = max(0, int(round(float(seconds) * 1000)))
+    hours, remainder = divmod(milliseconds, 3_600_000)
+    minutes, remainder = divmod(remainder, 60_000)
+    secs, millis = divmod(remainder, 1000)
+    return '%02d:%02d:%02d.%03d' % (hours, minutes, secs, millis)
+
+
+def parse_timecode(value):
+    parts = value.strip().split(':')
+    if len(parts) != 3:
+        raise ValueError('timecode must use HH:MM:SS.mmm')
+    hours = int(parts[0])
+    minutes = int(parts[1])
+    seconds = float(parts[2])
+    if hours < 0 or not 0 <= minutes < 60 or not 0 <= seconds < 60:
+        raise ValueError('timecode is outside its valid range')
+    return hours * 3600 + minutes * 60 + seconds
+
+
+class _MarkerSlider(QSlider):
+    """A standard slider with a compact non-interactive marker overlay."""
+
+    def __init__(self, parent=None):
+        super().__init__(Qt.Horizontal, parent)
+        self.spans = ()
+        self.accepted = ()
+        self.pending = ()
+        self.verified = ()
+
+    def set_markers(self, spans=(), accepted=(), pending=(), verified=()):
+        self.spans = tuple(spans)
+        self.accepted = tuple(accepted)
+        self.pending = tuple(pending)
+        self.verified = tuple(verified)
+        self.update()
+
+    def paintEvent(self, event):
+        super().paintEvent(event)
+        width = max(1, self.width() - 12)
+        left = 6
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.Antialiasing, False)
+        for start, end in self.spans:
+            painter.fillRect(
+                left + int(start * width / TIMELINE_MAX), 1,
+                max(1, int((end - start) * width / TIMELINE_MAX)), 3,
+                QColor(70, 140, 220, 160))
+        for values, color, y0, y1 in (
+                (self.accepted, QColor(45, 180, 90), 0, 6),
+                (self.pending, QColor(235, 165, 35), 0, 6),
+                (self.verified, QColor(125, 90, 220),
+                 self.height() - 6, self.height())):
+            painter.setPen(QPen(color, 2))
+            for value in values:
+                x = left + int(value * width / TIMELINE_MAX)
+                painter.drawLine(x, y0, x, y1)
+        painter.end()
+
+
+class VideoTimelineWidget(QWidget):
+    """Bottom-dock controls that emit immutable frame references."""
+
+    seekRequested = pyqtSignal(object)
+    previousRequested = pyqtSignal()
+    nextRequested = pyqtSignal()
+    playPauseRequested = pyqtSignal()
+    speedChanged = pyqtSignal(float)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._snapshot = None
+        self._dragging = False
+        self._playing = False
+        self._debounce = QTimer(self)
+        self._debounce.setSingleShot(True)
+        self._debounce.setInterval(50)
+        self._debounce.timeout.connect(self._emit_slider_seek)
+
+        style = self.style()
+        self.play_button = QPushButton()
+        self.play_button.setIcon(style.standardIcon(QStyle.SP_MediaPlay))
+        self.play_button.setToolTip('Play/Pause (Ctrl+Space)')
+        self.previous_button = QPushButton()
+        self.previous_button.setIcon(
+            style.standardIcon(QStyle.SP_MediaSkipBackward))
+        self.previous_button.setToolTip('Previous frame (A)')
+        self.next_button = QPushButton()
+        self.next_button.setIcon(
+            style.standardIcon(QStyle.SP_MediaSkipForward))
+        self.next_button.setToolTip('Next frame (D)')
+        self.time_edit = QLineEdit('00:00:00.000')
+        self.time_edit.setMaximumWidth(110)
+        self.time_edit.setToolTip('Exact presentation time (HH:MM:SS.mmm)')
+        self.speed_combo = QComboBox()
+        for speed in (0.25, 0.5, 1.0, 2.0):
+            self.speed_combo.addItem('%gx' % speed, speed)
+        self.speed_combo.setCurrentIndex(2)
+        self.position_label = QLabel('PTS — · Frame ~—')
+        self.slider = _MarkerSlider()
+        self.slider.setRange(0, TIMELINE_MAX)
+
+        top = QHBoxLayout()
+        top.setContentsMargins(4, 2, 4, 0)
+        top.addWidget(self.previous_button)
+        top.addWidget(self.play_button)
+        top.addWidget(self.next_button)
+        top.addWidget(self.time_edit)
+        top.addWidget(self.speed_combo)
+        top.addWidget(self.position_label)
+        top.addStretch(1)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(2, 2, 2, 2)
+        layout.setSpacing(1)
+        layout.addLayout(top)
+        layout.addWidget(self.slider)
+
+        self.play_button.clicked.connect(self.playPauseRequested)
+        self.previous_button.clicked.connect(self.previousRequested)
+        self.next_button.clicked.connect(self.nextRequested)
+        self.speed_combo.currentIndexChanged.connect(
+            lambda _index: self.speedChanged.emit(
+                float(self.speed_combo.currentData())))
+        self.time_edit.returnPressed.connect(self._emit_time_seek)
+        self.slider.sliderPressed.connect(self._slider_pressed)
+        self.slider.sliderReleased.connect(self._slider_released)
+        self.slider.valueChanged.connect(self._slider_changed)
+
+    def set_session(self, snapshot):
+        self._snapshot = snapshot
+        self.setEnabled(snapshot is not None)
+        if snapshot is None:
+            self.slider.setValue(0)
+            self.position_label.setText('PTS — · Frame ~—')
+            return
+        self.set_current_frame(snapshot.initial_frame.frame_ref)
+
+    def set_playing(self, playing):
+        self._playing = bool(playing)
+        icon = (QStyle.SP_MediaPause if self._playing
+                else QStyle.SP_MediaPlay)
+        self.play_button.setIcon(self.style().standardIcon(icon))
+
+    def set_markers(self, spans=(), accepted=(), pending=(), verified=()):
+        self.slider.set_markers(
+            spans=tuple(self._pts_to_normalized_range(item) for item in spans),
+            accepted=tuple(self._pts_to_normalized(item) for item in accepted),
+            pending=tuple(self._pts_to_normalized(item) for item in pending),
+            verified=tuple(self._pts_to_normalized(item) for item in verified))
+
+    def set_current_frame(self, frame_ref):
+        if self._snapshot is None:
+            return
+        value = self._pts_to_normalized(frame_ref.pts)
+        blocked = self.slider.blockSignals(True)
+        self.slider.setValue(value)
+        self.slider.blockSignals(blocked)
+        start_pts = int(self._snapshot.start_pts or 0)
+        seconds = (frame_ref.pts - start_pts) * \
+            self._snapshot.time_base_num / self._snapshot.time_base_den
+        self.time_edit.setText(format_timecode(seconds))
+        rate_num = self._snapshot.average_rate_num
+        rate_den = self._snapshot.average_rate_den
+        approximate = (
+            max(0, int(round(seconds * rate_num / rate_den)))
+            if rate_num and rate_den else None)
+        frame_text = '~%s' % approximate if approximate is not None else '~—'
+        self.position_label.setText(
+            'PTS %s · Frame %s' % (frame_ref.pts, frame_text))
+
+    def _duration_pts(self):
+        return max(0, int(self._snapshot.duration_pts or 0))
+
+    def _pts_to_normalized(self, pts):
+        if self._snapshot is None or not self._duration_pts():
+            return 0
+        start = int(self._snapshot.start_pts or 0)
+        return max(0, min(TIMELINE_MAX, int(round(
+            (int(pts) - start) * TIMELINE_MAX / self._duration_pts()))))
+
+    def _pts_to_normalized_range(self, span):
+        return (self._pts_to_normalized(span[0]),
+                self._pts_to_normalized(span[1]))
+
+    def _normalized_to_ref(self, value):
+        snapshot = self._snapshot
+        start = int(snapshot.start_pts or 0)
+        pts = start + int(round(
+            int(value) * self._duration_pts() / TIMELINE_MAX))
+        return VideoFrameRef(
+            snapshot.fingerprint, snapshot.stream_index, pts,
+            snapshot.time_base_num, snapshot.time_base_den)
+
+    def _slider_pressed(self):
+        self._dragging = True
+
+    def _slider_released(self):
+        self._dragging = False
+        self._debounce.stop()
+        self._emit_slider_seek()
+
+    def _slider_changed(self, _value):
+        if self._dragging:
+            self._debounce.start()
+
+    def _emit_slider_seek(self):
+        if self._snapshot is not None:
+            self.seekRequested.emit(
+                self._normalized_to_ref(self.slider.value()))
+
+    def _emit_time_seek(self):
+        if self._snapshot is None:
+            return
+        try:
+            seconds = parse_timecode(self.time_edit.text())
+        except ValueError:
+            self.time_edit.setText(format_timecode(
+                self._snapshot.initial_frame.frame_ref.seconds))
+            return
+        pts = int(self._snapshot.start_pts or 0) + int(round(
+            seconds * self._snapshot.time_base_den /
+            self._snapshot.time_base_num))
+        self.seekRequested.emit(VideoFrameRef(
+            self._snapshot.fingerprint, self._snapshot.stream_index, pts,
+            self._snapshot.time_base_num, self._snapshot.time_base_den))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,15 @@ dependencies = [
 sam = [
     "onnxruntime",
     "numpy",
-    "opencv-python-headless",
+    "opencv-python-headless>=4.8,<6",
+]
+video = [
+    "av>=12.3,<13; python_version == '3.8'",
+    "av>=15.1,<16; python_version == '3.9'",
+    "av>=17.1,<18; python_version == '3.10'",
+    "av>=18,<19; python_version >= '3.11'",
+    "numpy",
+    "opencv-python-headless>=4.8,<6",
 ]
 profile = [
     "psutil",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,29 @@ import os
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 
+_TEST_APPLICATION = None
+
+
+def pytest_sessionstart(session):
+    """Keep one strong QApplication reference for the complete test run."""
+    del session
+    global _TEST_APPLICATION
+    from PyQt5.QtCore import Qt
+    from PyQt5.QtWidgets import QApplication
+
+    if QApplication.instance() is None:
+        try:
+            QApplication.setAttribute(Qt.AA_EnableHighDpiScaling, True)
+            QApplication.setAttribute(Qt.AA_UseHighDpiPixmaps, True)
+        except AttributeError:
+            pass
+    _TEST_APPLICATION = QApplication.instance() or QApplication([])
+
+
 def pytest_sessionfinish(session, exitstatus):
     """Close every top-level widget and quit QApplication before exit."""
+    del session, exitstatus
+    global _TEST_APPLICATION
     try:
         from PyQt5.QtWidgets import QApplication
     except ImportError:
@@ -39,4 +60,5 @@ def pytest_sessionfinish(session, exitstatus):
     app.processEvents()
     app.processEvents()
     app.quit()
+    _TEST_APPLICATION = None
     gc.collect()

--- a/tests/core/test_task_coordinator.py
+++ b/tests/core/test_task_coordinator.py
@@ -85,3 +85,12 @@ def test_generation_cancellation_discards_result():
     assert _wait_until(lambda: not coordinator.queue_depths()['interactive'])
     assert delivered == []
     coordinator.shutdown()
+
+
+def test_video_lane_is_single_threaded_and_independent():
+    coordinator = TaskCoordinator(logical_cpus=8)
+    assert coordinator.pool('video').maxThreadCount() == 1
+    assert coordinator.pool('video') is not coordinator.pool('interactive')
+    assert coordinator.pool('video') is not coordinator.pool('background')
+    assert 'video' in coordinator.queue_depths()
+    coordinator.shutdown()

--- a/tests/video/__init__.py
+++ b/tests/video/__init__.py
@@ -1,0 +1,1 @@
+"""Smart-video unit and integration coverage."""

--- a/tests/video/conftest.py
+++ b/tests/video/conftest.py
@@ -1,0 +1,37 @@
+"""Deterministic PyAV media fixtures created only for video tests."""
+
+import fractions
+
+import pytest
+
+
+@pytest.fixture
+def make_video():
+    av = pytest.importorskip('av')
+    np = pytest.importorskip('numpy')
+
+    def create(path, frames=12, width=96, height=64, rate=12,
+               container_format=None, rotation=0):
+        output = av.open(str(path), mode='w', format=container_format)
+        stream = output.add_stream('mpeg4', rate=rate)
+        stream.width = width
+        stream.height = height
+        stream.pix_fmt = 'yuv420p'
+        stream.gop_size = 6
+        if rotation:
+            stream.metadata['rotate'] = str(rotation)
+        for index in range(frames):
+            array = np.zeros((height, width, 3), dtype=np.uint8)
+            array[:, :, 0] = (index * 17) % 255
+            array[12:36, 8 + index:32 + index, 1] = 255
+            frame = av.VideoFrame.from_ndarray(array, format='rgb24')
+            frame.pts = index
+            frame.time_base = fractions.Fraction(1, rate)
+            for packet in stream.encode(frame):
+                output.mux(packet)
+        for packet in stream.encode():
+            output.mux(packet)
+        output.close()
+        return str(path)
+
+    return create

--- a/tests/video/conftest.py
+++ b/tests/video/conftest.py
@@ -11,7 +11,8 @@ def make_video():
     np = pytest.importorskip('numpy')
 
     def create(path, frames=12, width=96, height=64, rate=12,
-               container_format=None, rotation=0):
+               container_format=None, rotation=0,
+               tracking_stress=False, scene_cut_at=None):
         output = av.open(str(path), mode='w', format=container_format)
         stream = output.add_stream('mpeg4', rate=rate)
         stream.width = width
@@ -23,7 +24,19 @@ def make_video():
         for index in range(frames):
             array = np.zeros((height, width, 3), dtype=np.uint8)
             array[:, :, 0] = (index * 17) % 255
-            array[12:36, 8 + index:32 + index, 1] = 255
+            if tracking_stress:
+                array[:, :, 0] = 0
+            if scene_cut_at is not None and index >= scene_cut_at:
+                array[:] = 255
+            if tracking_stress:
+                x0, y0 = 16 + index, 14
+                array[y0:y0 + 36, x0:x0 + 36] = 35
+                for y in range(y0 + 3, y0 + 34, 6):
+                    for x in range(x0 + 3, x0 + 34, 6):
+                        array[y - 1:y + 2, x - 1:x + 2] = \
+                            (240, 240, 240)
+            else:
+                array[12:36, 8 + index:32 + index, 1] = 255
             frame = av.VideoFrame.from_ndarray(array, format='rgb24')
             frame.pts = index
             frame.time_base = fractions.Fraction(1, rate)

--- a/tests/video/conftest.py
+++ b/tests/video/conftest.py
@@ -12,13 +12,14 @@ def make_video():
 
     def create(path, frames=12, width=96, height=64, rate=12,
                container_format=None, rotation=0,
-               tracking_stress=False, scene_cut_at=None):
+               tracking_stress=False, scene_cut_at=None,
+               variable_rate=False, gop_size=6):
         output = av.open(str(path), mode='w', format=container_format)
         stream = output.add_stream('mpeg4', rate=rate)
         stream.width = width
         stream.height = height
         stream.pix_fmt = 'yuv420p'
-        stream.gop_size = 6
+        stream.gop_size = gop_size
         if rotation:
             stream.metadata['rotate'] = str(rotation)
         for index in range(frames):
@@ -38,7 +39,8 @@ def make_video():
             else:
                 array[12:36, 8 + index:32 + index, 1] = 255
             frame = av.VideoFrame.from_ndarray(array, format='rgb24')
-            frame.pts = index
+            frame.pts = index + (
+                index // 4 if variable_rate else 0)
             frame.time_base = fractions.Fraction(1, rate)
             for packet in stream.encode(frame):
                 output.mux(packet)

--- a/tests/video/test_compatibility.py
+++ b/tests/video/test_compatibility.py
@@ -1,0 +1,39 @@
+import os
+import subprocess
+import sys
+
+from libs.core.video_decoder import VIDEO_INSTALL_HINT
+
+
+def test_video_dependency_markers_cover_each_python_line():
+    with open('pyproject.toml', 'r', encoding='utf-8') as stream:
+        metadata = stream.read()
+    assert 'av>=12.3,<13; python_version == \'3.8\'' in metadata
+    assert 'av>=15.1,<16; python_version == \'3.9\'' in metadata
+    assert 'av>=17.1,<18; python_version == \'3.10\'' in metadata
+    assert 'av>=18,<19; python_version >= \'3.11\'' in metadata
+    assert metadata.count('opencv-python-headless>=4.8,<6') == 2
+
+
+def test_base_application_imports_without_optional_video_modules():
+    script = r'''
+import builtins
+original_import = builtins.__import__
+def guarded_import(name, *args, **kwargs):
+    if name.split('.', 1)[0] in ('av', 'cv2', 'numpy'):
+        raise AssertionError('optional video module imported at base startup')
+    return original_import(name, *args, **kwargs)
+builtins.__import__ = guarded_import
+import labelImgPlusPlus
+from libs.core.video_decoder import VIDEO_INSTALL_HINT
+assert '[video]' in VIDEO_INSTALL_HINT
+'''
+    environment = os.environ.copy()
+    environment.setdefault('QT_QPA_PLATFORM', 'offscreen')
+    subprocess.run(
+        [sys.executable, '-c', script], check=True,
+        cwd=os.path.abspath(os.curdir), env=environment)
+
+
+def test_install_hint_names_the_optional_extra():
+    assert 'labelimgplusplus[video]' in VIDEO_INSTALL_HINT

--- a/tests/video/test_decoder.py
+++ b/tests/video/test_decoder.py
@@ -92,6 +92,28 @@ def test_vfr_seek_selects_nearest_presentation_timestamp(
         decoder.close()
 
 
+def test_next_frame_after_nearest_seek_returns_unconsumed_successor(
+        tmp_path, make_video):
+    path = make_video(
+        tmp_path / 'vfr-next.mkv', container_format='matroska',
+        variable_rate=True)
+    decoder = VideoDecoderSession(path)
+    try:
+        decoded = [decoder.decode_first().frame_ref.pts]
+        while True:
+            result = decoder.next_frame()
+            if result is None:
+                break
+            decoded.append(result.frame_ref.pts)
+
+        target = (decoded[6] + decoded[7]) // 2
+        sought = decoder.seek_pts(target)
+        expected_index = decoded.index(sought.frame_ref.pts) + 1
+        assert decoder.next_frame().frame_ref.pts == decoded[expected_index]
+    finally:
+        decoder.close()
+
+
 def test_display_matrix_rotation_overrides_stream_metadata():
     stream = SimpleNamespace(
         metadata={'rotate': '180'}, side_data={'DISPLAYMATRIX': 90.0})

--- a/tests/video/test_decoder.py
+++ b/tests/video/test_decoder.py
@@ -1,8 +1,17 @@
-from libs.core.video_decoder import VideoDecoderSession, pyav_major
+from types import SimpleNamespace
+import struct
+
+import pytest
+
+from libs.core.video_decoder import (
+    VIDEO_EXTENSIONS, VideoDecoderSession, _rotation_for_frame,
+    _rotation_for_stream, pyav_major,
+)
 from libs.core.video_project import default_project_path
 
 
 def test_pyav_adapter_reports_supported_major():
+    pytest.importorskip('av')
     assert pyav_major() in (12, 13, 14, 15, 16, 17, 18)
 
 
@@ -39,3 +48,73 @@ def test_snapshot_keeps_original_source_contract(tmp_path, make_video):
         assert snapshot.codec
     finally:
         decoder.close()
+
+
+@pytest.mark.parametrize('suffix,container_format', (
+    ('.mp4', 'mp4'),
+    ('.mov', 'mov'),
+    ('.mkv', 'matroska'),
+    ('.avi', 'avi'),
+))
+def test_guaranteed_local_containers_decode(
+        tmp_path, make_video, suffix, container_format):
+    path = make_video(
+        tmp_path / ('acceptance' + suffix),
+        container_format=container_format)
+    decoder = VideoDecoderSession(path)
+    try:
+        assert decoder.decode_first().display_width == 96
+        assert suffix in VIDEO_EXTENSIONS
+    finally:
+        decoder.close()
+
+
+def test_vfr_seek_selects_nearest_presentation_timestamp(
+        tmp_path, make_video):
+    path = make_video(
+        tmp_path / 'vfr.mkv', container_format='matroska',
+        variable_rate=True)
+    decoder = VideoDecoderSession(path)
+    try:
+        decoded = [decoder.decode_first().frame_ref.pts]
+        while True:
+            result = decoder.next_frame()
+            if result is None:
+                break
+            decoded.append(result.frame_ref.pts)
+        assert len(set(
+            right - left for left, right in zip(decoded, decoded[1:]))) > 1
+        target = (decoded[5] + decoded[6]) // 2
+        result = decoder.seek_pts(target)
+        expected = min(decoded, key=lambda pts: abs(pts - target))
+        assert result.frame_ref.pts == expected
+    finally:
+        decoder.close()
+
+
+def test_display_matrix_rotation_overrides_stream_metadata():
+    stream = SimpleNamespace(
+        metadata={'rotate': '180'}, side_data={'DISPLAYMATRIX': 90.0})
+    assert _rotation_for_stream(stream) == 90
+    assert _rotation_for_frame(SimpleNamespace(rotation=90), 0) == 90
+    assert _rotation_for_frame(SimpleNamespace(rotation=-90), 0) == 270
+    assert _rotation_for_frame(SimpleNamespace(), 180) == 180
+
+
+def test_raw_display_matrix_supports_intermediate_pyav_versions():
+    class DisplayMatrix:
+        type = SimpleNamespace(name='DISPLAYMATRIX')
+
+        def __bytes__(self):
+            return struct.pack(
+                '=9i', 0, -65536, 0, 65536, 0, 0, 0, 0, 1073741824)
+
+    frame = SimpleNamespace(side_data=(DisplayMatrix(),), rotation=0)
+    assert _rotation_for_frame(frame, 0) == 90
+
+
+def test_corrupted_container_is_rejected_without_side_effects(tmp_path):
+    path = tmp_path / 'corrupted.mp4'
+    path.write_bytes(b'not a media container')
+    with pytest.raises(Exception):
+        VideoDecoderSession(str(path))

--- a/tests/video/test_decoder.py
+++ b/tests/video/test_decoder.py
@@ -1,0 +1,41 @@
+from libs.core.video_decoder import VideoDecoderSession, pyav_major
+from libs.core.video_project import default_project_path
+
+
+def test_pyav_adapter_reports_supported_major():
+    assert pyav_major() in (12, 13, 14, 15, 16, 17, 18)
+
+
+def test_decoder_uses_pts_and_returns_detached_qimages(tmp_path, make_video):
+    path = make_video(tmp_path / 'clip.mp4')
+    decoder = VideoDecoderSession(path)
+    try:
+        first = decoder.decode_first()
+        assert first.frame_ref.stream_index == decoder.stream_index
+        assert first.frame_ref.time_base_den > 0
+        assert not first.image.isNull()
+        assert (first.display_width, first.display_height) == (96, 64)
+
+        step = int(round(
+            decoder.average_rate_den / decoder.average_rate_num /
+            float(decoder.time_base)))
+        target_pts = first.frame_ref.pts + 5 * step
+        sought = decoder.seek_pts(target_pts)
+        assert abs(sought.frame_ref.pts - target_pts) <= step
+        assert sought.decode_fingerprint != first.decode_fingerprint
+    finally:
+        decoder.close()
+
+
+def test_snapshot_keeps_original_source_contract(tmp_path, make_video):
+    path = make_video(tmp_path / 'clip.mkv', container_format='matroska')
+    decoder = VideoDecoderSession(path)
+    try:
+        first = decoder.decode_first()
+        snapshot = decoder.snapshot(default_project_path(path), first)
+        assert snapshot.source_path == path
+        assert snapshot.initial_frame.frame_ref.fingerprint == \
+            snapshot.fingerprint
+        assert snapshot.codec
+    finally:
+        decoder.close()

--- a/tests/video/test_editing.py
+++ b/tests/video/test_editing.py
@@ -1,7 +1,9 @@
+import threading
 import time
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from PyQt5.QtCore import QPointF
+from PyQt5.QtWidgets import QMessageBox
 
 from labelImgPlusPlus import get_main_app
 from libs.core.video_project import load_project
@@ -160,7 +162,6 @@ def test_verify_and_explicit_save_are_durable(tmp_path, make_video):
 
 def test_mutation_during_async_save_is_chained_into_next_delta(
         tmp_path, make_video):
-    import threading
     app, window = get_main_app()
     video = make_video(tmp_path / 'clip.mp4')
     gate = threading.Event()
@@ -214,5 +215,45 @@ def test_async_save_failure_retains_overlay_and_dirty_state(
         assert window.actions.save.isEnabled()
         assert 'disk unavailable' in window.statusBar().currentMessage()
     finally:
+        window.dirty = False
+        window.close()
+
+
+def test_close_with_save_ignores_first_event_until_async_commit_finishes(
+        tmp_path, make_video):
+    app, window = get_main_app()
+    video = make_video(tmp_path / 'close-save.mp4')
+    gate = threading.Event()
+    started = threading.Event()
+    from libs.core.video_project import save_project_delta
+
+    def delayed(request, cancelled=None, begin_commit=None):
+        started.set()
+        gate.wait(2)
+        return save_project_delta(
+            request, cancelled=cancelled, begin_commit=begin_commit)
+
+    event = MagicMock()
+    try:
+        assert window.open_video(video)
+        _seed_track(window)
+        with patch.object(
+                window, 'discard_changes_dialog',
+                return_value=QMessageBox.Yes), patch(
+                'labelImgPlusPlus.save_project_delta', delayed), patch.object(
+                window, 'close', return_value=True) as close:
+            window.closeEvent(event)
+            assert started.wait(1)
+            event.ignore.assert_called_once_with()
+            event.accept.assert_not_called()
+            assert window._video_close_save_pending is True
+            assert window.task_coordinator.is_shutting_down is False
+
+            gate.set()
+            assert _wait(app, lambda: close.called)
+            assert window._video_close_save_pending is False
+            assert window.dirty is False
+    finally:
+        gate.set()
         window.dirty = False
         window.close()

--- a/tests/video/test_editing.py
+++ b/tests/video/test_editing.py
@@ -1,0 +1,218 @@
+import time
+from unittest.mock import patch
+
+from PyQt5.QtCore import QPointF
+
+from labelImgPlusPlus import get_main_app
+from libs.core.video_project import load_project
+from libs.core.video_types import VideoFrameRef
+
+
+def _wait(app, predicate, timeout=5):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        app.processEvents()
+        if predicate():
+            return True
+        time.sleep(.002)
+    return False
+
+
+def _seed_track(window, end_pts=None):
+    model = window.video_model
+    start = window.current_video_frame_ref.pts
+    track = model.create_track(
+        'car', 'rectangle', (0, 255, 0, 255), track_id='track-1')
+    model.upsert_manual(track.track_id, start, [2, 3, 22, 23])
+    if end_pts is not None:
+        model.upsert_manual(track.track_id, end_pts, [12, 13, 32, 33])
+    window._selected_video_track_id = track.track_id
+    window._on_video_model_mutation()
+    window._materialize_video_frame(start)
+    return track
+
+
+def _ref(window, pts):
+    snapshot = window.video_snapshot
+    return VideoFrameRef(
+        snapshot.fingerprint, snapshot.stream_index, pts,
+        snapshot.time_base_num, snapshot.time_base_den)
+
+
+def test_tracks_tab_materializes_manual_shape_and_renames_globally(
+        tmp_path, make_video):
+    _app, window = get_main_app()
+    video = make_video(tmp_path / 'clip.mp4')
+    try:
+        assert window.open_video(video)
+        _seed_track(window)
+        assert window.track_list_widget.count() == 1
+        assert len(window.canvas.shapes) == 1
+        shape = window.canvas.shapes[0]
+        assert shape.video_track_id == 'track-1'
+        item = window.shapes_to_items[shape]
+        item.setText('vehicle')
+        assert window.video_model.tracks['track-1'].label == 'vehicle'
+        assert window.canvas.shapes[0].label == 'vehicle'
+    finally:
+        window.dirty = False
+        window.close()
+
+
+def test_editing_interpolation_creates_manual_anchor_and_undo_restores_it(
+        tmp_path, make_video):
+    app, window = get_main_app()
+    video = make_video(tmp_path / 'clip.mp4', frames=20)
+    try:
+        assert window.open_video(video)
+        step = window._video_step_pts()
+        start = window.current_video_frame_ref.pts
+        _seed_track(window, start + 10 * step)
+        window.request_video_frame(_ref(window, start + 5 * step))
+        assert _wait(
+            app, lambda: window.current_video_frame_ref.pts >=
+            start + 4 * step)
+        shape = window.canvas.shapes[0]
+        assert shape.video_render_state == 'interpolation'
+        old_points = list(shape.points)
+        shape.points = [QPointF(point.x() + 3, point.y() + 2)
+                        for point in shape.points]
+        window._on_shape_move_finished(shape, old_points)
+        pts = window.current_video_frame_ref.pts
+        exact = window.video_model.observations[('track-1', pts)]
+        assert exact.source == 'manual'
+        assert exact.anchor is True
+        window.undo_action()
+        assert ('track-1', pts) not in window.video_model.observations
+        assert window.canvas.shapes[0].video_render_state == 'interpolation'
+    finally:
+        window.dirty = False
+        window.close()
+
+
+def test_deleting_interpolated_occurrence_writes_absence_anchor(
+        tmp_path, make_video):
+    app, window = get_main_app()
+    video = make_video(tmp_path / 'clip.mp4', frames=20)
+    try:
+        assert window.open_video(video)
+        step = window._video_step_pts()
+        start = window.current_video_frame_ref.pts
+        _seed_track(window, start + 10 * step)
+        window.request_video_frame(_ref(window, start + 5 * step))
+        assert _wait(app, lambda: bool(window.canvas.shapes)
+                     and window.canvas.shapes[0].video_render_state
+                     == 'interpolation')
+        pts = window.current_video_frame_ref.pts
+        window.canvas.select_shape(window.canvas.shapes[0])
+        window.delete_selected_shape()
+        assert window.video_model.observations[('track-1', pts)].present is False
+        assert window.canvas.shapes == []
+    finally:
+        window.dirty = False
+        window.close()
+
+
+def test_add_keyframe_promotes_interpolation_to_manual_anchor(
+        tmp_path, make_video):
+    app, window = get_main_app()
+    video = make_video(tmp_path / 'clip.mp4', frames=20)
+    try:
+        assert window.open_video(video)
+        step = window._video_step_pts()
+        start = window.current_video_frame_ref.pts
+        _seed_track(window, start + 10 * step)
+        window.request_video_frame(_ref(window, start + 5 * step))
+        assert _wait(app, lambda: bool(window.canvas.shapes)
+                     and window.canvas.shapes[0].video_render_state
+                     == 'interpolation')
+        window._selected_video_track_id = 'track-1'
+        window.add_track_keyframe()
+        observation = window.video_model.observations[
+            ('track-1', window.current_video_frame_ref.pts)]
+        assert observation.source == 'manual'
+        assert observation.anchor is True
+        assert window.canvas.shapes[0].video_render_state == 'exact'
+    finally:
+        window.dirty = False
+        window.close()
+
+
+def test_verify_and_explicit_save_are_durable(tmp_path, make_video):
+    _app, window = get_main_app()
+    video = make_video(tmp_path / 'clip.mp4')
+    try:
+        assert window.open_video(video)
+        _seed_track(window)
+        pts = window.current_video_frame_ref.pts
+        window.video_model.set_frame_verified(pts, True)
+        window._on_video_model_mutation()
+        assert window.save_video_project()
+        contents = load_project(window.video_snapshot.project_path)
+        assert contents.tracks[0].track_id == 'track-1'
+        assert contents.observations[0].pts == pts
+        assert contents.frame_states[0].verified is True
+        assert window.dirty is False
+    finally:
+        window.dirty = False
+        window.close()
+
+
+def test_mutation_during_async_save_is_chained_into_next_delta(
+        tmp_path, make_video):
+    import threading
+    app, window = get_main_app()
+    video = make_video(tmp_path / 'clip.mp4')
+    gate = threading.Event()
+    started = threading.Event()
+    from libs.core.video_project import save_project_delta
+
+    def delayed(request, cancelled=None, begin_commit=None):
+        started.set()
+        gate.wait(2)
+        return save_project_delta(
+            request, cancelled=cancelled, begin_commit=begin_commit)
+
+    try:
+        assert window.open_video(video)
+        track = _seed_track(window)
+        with patch('labelImgPlusPlus.save_project_delta', delayed):
+            window.request_save_video_project()
+            assert started.wait(1)
+            step = window._video_step_pts()
+            window.video_model.upsert_manual(
+                track.track_id,
+                window.current_video_frame_ref.pts + step,
+                [3, 4, 23, 24])
+            window._on_video_model_mutation()
+            window.request_save_video_project()
+            gate.set()
+            assert _wait(app, lambda: not window.video_model.dirty)
+        contents = load_project(window.video_snapshot.project_path)
+        assert len(contents.observations) == 2
+        assert window.dirty is False
+    finally:
+        gate.set()
+        window.dirty = False
+        window.close()
+
+
+def test_async_save_failure_retains_overlay_and_dirty_state(
+        tmp_path, make_video):
+    app, window = get_main_app()
+    video = make_video(tmp_path / 'clip.mp4')
+    try:
+        assert window.open_video(video)
+        _seed_track(window)
+        with patch(
+                'labelImgPlusPlus.save_project_delta',
+                side_effect=RuntimeError('disk unavailable')):
+            window.request_save_video_project()
+            assert _wait(app, lambda: not window._video_save_active)
+        assert window.video_model.dirty is True
+        assert window.dirty is True
+        assert window.actions.save.isEnabled()
+        assert 'disk unavailable' in window.statusBar().currentMessage()
+    finally:
+        window.dirty = False
+        window.close()

--- a/tests/video/test_export.py
+++ b/tests/video/test_export.py
@@ -7,7 +7,7 @@ import pytest
 from libs.core.task_coordinator import JobCancelled
 from libs.core.video_decoder import VideoDecoderSession
 from libs.core.video_export import (
-    VideoExportError, export_video_frames, frame_export_name,
+    VideoExportError, _coco_document, export_video_frames, frame_export_name,
 )
 from libs.core.video_types import (
     FrameStateRecord, ObservationRecord, TrackRecord, VideoExportRequest,
@@ -143,3 +143,55 @@ def test_cancel_removes_only_owned_staging_tree(tmp_path, make_video):
              if path.name.startswith('.labelimgpp-export-')
              and path != unrelated]
     assert owned == []
+
+
+def test_vfr_every_n_frames_samples_decoded_sequence_not_average_rate(
+        tmp_path, make_video):
+    source = make_video(
+        tmp_path / 'vfr.mkv', container_format='matroska',
+        variable_rate=True)
+    decoder = VideoDecoderSession(source)
+    try:
+        results = [decoder.decode_first()]
+        while True:
+            result = decoder.next_frame()
+            if result is None:
+                break
+            results.append(result)
+    finally:
+        decoder.close()
+
+    request = VideoExportRequest(
+        source_path=source, project_path='',
+        destination=str(tmp_path / 'vfr-export'), stream_index=0,
+        frame_refs=(results[0].frame_ref, results[-1].frame_ref),
+        observations=(), tracks=(), frame_states=(),
+        annotation_format=LabelFileFormat.PASCAL_VOC,
+        range_start_pts=results[0].frame_ref.pts,
+        range_end_pts=results[-1].frame_ref.pts,
+        sample_every_frames=2)
+    export_video_frames(request, _Handle())
+    manifest = json.loads((tmp_path / 'vfr-export' /
+                           'video_export_manifest.json').read_text())
+    assert [item['pts'] for item in manifest['frames']] == [
+        result.frame_ref.pts for result in results[::2]]
+    assert manifest['source']['mtime_ns'] == \
+        results[0].frame_ref.fingerprint.mtime_ns
+
+
+def test_video_coco_keypoints_preserve_person_category_schema():
+    from libs.core.keypoint_config import COCO_KEYPOINT_NAMES, COCO_SKELETON
+
+    track = TrackRecord(
+        'person-1', 'person', 'rectangle', (0, 255, 0, 255))
+    observation = ObservationRecord(
+        track.track_id, 0, [1, 2, 20, 30],
+        keypoints=[[index, index + 1, 2] for index in range(17)])
+    document = _coco_document([{
+        'name': 'frame.jpg', 'width': 64, 'height': 48,
+        'accepted': ((track, observation),), 'verified': False,
+    }], ('person',))
+    category = document['categories'][0]
+    assert category['keypoints'] == list(COCO_KEYPOINT_NAMES)
+    assert category['skeleton'] == [
+        [start + 1, end + 1] for start, end in COCO_SKELETON]

--- a/tests/video/test_export.py
+++ b/tests/video/test_export.py
@@ -1,0 +1,145 @@
+import json
+import os
+import threading
+
+import pytest
+
+from libs.core.task_coordinator import JobCancelled
+from libs.core.video_decoder import VideoDecoderSession
+from libs.core.video_export import (
+    VideoExportError, export_video_frames, frame_export_name,
+)
+from libs.core.video_types import (
+    FrameStateRecord, ObservationRecord, TrackRecord, VideoExportRequest,
+)
+from libs.formats.labelFile import LabelFileFormat
+
+
+class _Handle:
+    def __init__(self, cancel_after=None):
+        self.cancelled = threading.Event()
+        self.cancel_after = cancel_after
+        self.progress = []
+        self.committing = False
+
+    def check_cancelled(self):
+        if self.cancelled.is_set() and not self.committing:
+            raise JobCancelled()
+
+    def is_cancelled(self):
+        return self.cancelled.is_set() and not self.committing
+
+    def report_progress(self, value):
+        self.progress.append(value)
+        if self.cancel_after is not None \
+                and len(self.progress) >= self.cancel_after:
+            self.cancelled.set()
+
+    def begin_non_cancellable(self):
+        self.check_cancelled()
+        self.committing = True
+
+
+def _request(tmp_path, make_video, annotation_format, destination='export'):
+    source = make_video(tmp_path / 'clip.mp4', frames=12)
+    decoder = VideoDecoderSession(source)
+    try:
+        first = decoder.decode_first()
+        second = decoder.next_frame()
+        third = decoder.next_frame()
+    finally:
+        decoder.close()
+    track = TrackRecord(
+        'track-1', 'car', 'rectangle', (0, 255, 0, 255), revision=1)
+    observations = (
+        ObservationRecord(
+            track.track_id, first.frame_ref.pts, [1, 2, 20, 22],
+            source='manual', review_state='accepted', anchor=True,
+            revision=1),
+        ObservationRecord(
+            track.track_id, second.frame_ref.pts, [2, 2, 21, 22],
+            source='tracker', review_state='pending', anchor=False,
+            revision=2),
+        ObservationRecord(
+            track.track_id, third.frame_ref.pts, [3, 2, 22, 22],
+            source='manual', review_state='accepted', anchor=True,
+            revision=3),
+    )
+    return VideoExportRequest(
+        source_path=source, project_path=source + '.labelimgpp.sqlite',
+        destination=str(tmp_path / destination), stream_index=0,
+        frame_refs=(first.frame_ref, second.frame_ref, third.frame_ref),
+        observations=observations, tracks=(track,),
+        frame_states=(FrameStateRecord(second.frame_ref.pts, True, 1),),
+        annotation_format=annotation_format,
+        class_order=('car',))
+
+
+def test_stable_export_name_uses_stream_and_integer_pts():
+    assert frame_export_name('drive', 2, -17, 'jpg') == \
+        'drive__s2__p-17.jpg'
+
+
+@pytest.mark.parametrize('annotation_format, annotation_name', [
+    (LabelFileFormat.PASCAL_VOC, 'clip__s0__p0.xml'),
+    (LabelFileFormat.YOLO, 'clip__s0__p0.txt'),
+    (LabelFileFormat.YOLO_SEG, 'clip__s0__p0.txt'),
+    (LabelFileFormat.COCO, 'annotations.json'),
+    (LabelFileFormat.CREATE_ML, 'annotations.json'),
+])
+def test_export_uses_existing_formats_and_writes_manifest(
+        tmp_path, make_video, annotation_format, annotation_name):
+    request = _request(tmp_path, make_video, annotation_format)
+    destination = export_video_frames(request, _Handle())
+    assert os.path.isdir(destination)
+    names = sorted(os.listdir(destination))
+    assert annotation_name in names
+    manifest = json.loads((tmp_path / 'export' /
+                           'video_export_manifest.json').read_text())
+    assert manifest['source']['sampled_sha256'] == \
+        request.frame_refs[0].fingerprint.sampled_sha256
+    assert [item['pts'] for item in manifest['frames']] == \
+        [item.pts for item in request.frame_refs]
+    # The pending tracker suggestion is excluded; interpolation between the
+    # two accepted manual anchors is exported on the middle frame instead.
+    assert manifest['frames'][1]['track_ids'] == ['track-1']
+    if annotation_format == LabelFileFormat.COCO:
+        document = json.loads((tmp_path / 'export' /
+                               'annotations.json').read_text())
+        assert len(document['images']) == 3
+        assert len(document['annotations']) == 3
+        assert document['categories'] == [{'id': 1, 'name': 'car'}]
+    elif annotation_format == LabelFileFormat.CREATE_ML:
+        document = json.loads((tmp_path / 'export' /
+                               'annotations.json').read_text())
+        assert len(document) == 3
+        assert all(len(item['annotations']) == 1 for item in document)
+
+
+def test_export_rejects_nonempty_destination_without_touching_it(
+        tmp_path, make_video):
+    request = _request(
+        tmp_path, make_video, LabelFileFormat.PASCAL_VOC)
+    destination = tmp_path / 'export'
+    destination.mkdir()
+    sentinel = destination / 'owned.txt'
+    sentinel.write_text('keep')
+    with pytest.raises(VideoExportError):
+        export_video_frames(request, _Handle())
+    assert sentinel.read_text() == 'keep'
+
+
+def test_cancel_removes_only_owned_staging_tree(tmp_path, make_video):
+    request = _request(
+        tmp_path, make_video, LabelFileFormat.PASCAL_VOC)
+    unrelated = tmp_path / '.labelimgpp-export-unrelated'
+    unrelated.mkdir()
+    (unrelated / 'keep').write_text('keep')
+    with pytest.raises(JobCancelled):
+        export_video_frames(request, _Handle(cancel_after=1))
+    assert not os.path.exists(request.destination)
+    assert (unrelated / 'keep').read_text() == 'keep'
+    owned = [path for path in tmp_path.iterdir()
+             if path.name.startswith('.labelimgpp-export-')
+             and path != unrelated]
+    assert owned == []

--- a/tests/video/test_export_ui.py
+++ b/tests/video/test_export_ui.py
@@ -1,0 +1,110 @@
+import os
+import time
+
+from PyQt5.QtWidgets import QApplication
+
+from labelImgPlusPlus import get_main_app
+from libs.core.video_types import (
+    FrameStateRecord, VideoExportRequest,
+)
+from libs.formats.labelFile import LabelFileFormat
+from libs.widgets.videoExportDialog import VideoExportDialog
+
+
+_APP = QApplication.instance() or QApplication([])
+
+
+def _wait(app, predicate, timeout=8):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        app.processEvents()
+        if predicate():
+            return True
+        time.sleep(.002)
+    return False
+
+
+def _seed(window):
+    model = window.video_model
+    track = model.create_track(
+        'car', 'rectangle', (0, 255, 0, 255), track_id='track-1')
+    pts = window.current_video_frame_ref.pts
+    model.upsert_manual(track.track_id, pts, [1, 2, 20, 22])
+    model.set_frame_verified(pts, True)
+    window._on_video_model_mutation()
+
+
+def test_export_dialog_defaults_to_annotated_jpeg_95():
+    dialog = VideoExportDialog(LabelFileFormat.COCO)
+    try:
+        values = dialog.values()
+        assert values['selection'] == 'annotated'
+        assert values['image_format'] == 'jpg'
+        assert values['jpeg_quality'] == 95
+        assert values['annotation_format'] == LabelFileFormat.COCO
+    finally:
+        dialog.close()
+
+
+def test_main_window_selection_builders_use_exact_pts(tmp_path, make_video):
+    _app, window = get_main_app()
+    video = make_video(tmp_path / 'clip.mp4')
+    try:
+        assert window.open_video(video)
+        _seed(window)
+        annotated = window._video_export_frame_refs({
+            'selection': 'annotated',
+        })
+        verified = window._video_export_frame_refs({
+            'selection': 'verified',
+        })
+        assert [item.pts for item in annotated] == \
+            [window.current_video_frame_ref.pts]
+        assert [item.pts for item in verified] == \
+            [window.current_video_frame_ref.pts]
+        ranged = window._video_export_frame_refs({
+            'selection': 'range',
+            'start_time': '00:00:00.000',
+            'end_time': '00:00:00.500',
+            'sample_unit': 'seconds',
+            'sample_seconds': .25,
+            'sample_frames': 1,
+        })
+        assert len(ranged) == 3
+        assert all(item.time_base_den > 0 for item in ranged)
+    finally:
+        window.dirty = False
+        window.close()
+
+
+def test_public_export_request_runs_in_background_and_publishes(
+        tmp_path, make_video):
+    app, window = get_main_app()
+    video = make_video(tmp_path / 'clip.mp4')
+    destination = str(tmp_path / 'published')
+    try:
+        assert window.open_video(video)
+        _seed(window)
+        state = window.video_model.snapshot_state()
+        request = VideoExportRequest(
+            source_path=window.video_snapshot.source_path,
+            project_path=window.video_snapshot.project_path,
+            destination=destination,
+            stream_index=window.video_snapshot.stream_index,
+            frame_refs=(window.current_video_frame_ref,),
+            observations=state.observations,
+            tracks=state.tracks,
+            frame_states=(FrameStateRecord(
+                window.current_video_frame_ref.pts, True, 1),),
+            annotation_format=LabelFileFormat.PASCAL_VOC,
+            class_order=state.classes)
+        handle = window.request_export_video(request)
+        assert handle is not None
+        assert _wait(app, lambda: window._video_export_handle is None)
+        assert os.path.isdir(destination)
+        assert os.path.isfile(os.path.join(
+            destination, 'video_export_manifest.json'))
+        assert 'Exported video frames' in window.statusBar().currentMessage()
+    finally:
+        window.dirty = False
+        window.close()

--- a/tests/video/test_model.py
+++ b/tests/video/test_model.py
@@ -95,3 +95,24 @@ def test_save_delta_coalesces_only_mutations_newer_than_completed_revision():
     assert [item.pts for item in second.observations] == [10]
     model.mark_saved(second.target_revision)
     assert not model.dirty
+
+
+def test_rerun_replaces_pending_and_rejected_but_never_accepted_or_manual():
+    model = VideoProjectModel()
+    track = _track(model)
+    pending = ObservationRecord(
+        track.track_id, 10, [1, 1, 11, 11], source='tracker',
+        review_state='pending', anchor=False)
+    model.upsert_tracker(pending)
+    replacement = ObservationRecord(
+        track.track_id, 10, [2, 2, 12, 12], source='tracker',
+        review_state='pending', anchor=False)
+    assert model.upsert_tracker(replacement).geometry == [2, 2, 12, 12]
+    model.review(track.track_id, 10, 'rejected')
+    assert model.upsert_tracker(replacement).review_state == 'pending'
+    model.review(track.track_id, 10, 'accepted')
+    accepted = model.observations[(track.track_id, 10)]
+    assert model.upsert_tracker(pending) == accepted
+    model.upsert_manual(track.track_id, 10, [3, 3, 13, 13])
+    manual = model.observations[(track.track_id, 10)]
+    assert model.upsert_tracker(pending) == manual

--- a/tests/video/test_model.py
+++ b/tests/video/test_model.py
@@ -1,0 +1,97 @@
+from libs.core.video_model import VideoProjectModel
+from libs.core.video_types import ObservationRecord
+
+
+def _track(model, shape_type='rectangle'):
+    return model.create_track(
+        'car', shape_type, (0, 255, 0, 255), track_id='track-1')
+
+
+def test_rectangle_interpolates_by_pts_and_keypoint_visibility_is_nearest():
+    model = VideoProjectModel()
+    track = _track(model)
+    model.upsert_manual(
+        track.track_id, 100, [0, 0, 10, 10],
+        keypoints=[[1, 2, 1], [3, 4, 2]])
+    model.upsert_manual(
+        track.track_id, 300, [10, 20, 30, 40],
+        keypoints=[[11, 12, 2], [13, 14, 0]])
+    materialized = model.materialize_one(track.track_id, 150)
+    assert materialized.render_state == 'interpolation'
+    assert materialized.observation.geometry == [2.5, 5.0, 15.0, 17.5]
+    assert materialized.observation.keypoints == [
+        [3.5, 4.5, 1], [5.5, 6.5, 2]]
+
+
+def test_polygon_is_never_interpolated():
+    model = VideoProjectModel()
+    track = _track(model, shape_type='polygon')
+    model.upsert_manual(track.track_id, 0, [[0, 0], [1, 0], [1, 1]])
+    model.upsert_manual(track.track_id, 10, [[2, 2], [3, 2], [3, 3]])
+    assert model.materialize_one(track.track_id, 5) is None
+
+
+def test_presence_anchor_terminates_interpolation_until_new_present_anchor():
+    model = VideoProjectModel()
+    track = _track(model)
+    model.upsert_manual(track.track_id, 0, [0, 0, 10, 10])
+    model.upsert_manual(track.track_id, 5, None, present=False)
+    model.upsert_manual(track.track_id, 10, [10, 10, 20, 20])
+    assert model.materialize_one(track.track_id, 3) is None
+    assert model.materialize_one(track.track_id, 5) is None
+    assert model.materialize_one(track.track_id, 7) is None
+
+
+def test_manual_and_review_precedence_over_generated_state():
+    model = VideoProjectModel()
+    track = _track(model)
+    model.upsert_manual(track.track_id, 0, [0, 0, 10, 10])
+    model.upsert_manual(track.track_id, 20, [20, 20, 30, 30])
+    pending = ObservationRecord(
+        track.track_id, 10, [9, 9, 19, 19], source='tracker',
+        review_state='pending', anchor=False)
+    model.upsert_tracker(pending)
+    assert model.materialize_one(track.track_id, 10).render_state == 'pending'
+    model.upsert_manual(track.track_id, 10, [8, 8, 18, 18])
+    exact = model.materialize_one(track.track_id, 10)
+    assert exact.render_state == 'exact'
+    assert exact.observation.source == 'manual'
+    assert exact.observation.geometry == [8, 8, 18, 18]
+
+
+def test_accepted_tracker_is_exact_but_not_interpolation_anchor():
+    model = VideoProjectModel()
+    track = _track(model)
+    model.upsert_manual(track.track_id, 0, [0, 0, 10, 10])
+    model.upsert_tracker(ObservationRecord(
+        track.track_id, 10, [10, 10, 20, 20], source='tracker',
+        review_state='accepted', anchor=False))
+    assert model.materialize_one(track.track_id, 10).render_state == 'exact'
+    assert model.materialize_one(track.track_id, 5) is None
+
+
+def test_deleting_interpolation_writes_absence_but_exact_delete_removes():
+    model = VideoProjectModel()
+    track = _track(model)
+    model.upsert_manual(track.track_id, 0, [0, 0, 10, 10])
+    model.upsert_manual(track.track_id, 10, [10, 10, 20, 20])
+    model.delete_occurrence(track.track_id, 5)
+    absence = model.observations[(track.track_id, 5)]
+    assert absence.present is False
+    model.delete_occurrence(track.track_id, 5)
+    assert (track.track_id, 5) not in model.observations
+
+
+def test_save_delta_coalesces_only_mutations_newer_than_completed_revision():
+    model = VideoProjectModel()
+    track = _track(model)
+    model.upsert_manual(track.track_id, 0, [0, 0, 10, 10])
+    first = model.build_save_request('/tmp/project.sqlite')
+    model.upsert_manual(track.track_id, 10, [1, 1, 11, 11])
+    model.mark_saved(first.target_revision)
+    assert model.dirty
+    second = model.build_save_request('/tmp/project.sqlite')
+    assert second.expected_durable_revision == first.target_revision
+    assert [item.pts for item in second.observations] == [10]
+    model.mark_saved(second.target_revision)
+    assert not model.dirty

--- a/tests/video/test_navigation.py
+++ b/tests/video/test_navigation.py
@@ -1,4 +1,6 @@
+import threading
 import time
+from unittest.mock import patch
 
 from labelImgPlusPlus import DocumentKind, get_main_app
 from libs.core.video_types import VideoFrameRef
@@ -102,6 +104,41 @@ def test_image_video_mode_transitions_reconfigure_docks_and_cache(
         assert not window.timeline_dock.isVisible()
         assert window.file_dock.isVisible()
         assert window.frame_cache.max_images == 5
+    finally:
+        window.dirty = False
+        window.close()
+
+
+def test_shutdown_waits_for_video_lane_before_closing_session_decoder(
+        tmp_path, make_video):
+    _app, window = get_main_app()
+    video = make_video(tmp_path / 'shutdown.mp4')
+    started = threading.Event()
+    finished = threading.Event()
+    closed = []
+    try:
+        assert window.open_video(video)
+        decoder = window.video_decoder
+        original_close = decoder.close
+
+        def cancellable_decode(cancelled=None):
+            started.set()
+            while cancelled is None or not cancelled():
+                time.sleep(.001)
+            finished.set()
+            return None
+
+        def observed_close():
+            closed.append(finished.is_set())
+            return original_close()
+
+        with patch.object(decoder, 'next_frame', cancellable_decode), \
+                patch.object(decoder, 'close', observed_close):
+            window.request_next_video_frame()
+            assert started.wait(1)
+            window._shutdown_workers()
+        assert finished.is_set()
+        assert closed == [True]
     finally:
         window.dirty = False
         window.close()

--- a/tests/video/test_navigation.py
+++ b/tests/video/test_navigation.py
@@ -1,0 +1,107 @@
+import time
+
+from labelImgPlusPlus import DocumentKind, get_main_app
+from libs.core.video_types import VideoFrameRef
+
+
+def _wait(app, predicate, timeout=5):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        app.processEvents()
+        if predicate():
+            return True
+        time.sleep(.002)
+    return False
+
+
+def _ref(window, pts):
+    snapshot = window.video_snapshot
+    return VideoFrameRef(
+        snapshot.fingerprint, snapshot.stream_index, pts,
+        snapshot.time_base_num, snapshot.time_base_den)
+
+
+def test_frame_step_and_previous_use_pts_not_frame_index(
+        tmp_path, make_video):
+    app, window = get_main_app()
+    video = make_video(tmp_path / 'clip.mp4')
+    try:
+        assert window.open_video(video)
+        first_pts = window.current_video_frame_ref.pts
+        window.request_next_video_frame()
+        assert _wait(
+            app, lambda: window.current_video_frame_ref.pts > first_pts)
+        next_pts = window.current_video_frame_ref.pts
+        assert next_pts - first_pts != 1
+        window.request_previous_video_frame()
+        assert _wait(
+            app, lambda: window.current_video_frame_ref.pts == first_pts)
+    finally:
+        window.dirty = False
+        window.close()
+
+
+def test_rapid_seek_commits_only_latest_request(tmp_path, make_video):
+    app, window = get_main_app()
+    video = make_video(tmp_path / 'clip.mp4', frames=20)
+    try:
+        assert window.open_video(video)
+        step = window._video_step_pts()
+        start = int(window.video_snapshot.start_pts or 0)
+        window.request_video_frame(_ref(window, start + 3 * step))
+        window.request_video_frame(_ref(window, start + 12 * step))
+        assert _wait(
+            app, lambda: not window.task_coordinator.queue_depths()['video'])
+        app.processEvents()
+        assert abs(window.current_video_frame_ref.pts -
+                   (start + 12 * step)) <= step
+    finally:
+        window.dirty = False
+        window.close()
+
+
+def test_playback_has_one_decode_request_in_flight_and_drops_debt(
+        tmp_path, make_video):
+    app, window = get_main_app()
+    video = make_video(tmp_path / 'clip.mp4', frames=30)
+    try:
+        assert window.open_video(video)
+        window.play_pause_video()
+        window._video_play_started_wall -= .3
+        window._video_playback_tick()
+        request_id = window._video_frame_request_id
+        window._video_playback_tick()
+        assert window._video_frame_request_id == request_id
+        assert window.task_coordinator.queue_depths()['video'] <= 1
+        assert _wait(
+            app, lambda: window.current_video_frame_ref.pts > 0)
+        window.pause_video()
+        assert not window._video_playback_timer.isActive()
+    finally:
+        window.dirty = False
+        window.close()
+
+
+def test_image_video_mode_transitions_reconfigure_docks_and_cache(
+        tmp_path, make_video):
+    app, window = get_main_app()
+    video = make_video(tmp_path / 'clip.mp4')
+    from PyQt5.QtGui import QImage
+    image_path = str(tmp_path / 'image.png')
+    image = QImage(32, 24, QImage.Format_RGB32)
+    image.fill(0xFFFFFFFF)
+    assert image.save(image_path)
+    try:
+        assert window.open_video(video)
+        assert window.document_kind == DocumentKind.VIDEO
+        assert window.timeline_dock.isVisible()
+        assert not window.file_dock.isVisible()
+        assert window.frame_cache.max_images == 12
+        window.request_open_file(image_path, skip_prompt=True)
+        assert _wait(app, lambda: window.document_kind == DocumentKind.IMAGE)
+        assert not window.timeline_dock.isVisible()
+        assert window.file_dock.isVisible()
+        assert window.frame_cache.max_images == 5
+    finally:
+        window.dirty = False
+        window.close()

--- a/tests/video/test_opening.py
+++ b/tests/video/test_opening.py
@@ -1,0 +1,138 @@
+import os
+import time
+from unittest.mock import patch
+
+from PyQt5.QtCore import QThread
+from PyQt5.QtGui import QImage, QPixmap
+
+from labelImgPlusPlus import DocumentKind, get_main_app
+from libs.core.video_decoder import VideoDependencyError
+from libs.core.video_project import default_project_path
+
+
+def _wait(app, predicate, timeout=5):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        app.processEvents()
+        if predicate():
+            return True
+        time.sleep(.002)
+    return False
+
+
+def _image(path):
+    image = QImage(64, 48, QImage.Format_RGB32)
+    image.fill(0xFFFFFFFF)
+    assert image.save(str(path))
+
+
+def test_synchronous_open_creates_sidecar_after_first_frame(
+        tmp_path, make_video):
+    _app, window = get_main_app()
+    video = make_video(tmp_path / 'clip.mp4')
+    project = default_project_path(video)
+    try:
+        assert not os.path.exists(project)
+        assert window.open_video(video)
+        assert os.path.isfile(project)
+        assert window.document_kind == DocumentKind.VIDEO
+        assert window.video_snapshot.project_path == project
+        assert window.file_path == video
+        assert not window.image.isNull()
+        assert window.file_dock.isVisible() is False
+        assert window.frame_cache.max_images == 12
+    finally:
+        window.dirty = False
+        window.close()
+
+
+def test_async_failed_open_keeps_previous_image_document(
+        tmp_path, make_video):
+    app, window = get_main_app()
+    image = tmp_path / 'image.png'
+    _image(image)
+    assert window.load_file(str(image))
+    try:
+        window.request_open_video(str(tmp_path / 'missing.mp4'),
+                                  skip_prompt=True)
+        assert _wait(
+            app, lambda: not window.task_coordinator.queue_depths()['video'])
+        app.processEvents()
+        assert window.document_kind == DocumentKind.IMAGE
+        assert window.file_path == str(image)
+        assert not window.image.isNull()
+    finally:
+        window.dirty = False
+        window.close()
+
+
+def test_async_open_decodes_qimage_off_thread_and_builds_qpixmap_on_gui(
+        tmp_path, make_video):
+    app, window = get_main_app()
+    video = make_video(tmp_path / 'clip.mp4')
+    decode_threads = []
+    pixmap_threads = []
+    from libs.core.video_decoder import VideoDecoderSession
+    original_decode = VideoDecoderSession.decode_first
+    original_from_image = QPixmap.fromImage
+
+    def observed_decode(self, *args, **kwargs):
+        decode_threads.append(QThread.currentThread() != app.thread())
+        return original_decode(self, *args, **kwargs)
+
+    def observed_pixmap(*args, **kwargs):
+        pixmap_threads.append(QThread.currentThread() == app.thread())
+        return original_from_image(*args, **kwargs)
+
+    try:
+        with patch.object(VideoDecoderSession, 'decode_first', observed_decode), \
+                patch('labelImgPlusPlus.QPixmap.fromImage', observed_pixmap):
+            window.request_open_video(video, skip_prompt=True)
+            assert _wait(app, lambda: window.document_kind == DocumentKind.VIDEO)
+        assert decode_threads == [True]
+        assert pixmap_threads == [True]
+    finally:
+        window.dirty = False
+        window.close()
+
+
+def test_missing_optional_dependencies_leave_current_document_untouched(
+        tmp_path, make_video):
+    app, window = get_main_app()
+    image = tmp_path / 'image.png'
+    _image(image)
+    video = make_video(tmp_path / 'clip.mp4')
+    assert window.load_file(str(image))
+    try:
+        with patch(
+                'libs.core.video_decoder.load_video_dependencies',
+                side_effect=VideoDependencyError('install [video]')):
+            window.request_open_video(video, skip_prompt=True)
+            assert _wait(
+                app, lambda: not window.task_coordinator.queue_depths()['video'])
+        assert window.document_kind == DocumentKind.IMAGE
+        assert window.file_path == str(image)
+        assert 'install [video]' in window.statusBar().currentMessage()
+    finally:
+        window.dirty = False
+        window.close()
+
+
+def test_cli_positional_argument_accepts_video_project(tmp_path, make_video):
+    app, first = get_main_app()
+    video = make_video(tmp_path / 'clip.mp4')
+    assert first.open_video(video)
+    project = first.video_snapshot.project_path
+    first.dirty = False
+    first.close()
+
+    _same_app, window = get_main_app(['labelimgpp', project])
+    try:
+        assert _same_app is app
+        assert _wait(
+            app, lambda: window.document_kind == DocumentKind.VIDEO)
+        assert window.video_snapshot.project_path == project
+        assert window.file_path == video
+    finally:
+        window.dirty = False
+        window.close()

--- a/tests/video/test_opening.py
+++ b/tests/video/test_opening.py
@@ -145,6 +145,12 @@ def test_missing_project_source_can_be_located_and_relinked(
     video = make_video(tmp_path / 'clip.mp4')
     assert window.open_video(video)
     project = window.video_snapshot.project_path
+    # Windows does not permit replacing a media file while the decoder owns
+    # its file handle. A moved-source project is reopened after the original
+    # document has been closed, which is also the real user workflow.
+    window.reset_state()
+    assert _wait(
+        app, lambda: not window.task_coordinator.queue_depths()['video'])
     moved = tmp_path / 'moved.mp4'
     os.replace(video, moved)
     try:

--- a/tests/video/test_opening.py
+++ b/tests/video/test_opening.py
@@ -185,3 +185,48 @@ def test_changed_source_can_create_a_separate_project(
     finally:
         window.dirty = False
         window.close()
+
+
+def test_read_only_video_blocks_controller_mutations_and_keeps_clean(
+        tmp_path, make_video):
+    _app, window = get_main_app()
+    video = make_video(tmp_path / 'read-only.mp4')
+    try:
+        assert window.open_video(video)
+        pts = window.current_video_frame_ref.pts
+        track = window.video_model.create_track(
+            'car', 'rectangle', (0, 255, 0, 255), track_id='track-1')
+        window.video_model.upsert_manual(
+            track.track_id, pts, [2, 3, 22, 23])
+        window._on_video_model_mutation()
+        assert window.save_video_project()
+        project = window.video_snapshot.project_path
+
+        with patch.object(
+                window, '_video_project_target', return_value=(project, True)):
+            assert window.open_video(video)
+        before = window.video_model.snapshot_state()
+        shape = window.canvas.shapes[0]
+        item = window.shapes_to_items[shape]
+        window.canvas.select_shape(shape)
+
+        assert window.video_snapshot.read_only is True
+        assert window.canvas.locked is True
+        assert not window.actions.verify.isEnabled()
+        assert not window.actions.delete.isEnabled()
+        assert not window.actions.videoAddKeyframe.isEnabled()
+        assert window.request_verify_image() is None
+        window.delete_selected_shape()
+        window.add_track_keyframe()
+        item.setText('changed')
+        window.copy_to_clipboard()
+        window.set_dirty()
+
+        assert window.video_model.snapshot_state() == before
+        assert item.text() == 'car'
+        assert not window.actions.pasteFromClipboard.isEnabled()
+        assert window.dirty is False
+        assert window.request_save_video_project() is None
+    finally:
+        window.dirty = False
+        window.close()

--- a/tests/video/test_opening.py
+++ b/tests/video/test_opening.py
@@ -8,6 +8,7 @@ from PyQt5.QtGui import QImage, QPixmap
 from labelImgPlusPlus import DocumentKind, get_main_app
 from libs.core.video_decoder import VideoDependencyError
 from libs.core.video_project import default_project_path
+from libs.core.video_project import read_project_source
 
 
 def _wait(app, predicate, timeout=5):
@@ -133,6 +134,54 @@ def test_cli_positional_argument_accepts_video_project(tmp_path, make_video):
             app, lambda: window.document_kind == DocumentKind.VIDEO)
         assert window.video_snapshot.project_path == project
         assert window.file_path == video
+    finally:
+        window.dirty = False
+        window.close()
+
+
+def test_missing_project_source_can_be_located_and_relinked(
+        tmp_path, make_video):
+    app, window = get_main_app()
+    video = make_video(tmp_path / 'clip.mp4')
+    assert window.open_video(video)
+    project = window.video_snapshot.project_path
+    moved = tmp_path / 'moved.mp4'
+    os.replace(video, moved)
+    try:
+        with patch(
+                'labelImgPlusPlus.QFileDialog.getOpenFileName',
+                return_value=(str(moved), 'Video files')):
+            window.request_open_video(project, skip_prompt=True)
+            assert _wait(
+                app, lambda: window.video_snapshot is not None
+                and window.video_snapshot.source_path == str(moved))
+        assert read_project_source(project).absolute_path == str(moved)
+    finally:
+        window.dirty = False
+        window.close()
+
+
+def test_changed_source_can_create_a_separate_project(
+        tmp_path, make_video):
+    app, window = get_main_app()
+    video = make_video(tmp_path / 'clip.mp4')
+    assert window.open_video(video)
+    old_project = window.video_snapshot.project_path
+    make_video(tmp_path / 'clip.mp4', width=80, height=64)
+    new_project = str(tmp_path / 'changed.labelimgpp.sqlite')
+    try:
+        with patch.object(
+                window, '_video_source_changed_choice',
+                return_value='create'), patch(
+                'labelImgPlusPlus.QFileDialog.getSaveFileName',
+                return_value=(new_project, 'LabelImg++ video project')):
+            window.request_open_video(video, skip_prompt=True)
+            assert _wait(
+                app, lambda: window.video_snapshot is not None
+                and window.video_snapshot.project_path == new_project)
+        assert os.path.isfile(old_project)
+        assert os.path.isfile(new_project)
+        assert window.video_snapshot.width == 80
     finally:
         window.dirty = False
         window.close()

--- a/tests/video/test_performance_tools.py
+++ b/tests/video/test_performance_tools.py
@@ -1,0 +1,48 @@
+import importlib.util
+import os
+from pathlib import Path
+import shutil
+
+import pytest
+
+from libs.core.video_decoder import VideoDecoderSession
+
+
+_GENERATOR_PATH = Path(__file__).parents[2] / 'tools' / 'performance' / \
+    'generate_workload.py'
+_SPEC = importlib.util.spec_from_file_location(
+    'labelimgpp_generate_workload', _GENERATOR_PATH)
+_GENERATOR = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_GENERATOR)
+generate_video_workload = _GENERATOR.generate_video_workload
+
+
+def test_smoke_workload_covers_media_acceptance_matrix(tmp_path):
+    pytest.importorskip('av')
+    pytest.importorskip('numpy')
+    paths = generate_video_workload(str(tmp_path), profile='smoke')
+    names = {os.path.basename(path) for path in paths}
+    assert {'cfr.mp4', 'cfr.avi', 'vfr.mkv', 'long-gop.mp4',
+            'rotated.mov', 'navigation-4k.mp4', 'navigation-8k.mkv',
+            'tracking-stress.mp4'} <= names
+    assert (tmp_path / 'video' / 'switch-image.jpg').is_file()
+
+    for path in paths:
+        decoder = VideoDecoderSession(path)
+        try:
+            assert not decoder.decode_first().image.isNull()
+        finally:
+            decoder.close()
+
+    if shutil.which('ffmpeg'):
+        rotated = VideoDecoderSession(str(tmp_path / 'video' / 'rotated.mov'))
+        try:
+            frame = rotated.decode_first()
+            assert frame.rotation == 90
+            assert frame.display_width == frame.original_height
+        finally:
+            rotated.close()
+
+    with open(tmp_path / 'video' / 'manifest.json', encoding='utf-8') as stream:
+        manifest = stream.read()
+    assert '"profile": "smoke"' in manifest

--- a/tests/video/test_performance_tools.py
+++ b/tests/video/test_performance_tools.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import shutil
 
 import pytest
+from PyQt5.QtWidgets import QApplication
 
 from libs.core.video_decoder import VideoDecoderSession
 
@@ -15,6 +16,13 @@ _SPEC = importlib.util.spec_from_file_location(
 _GENERATOR = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(_GENERATOR)
 generate_video_workload = _GENERATOR.generate_video_workload
+
+_PROFILER_PATH = Path(__file__).parents[2] / 'tools' / 'performance' / \
+    'profile_video.py'
+_PROFILER_SPEC = importlib.util.spec_from_file_location(
+    'labelimgpp_profile_video', _PROFILER_PATH)
+_PROFILER = importlib.util.module_from_spec(_PROFILER_SPEC)
+_PROFILER_SPEC.loader.exec_module(_PROFILER)
 
 
 def test_smoke_workload_covers_media_acceptance_matrix(tmp_path):
@@ -46,3 +54,19 @@ def test_smoke_workload_covers_media_acceptance_matrix(tmp_path):
     with open(tmp_path / 'video' / 'manifest.json', encoding='utf-8') as stream:
         manifest = stream.read()
     assert '"profile": "smoke"' in manifest
+
+
+def test_video_profiler_exercises_real_gui_workflow(tmp_path):
+    pytest.importorskip('av')
+    pytest.importorskip('numpy')
+    generate_video_workload(str(tmp_path), profile='smoke')
+    application = QApplication.instance() or QApplication([])
+    metrics = _PROFILER._gui_workflow_metrics(
+        application, str(tmp_path / 'video' / 'cfr.mp4'))
+    assert {
+        'first_frame_ms', 'event_loop_latency_p95_ms',
+        'event_loop_latency_max_ms', 'scrub_seek_ms',
+        'playback_advance_ms', 'timeline_paint_ms',
+        'drawing_commit_ms', 'canvas_paint_ms',
+    } <= set(metrics)
+    assert metrics['playback_advance_ms'] > 0

--- a/tests/video/test_project.py
+++ b/tests/video/test_project.py
@@ -1,0 +1,110 @@
+import os
+import sqlite3
+
+import pytest
+
+from libs.core.video_project import (
+    APPLICATION_ID, ProjectRevisionConflict, UnknownProjectError,
+    default_project_path, fingerprint_video, initialize_project, load_project,
+    read_project_source, save_project_as, save_project_delta,
+    validate_project_source,
+)
+from libs.core.video_types import (
+    ObservationRecord, TrackRecord, VideoSaveRequest,
+)
+
+
+class _Session:
+    def __init__(self, source_path, fingerprint):
+        self.source_path = source_path
+        self.fingerprint = fingerprint
+        self.stream_index = 0
+        self.time_base_num = 1
+        self.time_base_den = 30
+        self.duration_pts = 10
+        self.width = 64
+        self.height = 48
+        self.rotation = 0
+        self.codec = 'test'
+
+
+def _project(tmp_path):
+    source = tmp_path / 'clip.mp4'
+    source.write_bytes(b'a' * (2 * 1024 * 1024 + 31))
+    fingerprint = fingerprint_video(source)
+    project = default_project_path(source)
+    initialize_project(project, _Session(str(source), fingerprint))
+    return source, project, fingerprint
+
+
+def test_project_schema_has_fixed_identity_and_safe_pragmas(tmp_path):
+    _source, project, _fingerprint = _project(tmp_path)
+    connection = sqlite3.connect(project)
+    try:
+        assert connection.execute('PRAGMA application_id').fetchone()[0] == \
+            APPLICATION_ID
+        assert connection.execute('PRAGMA user_version').fetchone()[0] == 1
+        assert connection.execute('PRAGMA journal_mode').fetchone()[0] == 'wal'
+        tables = {row[0] for row in connection.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'")}
+        assert {
+            'project_meta', 'video_source', 'classes', 'tracks',
+            'observations', 'interpolation_segments', 'frame_state',
+        } <= tables
+    finally:
+        connection.close()
+
+
+def test_revision_guard_rolls_back_conflicting_delta(tmp_path):
+    _source, project, _fingerprint = _project(tmp_path)
+    track = TrackRecord('track-1', 'car', 'rectangle', (1, 2, 3, 255))
+    observation = ObservationRecord(
+        'track-1', 0, [1, 2, 10, 20], revision=1)
+    request = VideoSaveRequest(
+        project, 0, 1, tracks=(track,), observations=(observation,),
+        touched_tracks=('track-1',), classes=('car',))
+    assert save_project_delta(request) == 1
+    with pytest.raises(ProjectRevisionConflict):
+        save_project_delta(VideoSaveRequest(
+            project, 0, 2,
+            tracks=(TrackRecord('track-2', 'person', 'rectangle',
+                                (2, 3, 4, 255)),)))
+    contents = load_project(project)
+    assert contents.revision == 1
+    assert [track.track_id for track in contents.tracks] == ['track-1']
+    assert contents.observations == (observation,)
+    assert contents.classes == ('car',)
+
+
+def test_moved_source_is_repaired_when_sampled_content_matches(tmp_path):
+    source, project, fingerprint = _project(tmp_path)
+    moved_dir = tmp_path / 'moved'
+    moved_dir.mkdir()
+    moved = moved_dir / source.name
+    source.rename(moved)
+    stat = moved.stat()
+    os.utime(moved, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1000))
+    moved_fingerprint = fingerprint_video(moved)
+    assert fingerprint.content_matches(moved_fingerprint)
+    validate_project_source(project, moved, moved_fingerprint)
+    assert read_project_source(project).absolute_path == str(moved)
+
+
+def test_unknown_application_id_is_rejected_without_modification(tmp_path):
+    path = tmp_path / 'unknown.sqlite'
+    connection = sqlite3.connect(str(path))
+    connection.execute('CREATE TABLE sentinel (value TEXT)')
+    connection.execute("INSERT INTO sentinel VALUES ('unchanged')")
+    connection.commit()
+    connection.close()
+    before = path.read_bytes()
+    with pytest.raises(UnknownProjectError):
+        load_project(str(path))
+    assert path.read_bytes() == before
+
+
+def test_save_as_uses_consistent_sqlite_backup(tmp_path):
+    _source, project, _fingerprint = _project(tmp_path)
+    target = str(tmp_path / 'copy.labelimgpp.sqlite')
+    assert save_project_as(project, target) == target
+    assert load_project(target) == load_project(project)

--- a/tests/video/test_timeline.py
+++ b/tests/video/test_timeline.py
@@ -1,0 +1,71 @@
+from dataclasses import replace
+
+import pytest
+from PyQt5.QtTest import QSignalSpy
+from PyQt5.QtWidgets import QApplication
+
+from libs.core.video_decoder import VideoDecoderSession
+from libs.widgets.videoTimelineWidget import (
+    TIMELINE_MAX, VideoTimelineWidget, format_timecode, parse_timecode,
+)
+
+
+_APP = QApplication.instance() or QApplication([])
+
+
+@pytest.mark.parametrize('seconds, expected', [
+    (0, '00:00:00.000'),
+    (1.234, '00:00:01.234'),
+    (3661.999, '01:01:01.999'),
+])
+def test_timecode_round_trip(seconds, expected):
+    assert format_timecode(seconds) == expected
+    assert parse_timecode(expected) == pytest.approx(seconds)
+
+
+def test_normalized_slider_handles_long_duration_without_overflow(
+        tmp_path, make_video):
+    path = make_video(tmp_path / 'clip.mp4')
+    decoder = VideoDecoderSession(path)
+    try:
+        first = decoder.decode_first()
+        snapshot = decoder.snapshot(None, first)
+        snapshot = replace(snapshot, duration_pts=10 ** 15)
+        widget = VideoTimelineWidget()
+        widget.set_session(snapshot)
+        ref = replace(first.frame_ref, pts=5 * 10 ** 14)
+        widget.set_current_frame(ref)
+        assert 0 <= widget.slider.value() <= TIMELINE_MAX
+        assert abs(widget.slider.value() - TIMELINE_MAX // 2) <= 1
+        widget.close()
+    finally:
+        decoder.close()
+
+
+def test_release_emits_exact_frame_reference(tmp_path, make_video):
+    path = make_video(tmp_path / 'clip.mp4')
+    decoder = VideoDecoderSession(path)
+    try:
+        first = decoder.decode_first()
+        snapshot = decoder.snapshot(None, first)
+        widget = VideoTimelineWidget()
+        widget.set_session(snapshot)
+        spy = QSignalSpy(widget.seekRequested)
+        widget.slider.setValue(TIMELINE_MAX // 2)
+        widget._slider_released()
+        assert len(spy) == 1
+        ref = spy[0][0]
+        assert ref.stream_index == snapshot.stream_index
+        assert ref.time_base_den == snapshot.time_base_den
+        widget.close()
+    finally:
+        decoder.close()
+
+
+def test_invalid_timecode_does_not_emit():
+    widget = VideoTimelineWidget()
+    spy = QSignalSpy(widget.seekRequested)
+    widget.time_edit.setText('not-a-time')
+    widget._emit_time_seek()
+    assert len(spy) == 0
+    widget.close()

--- a/tests/video/test_tracking.py
+++ b/tests/video/test_tracking.py
@@ -1,0 +1,166 @@
+import threading
+
+import pytest
+
+from libs.core.task_coordinator import JobCancelled
+from libs.core.video_decoder import VideoDecoderSession
+from libs.core.video_tracking import _propagate_pair, track_optical_flow
+from libs.core.video_types import (
+    ObservationRecord, TrackRecord, TrackingRequest,
+)
+
+
+class _Handle:
+    def __init__(self):
+        self.cancelled = threading.Event()
+        self.progress = []
+
+    def check_cancelled(self):
+        if self.cancelled.is_set():
+            raise JobCancelled()
+
+    def is_cancelled(self):
+        return self.cancelled.is_set()
+
+    def report_progress(self, value):
+        self.progress.append(value)
+
+
+def test_affine_flow_tracks_textured_translation():
+    cv2 = pytest.importorskip('cv2')
+    np = pytest.importorskip('numpy')
+    previous = np.zeros((96, 128), dtype=np.uint8)
+    current = np.zeros_like(previous)
+    for y in range(23, 55, 6):
+        for x in range(23, 55, 6):
+            previous[y - 1:y + 2, x - 1:x + 2] = 255
+            current[y + 1:y + 4, x + 2:x + 5] = 255
+    rectangle = [18, 18, 60, 60]
+    points = cv2.goodFeaturesToTrack(
+        previous, maxCorners=100, qualityLevel=.01, minDistance=3)
+    propagated, reason = _propagate_pair(
+        previous, current, rectangle, points, cv2, np)
+    assert reason is None
+    transformed, _matrix, _points, quality = propagated
+    assert transformed == pytest.approx([21, 20, 63, 62], abs=.8)
+    assert quality > .5
+
+
+def test_affine_flow_rejects_insufficient_features():
+    cv2 = pytest.importorskip('cv2')
+    np = pytest.importorskip('numpy')
+    gray = np.zeros((64, 64), dtype=np.uint8)
+    propagated, reason = _propagate_pair(
+        gray, gray, [1, 1, 20, 20], None, cv2, np)
+    assert propagated is None
+    assert reason == 'insufficient features'
+
+
+def _request(path, decoder, first, end_pts):
+    track = TrackRecord(
+        'track-1', 'object', 'rectangle', (0, 255, 0, 255),
+        revision=2)
+    seed = ObservationRecord(
+        track.track_id, first.frame_ref.pts, [16, 14, 52, 50],
+        source='manual', review_state='accepted', anchor=True,
+        revision=2)
+    return TrackingRequest(
+        request_id=7, generation=3, source_path=path,
+        stream_index=decoder.stream_index, start_ref=first.frame_ref,
+        end_pts=end_pts, direction=1, track=track, seed=seed,
+        seed_track_revision=track.revision, document_revision=2)
+
+
+def test_worker_emits_pending_observations_with_quality(
+        tmp_path, make_video):
+    path = make_video(
+        tmp_path / 'tracking.mp4', frames=18, width=128, height=96,
+        tracking_stress=True)
+    decoder = VideoDecoderSession(path)
+    try:
+        first = decoder.decode_first()
+        step = int(round(
+            decoder.average_rate_den / decoder.average_rate_num /
+            float(decoder.time_base)))
+        request = _request(path, decoder, first, first.frame_ref.pts + 12 * step)
+        result = track_optical_flow(request, _Handle())
+        assert result.finished is True
+        assert len(result.observations) >= 8
+        assert all(item.source == 'tracker' for item in result.observations)
+        assert all(item.review_state == 'pending'
+                   for item in result.observations)
+        assert result.observations[-1].geometry[0] > \
+            result.observations[0].geometry[0]
+        assert all(0 <= item.quality <= 1 for item in result.observations)
+    finally:
+        decoder.close()
+
+
+def test_worker_stops_at_scene_cut(tmp_path, make_video):
+    path = make_video(
+        tmp_path / 'cut.mp4', frames=18, width=128, height=96,
+        tracking_stress=True, scene_cut_at=7)
+    decoder = VideoDecoderSession(path)
+    try:
+        first = decoder.decode_first()
+        step = int(round(
+            decoder.average_rate_den / decoder.average_rate_num /
+            float(decoder.time_base)))
+        result = track_optical_flow(
+            _request(path, decoder, first, first.frame_ref.pts + 14 * step),
+            _Handle())
+        assert result.stop_reason in (
+            'scene cut', 'insufficient forward/backward matches',
+            'insufficient features')
+        assert result.end_pts < first.frame_ref.pts + 14 * step
+    finally:
+        decoder.close()
+
+
+def test_backward_worker_processes_bounded_chunks_in_reverse(
+        tmp_path, make_video):
+    path = make_video(
+        tmp_path / 'backward.mp4', frames=30, width=128, height=96,
+        tracking_stress=True)
+    decoder = VideoDecoderSession(path)
+    try:
+        first = decoder.decode_first()
+        step = int(round(
+            decoder.average_rate_den / decoder.average_rate_num /
+            float(decoder.time_base)))
+        seed_frame = decoder.seek_pts(first.frame_ref.pts + 20 * step)
+        request = _request(path, decoder, seed_frame,
+                           first.frame_ref.pts + 8 * step)
+        request = request.__class__(
+            request.request_id, request.generation, request.source_path,
+            request.stream_index, request.start_ref, request.end_pts, -1,
+            request.track,
+            ObservationRecord(
+                request.track.track_id, seed_frame.frame_ref.pts,
+                [36, 14, 72, 50], source='manual',
+                review_state='accepted', anchor=True, revision=2),
+            request.seed_track_revision, request.document_revision)
+        result = track_optical_flow(request, _Handle())
+        assert len(result.observations) >= 8
+        assert result.observations[0].pts < seed_frame.frame_ref.pts
+        assert result.observations[-1].pts <= result.observations[0].pts
+        assert result.observations[-1].geometry[0] < \
+            result.observations[0].geometry[0]
+    finally:
+        decoder.close()
+
+
+def test_worker_honors_cancellation_before_decode(tmp_path, make_video):
+    path = make_video(
+        tmp_path / 'cancel.mp4', tracking_stress=True,
+        width=128, height=96)
+    decoder = VideoDecoderSession(path)
+    try:
+        first = decoder.decode_first()
+        handle = _Handle()
+        handle.cancelled.set()
+        request = _request(path, decoder, first, first.frame_ref.pts + 1000)
+        with pytest.raises(JobCancelled):
+            track_optical_flow(request, handle)
+    finally:
+        decoder.close()

--- a/tests/video/test_tracking_ui.py
+++ b/tests/video/test_tracking_ui.py
@@ -1,0 +1,108 @@
+import threading
+import time
+from unittest.mock import patch
+
+from labelImgPlusPlus import get_main_app
+from libs.core.video_types import VideoFrameRef
+
+
+def _wait(app, predicate, timeout=8):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        app.processEvents()
+        if predicate():
+            return True
+        time.sleep(.002)
+    return False
+
+
+def _seed(window):
+    model = window.video_model
+    track = model.create_track(
+        'object', 'rectangle', (0, 255, 0, 255), track_id='track-1')
+    model.upsert_manual(
+        track.track_id, window.current_video_frame_ref.pts,
+        [16, 14, 52, 50])
+    window._selected_video_track_id = track.track_id
+    window._on_video_model_mutation()
+    window._materialize_video_frame(window.current_video_frame_ref.pts)
+    return track
+
+
+def _ref(window, pts):
+    snapshot = window.video_snapshot
+    return VideoFrameRef(
+        snapshot.fingerprint, snapshot.stream_index, pts,
+        snapshot.time_base_num, snapshot.time_base_den)
+
+
+def test_tracking_batches_render_pending_and_review_is_undoable(
+        tmp_path, make_video):
+    app, window = get_main_app()
+    video = make_video(
+        tmp_path / 'tracking.mp4', frames=24, width=128, height=96,
+        tracking_stress=True)
+    try:
+        assert window.open_video(video)
+        _seed(window)
+        handle = window.track_selected_forward()
+        assert handle is not None
+        assert _wait(app, lambda: window._tracking_handle is None)
+        pending = [item for item in window.video_model.observations.values()
+                   if item.review_state == 'pending']
+        assert len(pending) >= 8
+        target = pending[0]
+        window.request_video_frame(_ref(window, target.pts))
+        assert _wait(app, lambda: window.current_video_frame_ref.pts
+                     == target.pts)
+        assert window.canvas.shapes[0].video_render_state == 'pending'
+        assert window.accept_current_suggestion()
+        accepted = window.video_model.observations[
+            (target.track_id, target.pts)]
+        assert accepted.review_state == 'accepted'
+        assert accepted.anchor is False
+        assert window.canvas.shapes[0].video_render_state == 'exact'
+        window.undo_action()
+        assert window.video_model.observations[
+            (target.track_id, target.pts)].review_state == 'pending'
+        assert window.review_full_propagation('rejected')
+        assert not any(
+            item.review_state == 'pending'
+            for item in window.video_model.observations.values())
+    finally:
+        window.dirty = False
+        window.close()
+
+
+def test_external_seed_edit_cancels_and_discards_stale_tracking_result(
+        tmp_path, make_video):
+    app, window = get_main_app()
+    video = make_video(
+        tmp_path / 'stale.mp4', frames=20, width=128, height=96,
+        tracking_stress=True)
+    gate = threading.Event()
+    started = threading.Event()
+    from libs.core.video_tracking import track_optical_flow
+
+    def delayed(request, handle):
+        started.set()
+        gate.wait(2)
+        return track_optical_flow(request, handle)
+
+    try:
+        assert window.open_video(video)
+        track = _seed(window)
+        with patch('labelImgPlusPlus.track_optical_flow', delayed):
+            window.track_selected_forward()
+            assert started.wait(1)
+            window.video_model.rename_track(track.track_id, 'changed')
+            window._on_video_model_mutation()
+            gate.set()
+            assert _wait(app, lambda: window._tracking_handle is None)
+        assert not any(
+            item.source == 'tracker'
+            for item in window.video_model.observations.values())
+    finally:
+        gate.set()
+        window.dirty = False
+        window.close()

--- a/tests/video/test_tracking_ui.py
+++ b/tests/video/test_tracking_ui.py
@@ -56,6 +56,10 @@ def test_tracking_batches_render_pending_and_review_is_undoable(
         assert _wait(app, lambda: window.current_video_frame_ref.pts
                      == target.pts)
         assert window.canvas.shapes[0].video_render_state == 'pending'
+        assert window.actions.videoAcceptVisible.isEnabled()
+        assert window.actions.videoRejectVisible.isEnabled()
+        assert window.actions.videoAcceptRun.isEnabled()
+        assert window.actions.videoRejectRun.isEnabled()
         assert window.accept_current_suggestion()
         accepted = window.video_model.observations[
             (target.track_id, target.pts)]
@@ -69,6 +73,30 @@ def test_tracking_batches_render_pending_and_review_is_undoable(
         assert not any(
             item.review_state == 'pending'
             for item in window.video_model.observations.values())
+    finally:
+        window.dirty = False
+        window.close()
+
+
+def test_tracking_action_accepts_exact_user_endpoint(tmp_path, make_video):
+    app, window = get_main_app()
+    video = make_video(
+        tmp_path / 'endpoint.mp4', frames=24, width=128, height=96,
+        tracking_stress=True)
+    try:
+        assert window.open_video(video)
+        _seed(window)
+        with patch(
+                'labelImgPlusPlus.QInputDialog.getText',
+                return_value=('00:00:00.500', True)):
+            handle = window.track_selected_forward(choose_endpoint=True)
+        assert handle is not None
+        expected = int(round(
+            .5 * window.video_snapshot.time_base_den /
+            window.video_snapshot.time_base_num))
+        assert window._active_tracking_request.end_pts == expected
+        window.cancel_video_tracking()
+        assert _wait(app, lambda: window._tracking_handle is None)
     finally:
         window.dirty = False
         window.close()

--- a/tools/performance/generate_workload.py
+++ b/tools/performance/generate_workload.py
@@ -4,7 +4,11 @@
 import argparse
 import json
 import os
+import shutil
+import subprocess
 import sys
+import tempfile
+from fractions import Fraction
 
 from PyQt5.QtCore import QByteArray, QBuffer, QIODevice
 from PyQt5.QtGui import QImage
@@ -15,6 +19,9 @@ if REPOSITORY_ROOT not in sys.path:
     sys.path.insert(0, REPOSITORY_ROOT)
 
 from libs.core.dataset import AnnotationResolver  # noqa: E402
+from libs.core.video_decoder import (  # noqa: E402
+    _rotation_for_frame, _rotation_for_stream,
+)
 
 
 def _jpeg_bytes(width=64, height=64):
@@ -187,12 +194,182 @@ def generate(root, count):
     }, indent=2))
 
 
+def _write_video(path, width, height, frames, rate=30, gop=12,
+                 rotation=0, variable_rate=False, tracking=False):
+    """Write deterministic optional media without importing video at boot."""
+    try:
+        import av
+        import numpy as np
+    except ImportError as exc:
+        raise RuntimeError(
+            'video workload generation requires labelimgplusplus[video]: %s'
+            % exc)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    output = av.open(path, mode='w')
+    stream = output.add_stream('mpeg4', rate=rate)
+    stream.width = width
+    stream.height = height
+    stream.pix_fmt = 'yuv420p'
+    stream.gop_size = gop
+    if rotation:
+        stream.metadata['rotate'] = str(rotation)
+    pts = 0
+    for index in range(frames):
+        array = np.zeros((height, width, 3), dtype=np.uint8)
+        array[:, :, 0] = 28
+        array[:, :, 2] = 52
+        box_size = max(24, min(width, height) // 8)
+        x0 = 16 + (index * max(1, width // 500)) % max(
+            1, width - box_size - 16)
+        y0 = max(8, height // 3)
+        array[y0:y0 + box_size, x0:x0 + box_size] = (35, 35, 35)
+        if tracking:
+            spacing = max(4, box_size // 10)
+            for y in range(y0 + spacing, y0 + box_size - 2, spacing):
+                for x in range(x0 + spacing, x0 + box_size - 2, spacing):
+                    array[y - 1:y + 2, x - 1:x + 2] = (240, 240, 240)
+        frame = av.VideoFrame.from_ndarray(array, format='rgb24')
+        frame.pts = pts
+        frame.time_base = Fraction(1, rate)
+        pts += (2 if variable_rate and index % 5 == 0 else 1)
+        for packet in stream.encode(frame):
+            output.mux(packet)
+    for packet in stream.encode():
+        output.mux(packet)
+    output.close()
+    if rotation:
+        _apply_rotation_metadata(path, rotation)
+
+
+def _apply_rotation_metadata(path, rotation):
+    """Attach a real display matrix after PyAV creates deterministic media."""
+    executable = shutil.which('ffmpeg')
+    if executable is None:
+        # Older FFmpeg/PyAV combinations preserve this stream metadata during
+        # encode. Newer MOV muxers require a display matrix, so the smoke test
+        # covers the decoder adapter independently when the CLI is absent.
+        return
+    file_descriptor, staged = tempfile.mkstemp(
+        prefix='.labelimgpp-rotated-', suffix=os.path.splitext(path)[1],
+        dir=os.path.dirname(path))
+    os.close(file_descriptor)
+    try:
+        commands = (
+            # FFmpeg before 6 converts the legacy rotate key to a display
+            # matrix. Newer versions removed that compatibility path.
+            [executable, '-hide_banner', '-loglevel', 'error', '-y',
+             '-i', path, '-map', '0', '-c', 'copy',
+             '-metadata:s:v:0', 'rotate=%s' % int(rotation), staged],
+            # Current FFmpeg exposes rotation as a per-stream input override
+            # and writes its display matrix through stream copy.
+            [executable, '-hide_banner', '-loglevel', 'error', '-y',
+             '-display_rotation:v:0', str(int(rotation)),
+             '-i', path, '-map', '0', '-c', 'copy', staged],
+        )
+        for command in commands:
+            try:
+                subprocess.run(
+                    command, check=True, stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL)
+            except subprocess.CalledProcessError:
+                continue
+            if _read_video_rotation(staged) == int(rotation) % 360:
+                os.replace(staged, path)
+                staged = None
+                return
+    finally:
+        if staged is not None:
+            try:
+                os.unlink(staged)
+            except OSError:
+                pass
+
+
+def _read_video_rotation(path):
+    try:
+        import av
+        container = av.open(path, mode='r')
+        try:
+            stream = container.streams.video[0]
+            frame = next(container.decode(stream), None)
+            stream_rotation = _rotation_for_stream(stream)
+            if frame is None:
+                return stream_rotation
+            return _rotation_for_frame(frame, stream_rotation)
+        finally:
+            container.close()
+    except (ImportError, IndexError, OSError, TypeError, ValueError):
+        return 0
+
+
+def generate_video_workload(root, profile='full'):
+    """Generate CFR/VFR/GOP/rotation/resolution/tracking acceptance media."""
+    video_root = os.path.join(root, 'video')
+    if profile == 'smoke':
+        specs = (
+            ('cfr.mp4', 160, 90, 16, 8, 0, False, False),
+            ('cfr.avi', 160, 90, 12, 6, 0, False, False),
+            ('vfr.mkv', 160, 90, 16, 8, 0, True, False),
+            ('long-gop.mp4', 160, 90, 16, 16, 0, False, False),
+            ('rotated.mov', 90, 160, 12, 8, 90, False, False),
+            ('navigation-4k.mp4', 384, 216, 6, 6, 0, False, False),
+            ('navigation-8k.mkv', 768, 432, 3, 3, 0, False, False),
+            ('tracking-stress.mp4', 192, 108, 24, 12, 0, False, True),
+        )
+    else:
+        specs = (
+            ('cfr.mp4', 1280, 720, 180, 12, 0, False, False),
+            ('cfr.avi', 640, 360, 90, 12, 0, False, False),
+            ('vfr.mkv', 960, 540, 120, 12, 0, True, False),
+            ('long-gop.mp4', 1920, 1080, 180, 120, 0, False, False),
+            ('rotated.mov', 720, 1280, 90, 30, 90, False, False),
+            ('navigation-4k.mp4', 3840, 2160, 30, 30, 0, False, False),
+            ('navigation-8k.mkv', 7680, 4320, 6, 6, 0, False, False),
+            ('tracking-stress.mp4', 1280, 720, 180, 60, 0, False, True),
+        )
+    records = []
+    for name, width, height, frames, gop, rotation, vfr, tracking in specs:
+        path = os.path.join(video_root, name)
+        _write_video(
+            path, width, height, frames, gop=gop, rotation=rotation,
+            variable_rate=vfr, tracking=tracking)
+        records.append({
+            'name': name, 'width': width, 'height': height,
+            'frames': frames, 'gop': gop, 'rotation': rotation,
+            'vfr': vfr, 'tracking': tracking,
+        })
+    switch_width, switch_height = (
+        (384, 216) if profile == 'smoke' else (3840, 2160))
+    switch_image = os.path.join(video_root, 'switch-image.jpg')
+    image = QImage(switch_width, switch_height, QImage.Format_RGB32)
+    image.fill(0xFF334455)
+    if not image.save(switch_image, 'JPEG', 85):
+        raise RuntimeError('failed to write %s' % switch_image)
+    _write(os.path.join(video_root, 'manifest.json'), json.dumps({
+        'seed': 0, 'profile': profile, 'media': records,
+        'switch_image': 'switch-image.jpg',
+    }, indent=2))
+    return tuple(os.path.join(video_root, item['name']) for item in records)
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('output')
     parser.add_argument('--count', type=int, default=10_000)
+    parser.add_argument(
+        '--video', action='store_true',
+        help='also generate the optional smart-video media corpus')
+    parser.add_argument(
+        '--video-only', action='store_true',
+        help='generate only the optional smart-video media corpus')
+    parser.add_argument(
+        '--video-profile', choices=('full', 'smoke'), default='full')
     args = parser.parse_args()
-    generate(os.path.abspath(args.output), args.count)
+    if not args.video_only:
+        generate(os.path.abspath(args.output), args.count)
+    if args.video or args.video_only:
+        generate_video_workload(
+            os.path.abspath(args.output), profile=args.video_profile)
 
 
 if __name__ == '__main__':

--- a/tools/performance/profile_video.py
+++ b/tools/performance/profile_video.py
@@ -24,7 +24,7 @@ if REPOSITORY_ROOT not in sys.path:
 if not os.environ.get('DISPLAY') and not os.environ.get('WAYLAND_DISPLAY'):
     os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')
 
-from PyQt5.QtCore import QEventLoop, QTimer  # noqa: E402
+from PyQt5.QtCore import QEventLoop, QPointF, QTimer  # noqa: E402
 from PyQt5.QtWidgets import QApplication  # noqa: E402
 
 from libs.core.image_pipeline import (  # noqa: E402
@@ -201,6 +201,110 @@ def _event_loop_latency(application, path):
         decoder.close()
 
 
+def _gui_workflow_metrics(application, path):
+    """Exercise open, scrub, playback, timeline, canvas, and drawing in Qt."""
+    from labelImgPlusPlus import DocumentKind, MainWindow
+    from libs.core.shape import Shape, ShapeType
+
+    latencies = []
+    interval = .010
+    last_tick = [time.perf_counter()]
+    timer = QTimer()
+    timer.setInterval(int(interval * 1000))
+
+    def tick():
+        now = time.perf_counter()
+        latencies.append(max(0.0, now - last_tick[0] - interval) * 1000)
+        last_tick[0] = now
+
+    timer.timeout.connect(tick)
+    window = MainWindow()
+    window.show()
+    application.processEvents()
+    try:
+        with tempfile.TemporaryDirectory(
+                prefix='labelimgpp-video-gui-profile-') as root:
+            project = os.path.join(root, 'profile.labelimgpp.sqlite')
+            last_tick[0] = time.perf_counter()
+            timer.start()
+            started = time.perf_counter()
+            window.request_open_video(
+                path, project_path=project, skip_prompt=True)
+            _wait_for(
+                application,
+                lambda: window.document_kind == DocumentKind.VIDEO)
+            first_frame_ms = (time.perf_counter() - started) * 1000
+
+            scrub_started = time.perf_counter()
+            window.video_timeline._slider_pressed()
+            window.video_timeline.slider.setValue(600_000)
+            window.video_timeline._slider_released()
+            _wait_for(
+                application,
+                lambda: not window.task_coordinator.queue_depths()['video'])
+            application.processEvents()
+            scrub_seek_ms = (time.perf_counter() - scrub_started) * 1000
+
+            playback_start = window.current_video_frame_ref.pts
+            playback_started = time.perf_counter()
+            window.play_pause_video()
+            _wait_for(
+                application,
+                lambda: (window.current_video_frame_ref is not None
+                         and window.current_video_frame_ref.pts
+                         > playback_start),
+                timeout=5.0)
+            playback_advance_ms = (
+                time.perf_counter() - playback_started) * 1000
+            window.pause_video()
+
+            timeline_started = time.perf_counter()
+            window.video_timeline.repaint()
+            application.processEvents()
+            timeline_paint_ms = (
+                time.perf_counter() - timeline_started) * 1000
+
+            width = max(8, window.video_snapshot.width)
+            height = max(8, window.video_snapshot.height)
+            shape = Shape(label='profile-object',
+                          shape_type=ShapeType.RECTANGLE)
+            left, top = width * .1, height * .1
+            right, bottom = width * .3, height * .3
+            for x, y in ((left, top), (right, top),
+                         (right, bottom), (left, bottom)):
+                shape.add_point(QPointF(x, y))
+            shape.close()
+            drawing_started = time.perf_counter()
+            window._store_video_shape_as_manual(shape)
+            window._on_video_model_mutation()
+            window._materialize_video_frame(
+                window.current_video_frame_ref.pts)
+            application.processEvents()
+            drawing_commit_ms = (
+                time.perf_counter() - drawing_started) * 1000
+
+            canvas_started = time.perf_counter()
+            window.canvas.repaint()
+            application.processEvents()
+            canvas_paint_ms = (time.perf_counter() - canvas_started) * 1000
+            timer.stop()
+            return {
+                'first_frame_ms': first_frame_ms,
+                'event_loop_latency_p95_ms': percentile(latencies, .95),
+                'event_loop_latency_max_ms': max(latencies or (0.0,)),
+                'scrub_seek_ms': scrub_seek_ms,
+                'playback_advance_ms': playback_advance_ms,
+                'timeline_paint_ms': timeline_paint_ms,
+                'drawing_commit_ms': drawing_commit_ms,
+                'canvas_paint_ms': canvas_paint_ms,
+            }
+    finally:
+        timer.stop()
+        window.dirty = False
+        window.close()
+        application.processEvents()
+
+
 class _TrackingHandle:
     def __init__(self):
         self.cancelled = threading.Event()
@@ -328,9 +432,8 @@ def measured_run(video_root, application, iteration):
 
     gc.collect()
     rss_before = _rss_bytes()
-    first_frame_ms, _first = _timed_decode(cfr)
+    gui = _gui_workflow_metrics(application, cfr)
     cold, prefetched, cache_bytes, combined = _seek_metrics(long_gop)
-    event_p95, event_max = _event_loop_latency(application, cfr)
     progress_gap, cancellation = _tracking_metrics(tracking)
     image_switch_ms = _image_switch_metric(switch_image)
     export_ms = _export_metric(cfr)
@@ -339,11 +442,16 @@ def measured_run(video_root, application, iteration):
     gc.collect()
     return {
         'iteration': iteration,
-        'first_frame_ms': first_frame_ms,
+        'first_frame_ms': gui['first_frame_ms'],
         'cold_seek_p95_ms': cold,
         'prefetched_seek_p95_ms': prefetched,
-        'event_loop_latency_p95_ms': event_p95,
-        'event_loop_latency_max_ms': event_max,
+        'event_loop_latency_p95_ms': gui['event_loop_latency_p95_ms'],
+        'event_loop_latency_max_ms': gui['event_loop_latency_max_ms'],
+        'scrub_seek_ms': gui['scrub_seek_ms'],
+        'playback_advance_ms': gui['playback_advance_ms'],
+        'timeline_paint_ms': gui['timeline_paint_ms'],
+        'drawing_commit_ms': gui['drawing_commit_ms'],
+        'canvas_paint_ms': gui['canvas_paint_ms'],
         'progress_gap_max_ms': progress_gap,
         'cancellation_ack_ms': cancellation,
         'video_cache_occupancy_bytes': cache_bytes,

--- a/tools/performance/profile_video.py
+++ b/tools/performance/profile_video.py
@@ -1,0 +1,439 @@
+#!/usr/bin/env python3
+"""Five-run Linux workstation profiler for smart video annotation."""
+
+import argparse
+import cProfile
+import csv
+import gc
+import json
+import os
+import platform
+import pstats
+import statistics
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+
+
+REPOSITORY_ROOT = os.path.abspath(os.path.join(
+    os.path.dirname(__file__), '..', '..'))
+if REPOSITORY_ROOT not in sys.path:
+    sys.path.insert(0, REPOSITORY_ROOT)
+if not os.environ.get('DISPLAY') and not os.environ.get('WAYLAND_DISPLAY'):
+    os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')
+
+from PyQt5.QtCore import QEventLoop, QTimer  # noqa: E402
+from PyQt5.QtWidgets import QApplication  # noqa: E402
+
+from libs.core.image_pipeline import (  # noqa: E402
+    FrameCache, load_image_result,
+)
+from libs.core.task_coordinator import JobCancelled, TaskCoordinator  # noqa: E402
+from libs.core.video_decoder import VideoDecoderSession  # noqa: E402
+from libs.core.video_export import export_video_frames  # noqa: E402
+from libs.core.video_tracking import track_optical_flow  # noqa: E402
+from libs.core.video_types import (  # noqa: E402
+    ObservationRecord, TrackingRequest, TrackRecord, VideoExportRequest,
+)
+from libs.formats.labelFile import LabelFileFormat  # noqa: E402
+
+
+MIB = 1024 * 1024
+TARGETS = {
+    'first_frame_ms': 1000.0,
+    'cold_seek_p95_ms': 500.0,
+    'prefetched_seek_p95_ms': 100.0,
+    'event_loop_latency_p95_ms': 50.0,
+    'event_loop_latency_max_ms': 100.0,
+    'progress_gap_max_ms': 250.0,
+    'cancellation_ack_ms': 500.0,
+    'combined_cache_bytes': 128 * MIB,
+    'rss_growth_percent': 10.0,
+}
+
+
+def percentile(values, fraction):
+    values = sorted(values)
+    if not values:
+        return 0.0
+    index = max(0, min(len(values) - 1,
+                       int(len(values) * fraction) - 1))
+    return values[index]
+
+
+def distribution(values):
+    values = list(values)
+    return {
+        'median': statistics.median(values) if values else 0.0,
+        'p95': percentile(values, .95),
+        'max': max(values) if values else 0.0,
+    }
+
+
+def _rss_bytes():
+    try:
+        import psutil
+        return psutil.Process().memory_info().rss
+    except ImportError:
+        try:
+            import resource
+            multiplier = 1024 if sys.platform.startswith('linux') else 1
+            return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * \
+                multiplier
+        except (AttributeError, ImportError):
+            return 0
+
+
+def _metadata(workload):
+    try:
+        commit = subprocess.check_output(
+            ['git', 'rev-parse', 'HEAD'], cwd=REPOSITORY_ROOT,
+            text=True).strip()
+        dirty = bool(subprocess.check_output(
+            ['git', 'status', '--porcelain'], cwd=REPOSITORY_ROOT))
+    except (OSError, subprocess.CalledProcessError):
+        commit = None
+        dirty = None
+    return {
+        'commit': commit,
+        'dirty': dirty,
+        'python': sys.version.split()[0],
+        'platform': platform.platform(),
+        'logical_cpus': os.cpu_count(),
+        'workload': os.path.abspath(workload),
+    }
+
+
+def _wait_for(application, predicate, timeout=60.0):
+    deadline = time.monotonic() + timeout
+    while not predicate():
+        application.processEvents(QEventLoop.AllEvents, 10)
+        if time.monotonic() >= deadline:
+            raise RuntimeError('timed out waiting for video worker')
+
+
+def _duration_targets(decoder):
+    start = decoder.start_pts or 0
+    duration = decoder.duration_pts or max(1, decoder.time_base_den * 5)
+    return tuple(start + int(duration * fraction)
+                 for fraction in (.15, .35, .55, .75, .9))
+
+
+def _timed_decode(path):
+    started = time.perf_counter()
+    decoder = VideoDecoderSession(path)
+    try:
+        result = decoder.decode_first()
+        elapsed = (time.perf_counter() - started) * 1000
+        return elapsed, result
+    finally:
+        decoder.close()
+
+
+def _seek_metrics(path):
+    decoder = VideoDecoderSession(path)
+    cache = FrameCache(max_images=12, max_bytes=96 * MIB)
+    cold = []
+    cached = []
+    try:
+        decoder.decode_first()
+        for target in _duration_targets(decoder):
+            started = time.perf_counter()
+            result = decoder.seek_pts(target)
+            cold.append((time.perf_counter() - started) * 1000)
+            if result is not None:
+                cache.put(result)
+        for result in tuple(cache._entries.values()):
+            started = time.perf_counter()
+            assert cache.get(result.frame_ref) is result
+            cached.append((time.perf_counter() - started) * 1000)
+        return (percentile(cold, .95), percentile(cached, .95),
+                cache.byte_size, cache.max_bytes + 32 * MIB)
+    finally:
+        cache.clear()
+        decoder.close()
+
+
+def _event_loop_latency(application, path):
+    decoder = VideoDecoderSession(path)
+    coordinator = TaskCoordinator()
+    completed = []
+    errors = []
+    latencies = []
+    interval = .010
+    last_tick = [time.perf_counter()]
+    timer = QTimer()
+    timer.setInterval(int(interval * 1000))
+
+    def tick():
+        now = time.perf_counter()
+        latencies.append(max(0.0, now - last_tick[0] - interval) * 1000)
+        last_tick[0] = now
+
+    targets = _duration_targets(decoder)
+
+    def seek_all(handle):
+        results = []
+        for target in targets:
+            handle.check_cancelled()
+            results.append(decoder.seek_pts(
+                target, cancelled=handle.is_cancelled))
+        return tuple(results)
+
+    try:
+        handle = coordinator.submit(
+            'video', seek_all, key='profile-video-seek', latest=True)
+        handle.result.connect(completed.append)
+        handle.error.connect(errors.append)
+        timer.timeout.connect(tick)
+        last_tick[0] = time.perf_counter()
+        timer.start()
+        _wait_for(application, lambda: bool(completed or errors))
+        timer.stop()
+        if errors:
+            raise RuntimeError(errors[0])
+        return percentile(latencies, .95), max(latencies or (0.0,))
+    finally:
+        timer.stop()
+        coordinator.shutdown(5000)
+        decoder.close()
+
+
+class _TrackingHandle:
+    def __init__(self):
+        self.cancelled = threading.Event()
+        self.progress_times = []
+
+    def check_cancelled(self):
+        if self.cancelled.is_set():
+            raise JobCancelled()
+
+    def is_cancelled(self):
+        return self.cancelled.is_set()
+
+    def report_progress(self, _value):
+        self.progress_times.append(time.perf_counter())
+
+    def begin_non_cancellable(self):
+        self.check_cancelled()
+
+
+def _tracking_request(path):
+    decoder = VideoDecoderSession(path)
+    try:
+        first = decoder.decode_first()
+        box_size = max(24, min(
+            first.display_width, first.display_height) // 8)
+        y0 = max(8, first.display_height // 3)
+        track = TrackRecord(
+            'profile-track', 'object', 'rectangle', (0, 255, 0, 255),
+            revision=1)
+        seed = ObservationRecord(
+            track.track_id, first.frame_ref.pts,
+            [16, y0, 16 + box_size, y0 + box_size],
+            source='manual', review_state='accepted', anchor=True,
+            revision=1)
+        duration = decoder.duration_pts or int(5 / float(decoder.time_base))
+        end_pts = min(
+            first.frame_ref.pts + int(5 / float(decoder.time_base)),
+            (decoder.start_pts or 0) + duration - 1)
+        return TrackingRequest(
+            1, 1, path, decoder.stream_index, first.frame_ref, end_pts, 1,
+            track, seed, track.revision, 1)
+    finally:
+        decoder.close()
+
+
+def _tracking_metrics(path):
+    request = _tracking_request(path)
+    handle = _TrackingHandle()
+    started = time.perf_counter()
+    track_optical_flow(request, handle)
+    ended = time.perf_counter()
+    points = [started] + handle.progress_times + [ended]
+    progress_gap = max(
+        ((right - left) * 1000
+         for left, right in zip(points, points[1:])), default=0.0)
+
+    cancel_handle = _TrackingHandle()
+    finished = threading.Event()
+
+    def cancellable():
+        try:
+            track_optical_flow(request, cancel_handle)
+        except JobCancelled:
+            pass
+        finally:
+            finished.set()
+
+    worker = threading.Thread(target=cancellable, daemon=True)
+    worker.start()
+    time.sleep(.02)
+    cancel_started = time.perf_counter()
+    cancel_handle.cancelled.set()
+    if not finished.wait(5.0):
+        raise RuntimeError('tracking cancellation timed out')
+    worker.join()
+    cancellation_ms = (time.perf_counter() - cancel_started) * 1000
+    return progress_gap, cancellation_ms
+
+
+def _image_switch_metric(path):
+    started = time.perf_counter()
+    result = load_image_result(path)
+    if result is None or result.image.isNull():
+        raise RuntimeError('failed to decode switch image')
+    return (time.perf_counter() - started) * 1000
+
+
+def _export_metric(path):
+    decoder = VideoDecoderSession(path)
+    try:
+        first = decoder.decode_first()
+        second = decoder.next_frame()
+        refs = (first.frame_ref,) + (
+            (second.frame_ref,) if second is not None else ())
+    finally:
+        decoder.close()
+    with tempfile.TemporaryDirectory(prefix='labelimgpp-video-profile-') as root:
+        destination = os.path.join(root, 'export')
+        request = VideoExportRequest(
+            source_path=path, project_path='', destination=destination,
+            stream_index=first.frame_ref.stream_index, frame_refs=refs,
+            observations=(), tracks=(), frame_states=(),
+            annotation_format=LabelFileFormat.PASCAL_VOC)
+        started = time.perf_counter()
+        export_video_frames(request, _TrackingHandle())
+        elapsed = (time.perf_counter() - started) * 1000
+        if not os.path.isfile(os.path.join(
+                destination, 'video_export_manifest.json')):
+            raise RuntimeError('video export did not publish its manifest')
+        return elapsed
+
+
+def measured_run(video_root, application, iteration):
+    cfr = os.path.join(video_root, 'cfr.mp4')
+    long_gop = os.path.join(video_root, 'long-gop.mp4')
+    tracking = os.path.join(video_root, 'tracking-stress.mp4')
+    navigation_4k = os.path.join(video_root, 'navigation-4k.mp4')
+    navigation_8k = os.path.join(video_root, 'navigation-8k.mkv')
+    switch_image = os.path.join(video_root, 'switch-image.jpg')
+    required = (cfr, long_gop, tracking, navigation_4k, navigation_8k,
+                switch_image)
+    missing = [path for path in required if not os.path.isfile(path)]
+    if missing:
+        raise RuntimeError('missing video workload: %s' % missing[0])
+
+    gc.collect()
+    rss_before = _rss_bytes()
+    first_frame_ms, _first = _timed_decode(cfr)
+    cold, prefetched, cache_bytes, combined = _seek_metrics(long_gop)
+    event_p95, event_max = _event_loop_latency(application, cfr)
+    progress_gap, cancellation = _tracking_metrics(tracking)
+    image_switch_ms = _image_switch_metric(switch_image)
+    export_ms = _export_metric(cfr)
+    high_4k_ms, _frame_4k = _timed_decode(navigation_4k)
+    high_8k_ms, _frame_8k = _timed_decode(navigation_8k)
+    gc.collect()
+    return {
+        'iteration': iteration,
+        'first_frame_ms': first_frame_ms,
+        'cold_seek_p95_ms': cold,
+        'prefetched_seek_p95_ms': prefetched,
+        'event_loop_latency_p95_ms': event_p95,
+        'event_loop_latency_max_ms': event_max,
+        'progress_gap_max_ms': progress_gap,
+        'cancellation_ack_ms': cancellation,
+        'video_cache_occupancy_bytes': cache_bytes,
+        'combined_cache_bytes': combined,
+        'navigation_4k_first_frame_ms': high_4k_ms,
+        'navigation_8k_first_frame_ms': high_8k_ms,
+        'image_switch_ms': image_switch_ms,
+        'atomic_export_ms': export_ms,
+        'rss_before_bytes': rss_before,
+        'rss_after_bytes': _rss_bytes(),
+    }
+
+
+def _acceptance(summary):
+    checks = {}
+    for key, limit in TARGETS.items():
+        if key == 'rss_growth_percent':
+            value = summary[key]
+        else:
+            values = summary['operations'][key]
+            value = values['max'] if key.endswith(
+                ('_max_ms', '_bytes')) else values['p95']
+        checks[key] = {
+            'value': value, 'limit': limit, 'passed': value <= limit,
+        }
+    return checks
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('workload')
+    parser.add_argument('--output', default='profile-results/video')
+    args = parser.parse_args()
+    video_root = os.path.join(os.path.abspath(args.workload), 'video')
+    output = os.path.abspath(args.output)
+    os.makedirs(output, exist_ok=True)
+    application = QApplication.instance() or QApplication([])
+
+    profiler = cProfile.Profile()
+    profiler.enable()
+    measured_run(video_root, application, 0)
+    profiler.disable()
+    profiler.dump_stats(os.path.join(output, 'profile.prof'))
+    with open(os.path.join(output, 'profile.txt'), 'w') as stream:
+        pstats.Stats(profiler, stream=stream).sort_stats(
+            'cumulative').print_stats(80)
+
+    runs = [measured_run(video_root, application, iteration)
+            for iteration in range(1, 6)]
+    summary = _metadata(video_root)
+    summary['runs'] = runs
+    summary['operations'] = {}
+    keys = sorted({
+        key for run in runs for key, value in run.items()
+        if key != 'iteration' and isinstance(value, (int, float))
+    })
+    for key in keys:
+        summary['operations'][key] = distribution(
+            run[key] for run in runs)
+    first_rss = runs[0]['rss_after_bytes']
+    last_rss = runs[-1]['rss_after_bytes']
+    summary['rss_growth_percent'] = (
+        max(0.0, (last_rss - first_rss) / first_rss * 100)
+        if first_rss else 0.0)
+    summary['acceptance'] = _acceptance(summary)
+    summary['passed'] = all(
+        check['passed'] for check in summary['acceptance'].values())
+
+    with open(os.path.join(output, 'summary.json'), 'w') as stream:
+        json.dump(summary, stream, indent=2, sort_keys=True)
+    with open(os.path.join(output, 'resources.csv'), 'w', newline='') as stream:
+        writer = csv.DictWriter(
+            stream, fieldnames=sorted({key for run in runs for key in run}))
+        writer.writeheader()
+        writer.writerows(runs)
+    with open(os.path.join(output, 'comparison.md'), 'w') as stream:
+        stream.write('# LabelImg++ smart-video performance run\n\n')
+        stream.write('- Commit: `%s`\n' % summary['commit'])
+        stream.write('- Dirty tree: `%s`\n' % summary['dirty'])
+        stream.write('- Overall: **%s**\n\n' % (
+            'PASS' if summary['passed'] else 'FAIL'))
+        stream.write('| Target | Observed | Limit | Result |\n')
+        stream.write('|---|---:|---:|---|\n')
+        for key, check in summary['acceptance'].items():
+            stream.write('| %s | %.3f | %.3f | %s |\n' % (
+                key, check['value'], check['limit'],
+                'PASS' if check['passed'] else 'FAIL'))
+    print(os.path.join(output, 'summary.json'))
+    return 0 if summary['passed'] else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- add optional PyAV/OpenCV smart-video mode for local MP4, MOV, MKV, and AVI sources with transactional opening, fingerprinted SQLite sidecars, moved/changed-source recovery, and synchronous compatibility APIs
- add PTS/time-base timeline navigation, silent playback, exact stepping, latest-request-wins seeking, rotation handling across supported PyAV versions, bounded prefetch, and the shared 128 MiB cache ceiling
- add UUID tracks, manual anchors, rectangle/keypoint interpolation, presence anchors, per-frame verification, video-aware undo, and track-aware canvas/list behavior
- add cancellable forward/backward optical-flow propagation with endpoint selection, stale-result fencing, scene-cut/quality stops, and current/visible/full-run review
- add atomic accepted-frame export to VOC, YOLO, YOLO-seg, COCO, and CreateML with deterministic names and a video export manifest
- add Python 3.8-3.13 video CI, combined SAM/video CI, Windows/macOS smoke coverage, deterministic media workloads, five-run profiling, and user/architecture/troubleshooting documentation

## Verification

- `QT_QPA_PLATFORM=offscreen python -m pytest -q`: 869 passed, 1 skipped
- scoped Ruff, `git diff --check`, and Python 3.8 AST parsing across 227 files: passed
- wheel and sdist build plus `twine check`: passed
- built base wheel keeps video dependencies optional: passed
- clean-tree five-run video gate at `98cb26e`: passed; first frame 2.60 ms, cold seek 123.07 ms p95, prefetched seek 0.001 ms p95, event-loop latency 0.020 ms p95, max pause 0.646 ms, progress gap 216.24 ms, cancellation 1.75 ms, cache 128 MiB, RSS growth 3.29%
- clean-tree five-run image/canvas gate at `98cb26e`: passed; event-loop latency 3.00 ms p95, max pause 8.45 ms, cold navigation 20.61 ms p95, canvas paint 3.45 ms p95, RSS growth 0%
- GitHub Actions feature matrix: passed on Python 3.8-3.13, combined SAM/video, Windows, and macOS

Refs #99