### PR TITLE
feat: add installed plugin architecture

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,46 @@ jobs:
           QT_QPA_PLATFORM: offscreen
         run: python -m pytest tests/ -v
 
+  plugin-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: pyproject.toml
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils libegl1-mesa-dev
+
+      - name: Install plugin test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyqt5 lxml pytest wheel
+
+      - name: Run plugin compatibility, packaging, and performance gates
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: |
+          python -m pytest \
+            tests/core/test_plugin_discovery.py \
+            tests/core/test_plugin_manager.py \
+            tests/core/test_shortcut_config.py \
+            tests/integration/test_plugins.py \
+            tests/integration/test_plugin_packaging.py \
+            tests/integration/test_plugin_performance.py \
+            -v
+
   sam-test:
     runs-on: ubuntu-latest
     strategy:
@@ -210,7 +250,7 @@ jobs:
           python -m pytest tests/video/test_decoder.py tests/video/test_project.py tests/video/test_model.py tests/video/test_tracking.py tests/video/test_export.py tests/video/test_opening.py tests/video/test_navigation.py tests/video/test_timeline.py -v
 
   build-release:
-    needs: [test, sam-test, video-test, sam-video-test, video-platform-smoke]
+    needs: [test, plugin-test, sam-test, video-test, sam-video-test, video-platform-smoke]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
 
@@ -267,7 +307,7 @@ jobs:
           if-no-files-found: error
 
   package-macos:
-    needs: [test, sam-test, video-test, sam-video-test, video-platform-smoke]
+    needs: [test, plugin-test, sam-test, video-test, sam-video-test, video-platform-smoke]
     runs-on: macos-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
@@ -293,7 +333,7 @@ jobs:
           if-no-files-found: error
 
   package-windows:
-    needs: [test, sam-test, video-test, sam-video-test, video-platform-smoke]
+    needs: [test, plugin-test, sam-test, video-test, sam-video-test, video-platform-smoke]
     runs-on: windows-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
@@ -320,7 +360,7 @@ jobs:
           if-no-files-found: error
 
   package-linux:
-    needs: [test, sam-test, video-test, sam-video-test, video-platform-smoke]
+    needs: [test, plugin-test, sam-test, video-test, sam-video-test, video-platform-smoke]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
@@ -339,6 +379,15 @@ jobs:
           python scripts/verify_qt_resources.py
       - name: Package
         run: pyinstaller --hidden-import=pyqt5 --hidden-import=lxml -F -n "labelImgPlusPlus" -c labelImgPlusPlus.py -p ./libs -p ./
+      - name: Verify base artifact boots without plugins
+        env:
+          QT_QPA_PLATFORM: offscreen
+          LABELIMGPP_DISABLE_PLUGINS: '1'
+        run: |
+          set +e
+          timeout 5s ./dist/labelImgPlusPlus
+          status=$?
+          test "$status" -eq 124
       - uses: actions/upload-artifact@v4
         with:
           name: Linux-artifact

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,20 @@
 History
 =======
 
+Unreleased
+----------
+
+* Add API-major-1 installed Python plugins with PyPA entry-point discovery,
+  transactional activation, host-owned commands and shortcuts, JSON-only
+  settings, bounded generation-scoped tasks, read-only document descriptors,
+  structured diagnostics, a restart-oriented manager, and safe-mode recovery.
+* Keep new and disabled plugins import-free, preserve unavailable
+  configuration until explicitly forgotten, and document that enabled plugins
+  are trusted in-process code rather than sandboxed extensions.
+* Qualify a separately installed fixture wheel on Python 3.8 through 3.13 and
+  add five-run startup, 100-entry discovery/manager, cancellation, and teardown
+  gates.
+
 3.0.0 (2026-08-09)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,15 @@ Workflow and Interface
     destination must be new or empty, and it is published only after the full
     export succeeds. See the `Ultralytics Export Guide <https://github.com/abhiksark/labelImg-plus-plus/blob/dev/docs/features/ultralytics-export.md>`_.
 
+**Installed Python Plugins**
+    Add trusted command plugins from separately installed Python distributions
+    without editing labelImg++ source. Review and enable them under
+    **Tools → Plugins…**; changes take effect after restart. Plugins use a
+    versioned public API with host-owned actions, namespaced shortcuts and
+    settings, bounded background work, read-only document state, diagnostics,
+    and ``LABELIMGPP_DISABLE_PLUGINS=1`` recovery. See the
+    `Plugin Authoring Guide <https://github.com/abhiksark/labelImg-plus-plus/blob/dev/docs/guides/plugin-authoring.md>`_.
+
 **Brightness Adjustment**
     Adjust image brightness on-the-fly to better see annotations on dark or light images.
 

--- a/build-tools/README.md
+++ b/build-tools/README.md
@@ -16,10 +16,24 @@ git push origin v3.0.0
 ```
 
 The workflow tests Python 3.8 through 3.13, tests the optional SAM dependency
-on the oldest and newest supported Python versions, verifies Qt resources,
-checks the wheel and sdist with Twine, and waits for all native packaging jobs
+on the oldest and newest supported Python versions, runs plugin discovery,
+packaged-wheel, lifecycle, threading, performance, and teardown gates across
+Python 3.8 through 3.13, verifies Qt resources, checks the wheel and sdist with
+Twine, and waits for all native packaging jobs
 before publishing the exact tested distributions through PyPI Trusted
 Publishing. Native binaries remain private workflow artifacts.
+
+Publishing must include both ``libs*`` and the stable ``labelimgplusplus*``
+public namespace. The base wheel has no plugin-only dependencies and contains
+no third-party plugins. The packaged fixture under
+``tests/fixtures/plugin_distribution`` is built and installed separately in a
+temporary environment so entry-point behavior is tested from real distribution
+metadata.
+
+PyInstaller builds contain the plugin host but intentionally bundle no external
+plugin distributions. The Linux release job boots the base executable with
+``LABELIMGPP_DISABLE_PLUGINS=1`` before upload. Use the normal Python package in
+a virtual environment when separately installed plugins are required.
 
 ## Build for Ubuntu
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,6 +33,41 @@ Menu, shortcut, autosave, navigation, and verification saves create immutable
 `os.replace`; a revision check marks the document clean only if no later edit
 occurred. `save_file()` remains the synchronous compatibility entry point.
 
+## Plugin runtime
+
+The Qt-free public boundary is `labelimgplusplus.plugins`. Installed
+distributions advertise zero-argument factories through the
+`labelimgplusplus.plugins` entry-point group. `plugin_discovery.py` reads only
+distribution metadata during discovery, adapts both legacy and selectable
+`importlib.metadata` collections, sorts deterministically, and does not import
+disabled plugin targets.
+
+MainWindow constructs `PluginManager` after Settings and TaskCoordinator. Once
+core UI construction is complete, enabled candidates are loaded in order.
+Each activation receives an `ActivationContext` containing staged commands,
+namespaced JSON settings, a restricted background task service, immutable
+document descriptors, and diagnostics. The manager commits registrations
+atomically or discards them and continues base startup.
+
+The Qt command host creates every plugin `QAction`, places actions in the
+host-owned Plugins menu, and applies dynamic shortcut defaults and retained
+overrides. Plugins never receive MainWindow, menu, action, Canvas, Shape, or
+mutable video objects. Enable/disable state is saved immediately but is applied
+only on restart.
+
+Plugin workers share the bounded background lane and use cooperative
+cancellation. Result, error, progress, command, enablement, and document
+callbacks return to `QApplication.thread()`. Successful image/video commits,
+reset/close transitions, and dirty/revision changes publish frozen
+`DocumentDescriptor` values. A generation change cancels plugin work and
+discards stale results.
+
+Shutdown stops plugin task submission, cancels handles, deactivates active
+plugins in reverse order, removes host registrations, and then shuts down the
+core TaskCoordinator. `LABELIMGPP_DISABLE_PLUGINS=1` bypasses discovery and
+loading for recovery. This boundary limits accidental coupling but is not a
+sandbox; enabled plugins are trusted in-process Python code.
+
 Ultralytics dataset export captures the active immutable snapshot, annotation
 resolver, source-format selection, class order, split ratios, and copy mode in
 an `UltralyticsExportRequest`. A background job reuses the image annotation

--- a/docs/guides/extension-guide.md
+++ b/docs/guides/extension-guide.md
@@ -2,6 +2,20 @@
 
 Overview of extension points in labelImg++ for developers who want to customize or extend functionality.
 
+## External plugins or source contributions?
+
+Use the [plugin API](plugin-authoring.md) when a separately installed package
+only needs host-owned commands, JSON settings, background tasks, read-only
+document state, and diagnostics. Plugins use the stable
+`labelimgplusplus.plugins` namespace and do not modify this repository.
+
+The patterns below are for source contributions built and reviewed with
+labelImg++ itself. Direct imports from `libs.*` and edits to MainWindow, Canvas,
+Shape, format dispatch, resources, or string bundles are not external plugin
+APIs. Custom annotation-tool APIs are tracked by issue #27 and external format
+adapters by issue #28; until those land, such work must remain a source
+contribution.
+
 ## Extension Points Overview
 
 ```
@@ -38,6 +52,7 @@ Overview of extension points in labelImg++ for developers who want to customize 
 
 | Extension Type | Files to Modify | Guide |
 |----------------|-----------------|-------|
+| External command plugin | Separate installed distribution | [Plugin Authoring](plugin-authoring.md) |
 | New annotation format | `libs/*_io.py`, `libs/labelFile.py`, `labelImgPlusPlus.py` | [Adding Formats](adding-formats.md) |
 | New action/feature | `labelImgPlusPlus.py`, `resources/strings/` | [Adding Features](adding-features.md) |
 | New language | `resources/strings/strings-XX.properties` | [i18n Guide](i18n-guide.md) |
@@ -232,6 +247,8 @@ assert shapes[0][0] == 'cat'
 
 ## Resources
 
+- [Plugin Authoring Guide](plugin-authoring.md) - Stable external plugin workflow
+- [Plugin API Major 1](../reference/plugin-api-v1.md) - Public types and compatibility policy
 - [Adding Formats Guide](adding-formats.md) - Complete format implementation
 - [Adding Features Guide](adding-features.md) - UI and action implementation
 - [i18n Guide](i18n-guide.md) - Adding translations

--- a/docs/guides/plugin-authoring.md
+++ b/docs/guides/plugin-authoring.md
@@ -1,0 +1,235 @@
+# Plugin authoring guide
+
+labelImg++ API-major-1 plugins are normal Python distributions installed into
+the same environment as the application. The host discovers them through
+Python package entry points, keeps new plugins disabled, and loads code only
+after the user enables the plugin and restarts labelImg++.
+
+> Plugins are trusted in-process code, not sandboxed extensions. Enabling one
+> grants it the same filesystem, network, process, and Python access as
+> labelImg++. Review its publisher, source, version, homepage, and entry-point
+> reference, and install plugins in a dedicated virtual environment.
+
+## Create the distribution
+
+Use a separate project; do not place plugin source inside the labelImg++
+checkout:
+
+```text
+review-plugin/
+├── pyproject.toml
+└── src/
+    └── labelimgpp_review/
+        └── __init__.py
+```
+
+`pyproject.toml` declares one zero-argument factory in the canonical entry-point
+group:
+
+```toml
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "labelimgpp-review-plugin"
+version = "0.1.0"
+requires-python = ">=3.8"
+dependencies = ["labelimgplusplus>=3.0"]
+
+[project.entry-points."labelimgplusplus.plugins"]
+"com.example.review" = "labelimgpp_review:create_plugin"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+```
+
+The entry-point name is the canonical plugin ID. It must exactly match
+`PluginMetadata.id`, be globally unique, and contain only lowercase letters,
+digits, dots, underscores, and hyphens. Reverse-domain IDs are recommended.
+
+## Register a command
+
+The public API is `labelimgplusplus.plugins`; modules under `libs.*` are
+internal and are not a compatibility contract.
+
+```python
+from labelimgplusplus.plugins import (
+    CommandSpec,
+    PluginCapability,
+    PluginMetadata,
+)
+
+
+class ReviewPlugin:
+    metadata = PluginMetadata(
+        id="com.example.review",
+        display_name="Example Review",
+        version="0.1.0",
+        api_major=1,
+        capabilities=(PluginCapability.COMMANDS,),
+        description="Run a read-only review of the active document.",
+        homepage="https://example.com/labelimgpp-review",
+    )
+
+    def activate(self, context):
+        self.context = context
+        context.commands.register(CommandSpec(
+            id="run",
+            title="Run Example Review",
+            description="Analyze the active image or video project",
+            default_shortcut="Ctrl+Alt+R",
+            callback=self.run,
+            enabled=lambda document: document.kind in ("image", "video"),
+        ))
+
+    def deactivate(self):
+        pass
+
+    def run(self):
+        document = self.context.documents.current
+        self.context.diagnostics.report(
+            "review_started",
+            "Review started for %s" % document.source_path,
+            severity="info",
+        )
+
+
+def create_plugin():
+    return ReviewPlugin()
+```
+
+The host creates the `QAction`, owns its lifetime, places it in the Plugins
+menu, invokes the callback on `QApplication.thread()`, and exposes it to the
+shortcut editor as `plugin.com.example.review.run`. Plugins never receive the
+action, menu, MainWindow, Canvas, Shape, or another mutable application object.
+
+Activation and deactivation are synchronous and must be lightweight.
+Activation is registration-only: attempting to start a task from `activate()`
+rejects the activation. If any registration or activation step fails, all
+staged commands, settings writes, and document subscriptions are discarded.
+
+## Store settings
+
+Settings are isolated automatically by plugin ID:
+
+```python
+threshold = self.context.settings.get("threshold", 0.8)
+self.context.settings.set("threshold", 0.9)
+self.context.settings.delete("obsolete")
+```
+
+Values must be strict JSON: `None`, booleans, finite numbers, strings, lists,
+and dictionaries with string keys. Tuples, arbitrary Python objects, cycles,
+NaN/infinity, and a `__type__` key at any nesting level are rejected. Reads
+return copies and `as_dict()` returns a read-only snapshot.
+
+Writes made during activation are staged. Once active, successful writes are
+persisted immediately under `plugins.config.<plugin-id>` in the existing
+settings file. Configuration for an uninstalled plugin is retained until the
+user chooses **Forget Unavailable Plugin**.
+
+## Run background work
+
+Capture immutable/plain inputs on the GUI thread and submit heavy work after
+activation, normally from a command callback:
+
+```python
+def run(self):
+    document = self.context.documents.current
+    source_path = document.source_path
+
+    def work(handle):
+        handle.check_cancelled()
+        result = analyze_file(source_path)
+        handle.report_progress(100)
+        handle.check_cancelled()
+        return result
+
+    self.context.tasks.submit(
+        work,
+        key="review",
+        latest=True,
+        on_progress=self.show_progress,
+        on_result=self.show_result,
+        on_error=self.show_error,
+    )
+```
+
+Plugin task keys are host-namespaced. `latest=True` cooperatively cancels the
+previous task with the same local key. The host also cancels plugin work on a
+document-generation change and plugin shutdown, and discards stale results.
+Worker functions must call `check_cancelled()` around expensive steps. Result,
+error, and progress callbacks run on the GUI thread and are converted to
+diagnostics if they raise.
+
+Workers may return immutable/plain values or detached `QImage` values. They
+must not create `QPixmap`, widgets, `QAction`, or mutable Shape/Canvas/video
+objects, and must not use unmanaged global thread pools for host-integrated
+work.
+
+## Observe documents
+
+`context.documents.current` is a frozen `DocumentDescriptor`. Subscribe when
+the plugin needs updates:
+
+```python
+self.unsubscribe = context.documents.subscribe(self.document_changed)
+```
+
+The descriptor contains `kind`, `source_path`, `project_path`, `generation`,
+`revision`, `dirty`, and `read_only`. A subscription receives descriptors, not
+live models or widgets. Subscriptions are staged during activation and removed
+automatically at shutdown; the returned callable can remove one earlier.
+
+## Install and test locally
+
+Use the same virtual environment for the host and plugin:
+
+```bash
+python -m venv .venv
+. .venv/bin/activate
+python -m pip install labelimgplusplus
+python -m pip install -e ./review-plugin
+labelimgpp
+```
+
+On Windows, activate with `.venv\Scripts\activate`. Open **Tools → Plugins…**,
+review the provider and entry-point reference, enable the plugin, close the
+application cleanly, and restart it. Enable/disable changes never hot-load or
+hot-unload code in API major 1.
+
+For automated tests, build a wheel and install it into a clean environment.
+Test disabled discovery without importing the plugin module, enabled
+activation, command execution, callback failures, generation changes,
+cooperative cancellation, and repeated shutdown.
+
+## Recover from a broken plugin
+
+Start without discovery or loading:
+
+```bash
+LABELIMGPP_DISABLE_PLUGINS=1 labelimgpp
+```
+
+On Windows PowerShell:
+
+```powershell
+$env:LABELIMGPP_DISABLE_PLUGINS = "1"
+labelimgpp
+```
+
+Then uninstall or repair the distribution. Safe mode does not reset plugin
+configuration, shortcuts, application settings, or image/video project data.
+See [Troubleshooting](../reference/troubleshooting.md#plugins).
+
+## Scope of API major 1
+
+API major 1 initially supports commands, JSON settings, restricted background
+tasks, read-only document descriptors, and diagnostics. It does not provide a
+marketplace, automatic installation, signing, permissions, sandboxing, hot
+reload, plugin dependency resolution, or native-crash containment.
+
+Custom annotation tools belong to issue #27 and format/import/export adapters
+belong to issue #28. Until those APIs land, such changes remain source
+contributions rather than external plugins.

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,8 @@ This documentation provides comprehensive guidance for developers working with t
 | [Annotation Formats](formats/) | Format specifications and I/O |
 | [Ultralytics Dataset Export](features/ultralytics-export.md) | Direct YOLO detection layout, splits, and class mapping |
 | [Smart Video Annotation](features/smart-video-annotation.md) | PTS-based video projects, tracking, review, and export |
+| [Plugin Authoring](guides/plugin-authoring.md) | Build separately installed command plugins |
+| [Plugin API Major 1](reference/plugin-api-v1.md) | Stable types, services, lifecycle, and compatibility |
 | [Extension Guides](guides/) | How to extend labelImg++ |
 | [Reference](reference/) | Shortcuts, settings, troubleshooting |
 
@@ -142,6 +144,7 @@ python3 -m unittest discover tests -v
 - [CreateML](formats/createml.md) - JSON format details
 
 ### Guides
+- [Plugin Authoring](guides/plugin-authoring.md) - Package, install, enable, and test an external plugin
 - [Extension Guide](guides/extension-guide.md) - Overview of extension points
 - [Adding Formats](guides/adding-formats.md) - Create new annotation formats
 - [Adding Features](guides/adding-features.md) - Add new actions and UI
@@ -151,6 +154,7 @@ python3 -m unittest discover tests -v
 - [Testing Plan](testing-plan.md) - Test audit findings and roadmap
 
 ### Reference
+- [Plugin API Major 1](reference/plugin-api-v1.md) - Public plugin contract and deprecation policy
 - [Keyboard Shortcuts](reference/keyboard-shortcuts.md) - Complete hotkey reference
 - [Settings](reference/settings.md) - Configuration options
 - [Troubleshooting](reference/troubleshooting.md) - Common issues and solutions

--- a/docs/reference/plugin-api-v1.md
+++ b/docs/reference/plugin-api-v1.md
@@ -1,0 +1,158 @@
+# Plugin API major 1 reference
+
+Import the stable API from `labelimgplusplus.plugins`. Importing this module is
+standard-library-only and does not import Qt, NumPy, OpenCV, PyAV, SAM, Canvas,
+Shape, or MainWindow.
+
+```python
+from labelimgplusplus.plugins import PLUGIN_API_MAJOR
+
+assert PLUGIN_API_MAJOR == 1
+```
+
+## Discovery and identity
+
+- Entry-point group: `labelimgplusplus.plugins`
+- Entry-point value: a zero-argument `create_plugin()` factory
+- Canonical ID: the entry-point name, exactly equal to `PluginMetadata.id`
+- Allowed ID characters: lowercase letters, digits, dots, underscores, hyphens
+- Activation order: deterministic normalized-ID order
+- Duplicate IDs: every conflicting candidate is disabled
+- Disabled plugins: distribution metadata is read, target modules are not
+  imported
+- Safe mode: `LABELIMGPP_DISABLE_PLUGINS=1` skips discovery and loading
+
+Production discovery uses `importlib.metadata` and supports both the legacy
+Python 3.8/3.9 collection shapes and selectable Python 3.10–3.13 collections.
+
+## Frozen descriptors
+
+### `PluginMetadata`
+
+| Field | Type | Meaning |
+|---|---|---|
+| `id` | `str` | Canonical globally unique ID |
+| `display_name` | `str` | User-facing name |
+| `version` | `str` | Plugin API/content version |
+| `api_major` | `int` | Exactly one required plugin API major |
+| `capabilities` | `tuple[PluginCapability, ...]` | Declared host capabilities |
+| `description` | `str` | Optional summary |
+| `homepage` | `str` | Optional publisher/source page |
+
+### `PluginDiagnostic`
+
+Structured diagnostics contain `plugin_id`, `phase`, `code`, `message`,
+`details`, and `severity`. The manager preserves tracebacks in `details` for
+load, lifecycle, task, and callback failures.
+
+### `DocumentDescriptor`
+
+| Field | Meaning |
+|---|---|
+| `kind` | `none`, `image`, or `video` |
+| `source_path` | Active image/video path, if any |
+| `project_path` | Video project path, if any |
+| `generation` | Changes when the published document identity changes |
+| `revision` | Current document content revision |
+| `dirty` | Whether the active document has unsaved changes |
+| `read_only` | Whether host mutation is unavailable |
+
+### `CommandSpec`
+
+`CommandSpec(id, title, callback, description="", default_shortcut="",
+enabled=None)` declares a plugin-local command. The optional `enabled`
+predicate receives the current frozen `DocumentDescriptor`. The host-visible
+ID and shortcut key are `plugin.<plugin-id>.<command-id>`.
+
+## Capabilities
+
+`PluginCapability.COMMANDS` is the only initial capability. Unknown or
+unsupported required capabilities make the plugin incompatible. Issue #27 may
+add annotation-tool descriptors and issue #28 may add format/import/export
+descriptors only through backward-compatible additions or a later API major.
+
+## Lifecycle protocols
+
+The entry-point factory returns a `Plugin` with `metadata`,
+`activate(context)`, and `deactivate()`. The host calls activation on the GUI
+thread after core widgets, actions, menus, Settings, and TaskCoordinator exist,
+but before a queued startup document opens.
+
+Activation may register commands, settings changes, and document
+subscriptions. Those changes commit atomically after `activate()` returns.
+Tasks cannot start during activation. An import, factory, metadata,
+registration, or activation failure discards the staged transaction and does
+not stop base startup.
+
+Shutdown stops new task submissions, cancels plugin handles, deactivates active
+plugins in reverse order, removes subscriptions and host-owned actions, then
+continues TaskCoordinator shutdown. One deactivation failure does not block the
+remaining plugins. Repeated shutdown is safe.
+
+## `PluginContext` services
+
+### `commands`
+
+`register(CommandSpec) -> str` stages one command and returns its namespaced
+host ID. Duplicate local or host IDs reject the complete activation.
+
+### `tasks`
+
+```python
+submit(
+    work,
+    key=None,
+    latest=False,
+    on_result=None,
+    on_error=None,
+    on_progress=None,
+) -> PluginTaskHandle
+```
+
+Work runs on the existing bounded background lane and receives a handle with
+`cancel()`, `is_cancelled()`, `check_cancelled()`, and
+`report_progress(value)`. Callbacks return to the GUI thread. Keys are
+plugin-namespaced; results from an old generation or shutting-down plugin are
+discarded.
+
+### `settings`
+
+`get(key, default=None)`, `set(key, value)`, `delete(key)`, and `as_dict()`
+operate only on the active plugin's JSON object. Values are copied, validated
+recursively, and may not contain `__type__` keys. Configuration remains after
+the distribution disappears until explicitly forgotten.
+
+### `documents`
+
+`current` returns the latest `DocumentDescriptor`.
+`subscribe(callback) -> unsubscribe` stages a descriptor subscription.
+Document publications occur at successful image/video commits, dirty/revision
+changes, resets, and close transitions.
+
+### `diagnostics`
+
+`report(code, message, details="", severity="error")` adds a plugin-scoped
+diagnostic visible in **Tools → Plugins…**.
+
+## Thread and trust contract
+
+Plugin code is trusted and executes in-process. The API reduces accidental
+coupling; it does not restrict Python or operating-system access and is not a
+sandbox.
+
+The host owns all widgets, `QAction`, `QPixmap`, Canvas, Shape, selection,
+timeline, track state, undo/dirty state, and document mutation. Worker inputs
+and outputs must be detached plain/immutable data or detached `QImage` values.
+Plugin callbacks and every host UI mutation run on `QApplication.thread()`.
+
+## Compatibility and deprecation policy
+
+- Additive fields, protocols, methods, or capabilities may be introduced
+  within API major 1 when existing plugins continue to work.
+- Breaking signature, lifecycle, identity, or semantic changes require a new
+  API major.
+- A future major will be documented with a migration guide and a deprecation
+  period before support for the previous major is removed.
+- The application version and plugin API major are independent.
+- Nothing under `libs.*`, nor any MainWindow/Canvas/Shape attribute, becomes
+  public through plugin availability.

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -1,229 +1,130 @@
-# Settings Reference
+# Settings reference
 
-labelImg++ persists user preferences using a pickle-based settings system.
+labelImg++ stores application and plugin preferences as JSON. It never
+deserializes pickle data.
 
-**File:** `libs/settings.py` (lines 5-45)
+## Location and safety
 
-## Settings Location
+The default file is:
 
-```
-~/.labelImgSettings.pkl
-```
-
-The settings file is created automatically on first run and updated when the application closes.
-
-## Settings Class
-
-```python
-class Settings(object):
-    def __init__(self):
-        self.data = {}
-        self.path = get_config('.labelImgSettings.pkl')
-
-    def __setitem__(self, key, value):
-        self.data[key] = value
-
-    def __getitem__(self, key):
-        return self.data[key]
-
-    def get(self, key, default=None):
-        return self.data.get(key, default)
-
-    def save(self):
-        with open(self.path, 'wb') as f:
-            pickle.dump(self.data, f)
-
-    def load(self):
-        if os.path.exists(self.path):
-            with open(self.path, 'rb') as f:
-                self.data = pickle.load(f)
-
-    def reset(self):
-        if os.path.exists(self.path):
-            os.remove(self.path)
+```text
+~/.labelImgSettings.json
 ```
 
-## Settings Keys
+`libs/core/settings.py` loads the file during MainWindow construction and saves
+it on close or when a plugin enablement/configuration change must persist
+immediately. Corrupt JSON, invalid UTF-8, and old pickle content are rejected
+and defaults are used.
 
-**File:** `libs/constants.py` (lines 1-20)
+Qt values used by the application are represented by whitelisted `__type__`
+tags for `QSize`, `QPoint`, `QColor`, `QByteArray`, and known enums. Plugin
+settings cannot use `__type__` at any nesting level, preventing a plugin value
+from entering the application's tagged-value decoder.
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `SETTING_FILENAME` | str | '' | Last opened file path |
-| `SETTING_RECENT_FILES` | list | [] | Recent files list (max 7) |
-| `SETTING_WIN_SIZE` | QSize | (600, 500) | Window size |
-| `SETTING_WIN_POSE` | QPoint | (0, 0) | Window position |
-| `SETTING_WIN_STATE` | QByteArray | - | Dock/toolbar layout |
-| `SETTING_LINE_COLOR` | QColor | Green | Default line color |
-| `SETTING_FILL_COLOR` | QColor | Red | Default fill color |
-| `SETTING_ADVANCE_MODE` | bool | False | Advanced mode enabled |
-| `SETTING_AUTO_SAVE` | bool | False | Auto-save on navigate |
-| `SETTING_SINGLE_CLASS` | bool | False | Single class mode |
-| `SETTING_PAINT_LABEL` | bool | False | Display labels on boxes |
-| `SETTING_DRAW_SQUARE` | bool | False | Constrain to squares |
-| `SETTING_SAVE_DIR` | str | None | Default save directory |
-| `SETTING_LAST_OPEN_DIR` | str | None | Last browsed directory |
-| `SETTING_LABEL_FILE_FORMAT` | enum | PASCAL_VOC | Default format |
+## Application settings
 
-## Setting Details
+Common persisted keys include:
 
-### Window State
+| Key | Type | Description |
+|---|---|---|
+| `filename` | string | Last startup file when no directory is active |
+| `recentFiles` | list | Recently opened files/projects |
+| `window/size` | tagged QSize | Main window size |
+| `window/position` | tagged QPoint | Validated on-screen position |
+| `window/state` | tagged QByteArray | Dock and toolbar layout |
+| `line/color` | tagged QColor | Default annotation line color |
+| `fill/color` | tagged QColor | Default annotation fill color |
+| `advanced` | boolean | Advanced mode |
+| `galleryMode` | boolean | Full gallery mode |
+| `savedir` | string | Annotation destination |
+| `lastOpenDir` | string | Last browsed directory |
+| `autosave` | boolean | Save while navigating |
+| `autoSaveEnabled` | boolean | Timer-based autosave |
+| `autoSaveInterval` | integer | Timer interval in seconds |
+| `labelFileFormat` | tagged enum | Active built-in annotation format |
+| `shortcuts` | object | Built-in and retained plugin shortcut overrides |
 
-```python
-# Saved on close (labelImgPlusPlus.py:1255-1257)
-settings[SETTING_WIN_SIZE] = self.size()
-settings[SETTING_WIN_POSE] = self.pos()
-settings[SETTING_WIN_STATE] = self.saveState()
+See `libs/utils/constants.py` for the complete built-in key list. Existing
+annotation formats, filenames, class ordering, and project data are not stored
+in the plugin section.
 
-# Restored on start (labelImgPlusPlus.py:485-503)
-size = settings.get(SETTING_WIN_SIZE, QSize(600, 500))
-position = settings.get(SETTING_WIN_POSE, QPoint(0, 0))
-self.resize(size)
-self.move(position)
-self.restoreState(settings.get(SETTING_WIN_STATE, QByteArray()))
+## Plugin settings
+
+Plugin state uses one top-level JSON object:
+
+```json
+{
+  "plugins": {
+    "enabled": ["com.example.review"],
+    "config": {
+      "com.example.review": {
+        "threshold": 0.8
+      }
+    },
+    "metadata": {
+      "com.example.review": {
+        "display_name": "Example Review",
+        "version": "0.1.0",
+        "api_major": 1,
+        "capabilities": ["commands"],
+        "description": "",
+        "homepage": "https://example.com/plugin"
+      }
+    },
+    "shortcut_owners": {
+      "plugin.com.example.review.run": "com.example.review"
+    }
+  }
+}
 ```
 
-### Multi-Monitor Handling
+- `plugins.enabled` is the sorted set requested for the next startup. Newly
+  discovered plugins default to disabled. Changes made in **Tools → Plugins…**
+  save immediately and require restart.
+- `plugins.config.<plugin-id>` is accessible only through that plugin's
+  `PluginSettings` service. Values must be strict JSON with string keys, finite
+  numbers, no cycles, and no `__type__` key.
+- `plugins.metadata.<plugin-id>` caches structurally validated metadata after
+  an enabled load so the manager can show API/capability details without
+  importing a disabled plugin on later starts.
+- `plugins.shortcut_owners` is a host-maintained ownership index used to forget
+  retained shortcuts exactly even when one plugin ID is a dot-prefix of
+  another. Plugins cannot read or write it through `PluginSettings`.
+- Configuration and cached metadata remain when a distribution is removed.
+  **Forget Unavailable Plugin** removes them, its enabled state, and retained
+  `plugin.<plugin-id>.*` shortcut keys.
 
-```python
-# Validates position is on a visible screen
-saved_position = settings.get(SETTING_WIN_POSE, position)
-for i in range(QApplication.desktop().screenCount()):
-    if QApplication.desktop().availableGeometry(i).contains(saved_position):
-        position = saved_position
-        break
-```
+Disabled plugin shortcuts remain in `shortcuts` but are hidden from the
+shortcut editor and conflict detection until their commands are registered.
+Reset/import/export includes active plugin commands; unknown non-plugin keys
+are ignored.
 
-### Recent Files
+## Inspect the file
 
-```python
-# Maximum 7 recent files
-self.max_recent = 7
-
-def add_recent_file(self, file_path):
-    if file_path in self.recent_files:
-        self.recent_files.remove(file_path)
-    elif len(self.recent_files) >= self.max_recent:
-        self.recent_files.pop()
-    self.recent_files.insert(0, file_path)
-```
-
-### Colors
-
-```python
-# Default colors (libs/shape.py)
-DEFAULT_LINE_COLOR = QColor(0, 255, 0, 128)    # Green, semi-transparent
-DEFAULT_FILL_COLOR = QColor(255, 0, 0, 128)    # Red, semi-transparent
-
-# Saved as QColor objects
-settings[SETTING_LINE_COLOR] = self.line_color
-settings[SETTING_FILL_COLOR] = self.fill_color
-```
-
-### Format Setting
-
-```python
-# Saved as enum value
-settings[SETTING_LABEL_FILE_FORMAT] = self.label_file_format
-
-# Restored
-self.label_file_format = settings.get(
-    SETTING_LABEL_FILE_FORMAT,
-    LabelFileFormat.PASCAL_VOC
-)
-```
-
-## UI Menu Options
-
-These settings are accessible via the View menu:
-
-| Menu Item | Setting Key | Description |
-|-----------|-------------|-------------|
-| Auto Save Mode | `SETTING_AUTO_SAVE` | Save when navigating |
-| Single Class Mode | `SETTING_SINGLE_CLASS` | Reuse last label |
-| Display Labels | `SETTING_PAINT_LABEL` | Show labels on canvas |
-| Draw Squares | `SETTING_DRAW_SQUARE` | Square constraint |
-
-## Resetting Settings
-
-### Via Menu
-
-```
-File > Reset All
-```
-
-This calls `MainWindow.reset_all()`:
-```python
-def reset_all(self):
-    self.settings.reset()  # Deletes settings file
-    self.close()
-    process = QProcess()
-    process.startDetached(os.path.abspath(__file__))  # Restart app
-```
-
-### Manual Reset
+Use a JSON parser rather than pickle:
 
 ```bash
-rm ~/.labelImgSettings.pkl
+python -m json.tool ~/.labelImgSettings.json
 ```
 
-## Save Triggers
+Do not edit the file while labelImg++ is running; a later application or
+plugin save may replace manual changes.
 
-Settings are saved in `closeEvent`:
+## Recovery and reset
 
-```python
-def closeEvent(self, event):
-    if not self.may_continue():
-        event.ignore()
-        return
+To bypass plugin discovery/loading without changing settings:
 
-    settings = self.settings
-    # ... set all values ...
-    settings.save()
+```bash
+LABELIMGPP_DISABLE_PLUGINS=1 labelimgpp
 ```
 
-## Load Timing
+To reset every application and plugin preference, use **File → Reset All** or
+remove the JSON file while the application is closed:
 
-Settings are loaded during `MainWindow.__init__`:
-
-```python
-def __init__(self, ...):
-    # Line 81-83
-    self.settings = Settings()
-    self.settings.load()
-    settings = self.settings
+```bash
+rm ~/.labelImgSettings.json
 ```
 
-## Constants Reference
-
-```python
-# libs/constants.py
-SETTING_FILENAME = 'filename'
-SETTING_RECENT_FILES = 'recentFiles'
-SETTING_WIN_SIZE = 'window/size'
-SETTING_WIN_POSE = 'window/position'
-SETTING_WIN_STATE = 'window/state'
-SETTING_LINE_COLOR = 'line/color'
-SETTING_FILL_COLOR = 'fill/color'
-SETTING_ADVANCE_MODE = 'advanced'
-SETTING_WIN_GEOMETRY = 'window/geometry'
-SETTING_SAVE_DIR = 'savedir'
-SETTING_LAST_OPEN_DIR = 'lastOpenDir'
-SETTING_AUTO_SAVE = 'autosave'
-SETTING_SINGLE_CLASS = 'singleclass'
-SETTING_PAINT_LABEL = 'paintlabel'
-SETTING_DRAW_SQUARE = 'draw/square'
-SETTING_LABEL_FILE_FORMAT = 'labelFileFormat'
-```
-
-## Debugging Settings
-
-To inspect current settings:
-
-```python
-import pickle
-with open(os.path.expanduser('~/.labelImgSettings.pkl'), 'rb') as f:
-    data = pickle.load(f)
-    for key, value in data.items():
-        print(f"{key}: {value}")
-```
+Reset All keeps the configured settings path usable, relaunches the
+application, and does not delete annotations, images, videos, or video project
+databases.

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -23,12 +23,17 @@ Common issues and solutions when using labelImg++.
    python3 -c "from lxml import etree; print('lxml OK')"
    ```
 
-3. **Reset Settings**
+3. **Start in plugin safe mode**
    ```bash
-   rm ~/.labelImgSettings.pkl
+   LABELIMGPP_DISABLE_PLUGINS=1 labelimgpp
    ```
 
-4. **Rebuild Resources**
+4. **Reset Settings**
+   ```bash
+   rm ~/.labelImgSettings.json
+   ```
+
+5. **Rebuild Resources**
    ```bash
    make qt5py3
    # Or manually:
@@ -50,8 +55,57 @@ make qt5py3
 
 **Solution:**
 ```bash
-rm ~/.labelImgSettings.pkl
+rm ~/.labelImgSettings.json
 ```
+
+## Plugins
+
+### Startup changed after enabling a plugin
+
+Run labelImg++ without discovering or loading any plugin:
+
+```bash
+LABELIMGPP_DISABLE_PLUGINS=1 labelimgpp
+```
+
+In Windows PowerShell:
+
+```powershell
+$env:LABELIMGPP_DISABLE_PLUGINS = "1"
+labelimgpp
+```
+
+Safe mode does not change image/video projects, plugin configuration,
+shortcuts, or unrelated application settings. Uninstall or repair the suspect
+distribution in the same virtual environment, then start normally. Plugins are
+trusted in-process code; safe mode cannot undo filesystem, network, or process
+actions already performed by a plugin.
+
+### Plugin is disabled or says restart required
+
+Open **Tools → Plugins…**, verify the distribution name, version, homepage, and
+entry-point reference, then change the checkbox. The change is persisted
+immediately but takes effect only after a complete application restart. New
+plugins always default to disabled.
+
+### Plugin is incompatible, conflicting, or failed
+
+- **Incompatible** means its required API major or capability is unsupported.
+- **Conflicting** means multiple installed distributions claim the same plugin
+  ID; the host loads none of them.
+- **Failed** means factory, metadata, activation, command, callback, task, or
+  deactivation validation raised an exception.
+
+Select the plugin in the manager and copy its structured diagnostics. Upgrade
+or remove the distribution rather than editing `libs.*` or plugin metadata in
+place.
+
+### Uninstalled plugin still appears
+
+Unavailable entries retain their configuration and shortcut overrides by
+design. Select the entry and choose **Forget Unavailable Plugin** to remove its
+`plugins.config`, cached metadata, enabled state, and `plugin.<id>.*` shortcut
+keys.
 
 ## Smart Video
 
@@ -333,7 +387,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 | Problem | Quick Fix |
 |---------|-----------|
-| Won't start | `rm ~/.labelImgSettings.pkl` |
+| Won't start | Try `LABELIMGPP_DISABLE_PLUGINS=1`, then inspect `~/.labelImgSettings.json` |
 | No resources | `make qt5py3` |
 | No save | Check File > Change Save Dir |
 | No load | Check annotation filename matches |

--- a/docs/testing-plan.md
+++ b/docs/testing-plan.md
@@ -13,7 +13,7 @@ Linux workstation gate and its deterministic 10k corpora.
 
 - `tests/test_commands.py`: unit tests for undo/redo command system (`libs/commands.py`)
 - `tests/test_io.py`: Pascal VOC + CreateML I/O smoke tests (`libs/pascal_voc_io.py`, `libs/create_ml_io.py`)
-- `tests/test_settings.py`: basic settings persistence (`libs/settings.py`)
+- `tests/core/test_settings.py`: isolated JSON settings persistence (`libs/core/settings.py`)
 - `tests/test_utils.py`: basic utilities (`libs/utils.py`)
 - `tests/test_stringBundle.py`: i18n bundle loading (`libs/stringBundle.py`)
 - `tests/test_qt.py`: Qt app boot (currently a no-op test)
@@ -43,7 +43,7 @@ documented in `docs/performance.md`.
 
 ### Stability / isolation risks
 
-- `tests/test_settings.py` writes to `~/.labelImgSettings.pkl` (can pollute machines and create flaky tests)
+- Settings tests replace the default path with isolated temporary JSON files.
 - `tests/test_stringBundle.py` assumes `LC_ALL` and `LANG` exist in the environment
 - `tests/test_io.py` writes into the repository under `tests/` instead of a temporary directory
 

--- a/labelImgPlusPlus.py
+++ b/labelImgPlusPlus.py
@@ -79,6 +79,7 @@ from libs.core.save_pipeline import (
     SaveRequest, target_path as annotation_target_path, write_save_request,
 )
 from libs.core.task_coordinator import JobPriority, TaskCoordinator
+from libs.core.plugin_manager import PluginManager
 from libs.core.profiling import (
     hash_path, recorder as trace_recorder, trace_span,
 )
@@ -98,7 +99,11 @@ from libs.core.video_types import (
     DocumentKind, TrackingRequest, VideoExportRequest, VideoFrameRef,
 )
 from libs.widgets.videoTimelineWidget import format_timecode, parse_timecode
+from libs.widgets.pluginManagerDialog import (
+    PluginManagerDialog, QtPluginCommandHost,
+)
 from libs.integrations import segmentation
+from labelimgplusplus.plugins import DocumentDescriptor
 
 # Formats
 from libs.formats.labelFile import LabelFile, LabelFileError, LabelFileFormat
@@ -205,6 +210,10 @@ class MainWindow(QMainWindow, WindowMixin):
         self._path_to_idx = {}  # O(1) lookup: path -> index
         self._annotation_status_cache = {}  # Cache: path -> status (reduces I/O)
         self.task_coordinator = TaskCoordinator(parent=self)
+        self._plugin_document_generation = 0
+        self._plugin_document_ready = False
+        self.plugin_manager = PluginManager(
+            settings, self.task_coordinator, parent=self)
         self._dataset_generation = 0
         self.dataset_snapshot = DatasetSnapshot.from_images(
             (), save_dir=default_save_dir, generation=0)
@@ -895,6 +904,7 @@ class MainWindow(QMainWindow, WindowMixin):
             edit=self.menu(get_str('menu_edit')),
             view=self.menu(get_str('menu_view')),
             tools=self.menu('&Tools'),
+            plugins=self.menu('&Plugins'),
             help=self.menu(get_str('menu_help')),
             recentFiles=QMenu(get_str('menu_openRecent')),
             labelList=label_menu)
@@ -1030,6 +1040,9 @@ class MainWindow(QMainWindow, WindowMixin):
         export_ultralytics_action = action(
             get_str('exportUltralytics'), self.export_ultralytics_dataset,
             None, 'save-as', get_str('exportUltralyticsDetail'))
+        plugin_manager_action = action(
+            'Plugins…', self.show_plugins_dialog,
+            None, None, 'Inspect, enable, disable, and diagnose installed plugins')
         add_actions(self.menus.tools, (
             check_labels, batch_verify_action, split_dataset_action,
             export_ultralytics_action,
@@ -1039,7 +1052,8 @@ class MainWindow(QMainWindow, WindowMixin):
             video_accept_visible, video_reject_visible,
             video_accept_run, video_reject_run,
             video_delete_track, video_export,
-            None, sam_mode_action, sam_settings_action))
+            None, sam_mode_action, sam_settings_action,
+            None, plugin_manager_action))
 
         # Custom context menu for the canvas widget:
         add_actions(self.canvas.menus[0], self.actions.beginnerContext)
@@ -1181,6 +1195,12 @@ class MainWindow(QMainWindow, WindowMixin):
         # Start auto-save timer if enabled (Issue #13)
         if self.auto_save_enabled.isChecked():
             self._toggle_auto_save_timer()
+
+        self.plugin_command_host = QtPluginCommandHost(
+            self, self.menus.plugins, self.shortcut_config,
+            self._action_map, self.settings)
+        self.plugin_manager.command_host = self.plugin_command_host
+        self.plugin_manager.activate_enabled()
 
     def keyReleaseEvent(self, event):
         if event.key() == Qt.Key_Control:
@@ -1374,12 +1394,14 @@ class MainWindow(QMainWindow, WindowMixin):
             self.actions.save.setEnabled(True)
             self.update_save_status(saved=False)
             self.update_box_count()
+            self._publish_plugin_document()
             return
         self._document_revision += 1
         self.dirty = True
         self.actions.save.setEnabled(True)
         self.update_save_status(saved=False)
         self.update_box_count()
+        self._publish_plugin_document()
 
     def set_clean(self):
         self.dirty = False
@@ -1395,6 +1417,46 @@ class MainWindow(QMainWindow, WindowMixin):
             self.actions.editMode.setEnabled(False)
             self.actions.verify.setEnabled(False)
         self.update_save_status(saved=True)
+        self._publish_plugin_document()
+
+    def _plugin_document_descriptor(self):
+        kind = getattr(self, 'document_kind', DocumentKind.NONE)
+        source_path = None
+        project_path = None
+        read_only = True
+        revision = 0
+        dirty = False
+        if kind == DocumentKind.IMAGE:
+            source_path = self.file_path or None
+            read_only = False
+            revision = self._document_revision
+            dirty = bool(self.dirty)
+        elif kind == DocumentKind.VIDEO and self.video_snapshot is not None:
+            source_path = self.video_snapshot.source_path
+            project_path = self.video_snapshot.project_path
+            if project_path is not None:
+                project_path = os.fspath(project_path)
+            read_only = bool(self.video_snapshot.read_only)
+            revision = self._document_revision
+            dirty = bool(self.dirty)
+        return DocumentDescriptor(
+            kind=kind.value,
+            source_path=source_path,
+            project_path=project_path,
+            generation=self._plugin_document_generation,
+            revision=revision,
+            dirty=dirty,
+            read_only=read_only,
+        )
+
+    def _publish_plugin_document(self, new_generation=False, force=False):
+        manager = getattr(self, 'plugin_manager', None)
+        if manager is None or (not self._plugin_document_ready and not force):
+            return
+        assert QApplication.instance().thread() == self.thread()
+        if new_generation:
+            self._plugin_document_generation += 1
+        manager.publish_document(self._plugin_document_descriptor())
 
     def toggle_actions(self, value=True):
         """Enable/Disable widgets which depend on an opened image."""
@@ -1463,6 +1525,7 @@ class MainWindow(QMainWindow, WindowMixin):
         self._update_save_status_style(saved)
 
     def reset_state(self):
+        self._plugin_document_ready = False
         self._restart_workers_if_needed()
         self._close_video_decoder()
         self._set_document_kind(DocumentKind.NONE)
@@ -1483,6 +1546,7 @@ class MainWindow(QMainWindow, WindowMixin):
         # Reset status bar widgets
         self.label_box_count.setText('Boxes: 0')
         self.update_save_status(saved=True)
+        self._publish_plugin_document(new_generation=True, force=True)
 
     def _set_document_kind(self, kind):
         """Switch cache policy and document-only UI without touching content."""
@@ -1637,6 +1701,12 @@ class MainWindow(QMainWindow, WindowMixin):
         dialog = ShortcutsDialog(self.shortcut_config, self._action_map, self)
         if hasattr(self, '_current_theme'):
             dialog.apply_theme(self._current_theme)
+        dialog.exec_()
+
+    def show_plugins_dialog(self):
+        dialog = PluginManagerDialog(self.plugin_manager, self)
+        if hasattr(self, '_current_theme'):
+            dialog.setStyleSheet(get_stylesheet(self._current_theme))
         dialog.exec_()
 
     def create_shape(self):
@@ -2959,6 +3029,8 @@ class MainWindow(QMainWindow, WindowMixin):
         self.update_status_bar()
         self.canvas.setFocus(True)
         self.status('Opened video %s' % os.path.basename(snapshot.source_path))
+        self._plugin_document_ready = True
+        self._publish_plugin_document(new_generation=True, force=True)
 
     def open_video(self, path, project_path=None):
         """Synchronous compatibility API for extensions and tests."""
@@ -3126,6 +3198,7 @@ class MainWindow(QMainWindow, WindowMixin):
         self._refresh_video_timeline_markers()
         self._refresh_video_track_list()
         self.update_box_count()
+        self._publish_plugin_document()
 
     def _shape_geometry(self, shape):
         inverse = (1.0 / self._image_scale_factor
@@ -4171,6 +4244,8 @@ class MainWindow(QMainWindow, WindowMixin):
                 'image.ui-apply', trace_started,
                 args={'path': hash_path(result.path),
                       'shapes': len(result.shapes)})
+        self._plugin_document_ready = True
+        self._publish_plugin_document(new_generation=True, force=True)
 
     def request_next_image(self, _value=False):
         if self.document_kind == DocumentKind.VIDEO:
@@ -4379,6 +4454,8 @@ class MainWindow(QMainWindow, WindowMixin):
 
             self.canvas.setFocus(True)
             self._update_current_image_stats()
+            self._plugin_document_ready = True
+            self._publish_plugin_document(new_generation=True, force=True)
             return True
         return False
 
@@ -4540,6 +4617,10 @@ class MainWindow(QMainWindow, WindowMixin):
         QTimer.singleShot(0, self.close)
 
     def _shutdown_workers(self):
+        self._plugin_document_ready = False
+        self._publish_plugin_document(new_generation=True, force=True)
+        if hasattr(self, 'plugin_manager'):
+            self.plugin_manager.shutdown()
         self.annotation_catalog.cancel()
         if hasattr(self, 'sam_controller'):
             self.sam_controller.cancel()

--- a/labelimgplusplus/__init__.py
+++ b/labelimgplusplus/__init__.py
@@ -1,0 +1,7 @@
+"""Stable public interfaces for labelImg++ integrations.
+
+Application implementation modules remain under :mod:`libs` and are not part
+of the compatibility contract.  Public APIs are exposed from this package.
+"""
+
+__all__ = ["plugins"]

--- a/labelimgplusplus/plugins.py
+++ b/labelimgplusplus/plugins.py
@@ -1,0 +1,176 @@
+"""Public, Qt-free plugin API for labelImg++.
+
+Plugins are trusted, installed Python packages.  These interfaces deliberately
+expose descriptors and host-owned services instead of application internals.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Callable, Mapping, Optional, Protocol, Tuple
+
+
+PLUGIN_API_MAJOR = 1
+
+
+class PluginCapability(str, Enum):
+    """Capabilities understood by the current plugin host."""
+
+    COMMANDS = "commands"
+
+
+@dataclass(frozen=True)
+class PluginMetadata:
+    """Identity and compatibility information declared by a plugin."""
+
+    id: str
+    display_name: str
+    version: str
+    api_major: int
+    capabilities: Tuple[PluginCapability, ...]
+    description: str = ""
+    homepage: str = ""
+
+
+@dataclass(frozen=True)
+class PluginDiagnostic:
+    """A structured plugin failure or warning suitable for display."""
+
+    plugin_id: str
+    phase: str
+    code: str
+    message: str
+    details: str = ""
+    severity: str = "error"
+
+
+@dataclass(frozen=True)
+class DocumentDescriptor:
+    """Immutable summary of the active document."""
+
+    kind: str = "none"
+    source_path: Optional[str] = None
+    project_path: Optional[str] = None
+    generation: int = 0
+    revision: int = 0
+    dirty: bool = False
+    read_only: bool = True
+
+
+@dataclass(frozen=True)
+class CommandSpec:
+    """A plugin-local command registered as a host-owned action."""
+
+    id: str
+    title: str
+    callback: Callable[[], None]
+    description: str = ""
+    default_shortcut: str = ""
+    enabled: Optional[Callable[[DocumentDescriptor], bool]] = None
+
+
+class CommandRegistry(Protocol):
+    """Transactional registry for commands declared during activation."""
+
+    def register(self, command: CommandSpec) -> str:
+        """Stage *command* and return its host namespaced identifier."""
+
+
+class PluginTaskHandle(Protocol):
+    """Cooperative cancellation and progress surface passed to task work."""
+
+    def cancel(self) -> None: ...
+
+    def is_cancelled(self) -> bool: ...
+
+    def check_cancelled(self) -> None: ...
+
+    def report_progress(self, value: Any) -> None: ...
+
+
+class PluginTaskService(Protocol):
+    """Restricted access to the host's background worker lane."""
+
+    def submit(
+        self,
+        work: Callable[[PluginTaskHandle], Any],
+        key: Optional[str] = None,
+        latest: bool = False,
+        on_result: Optional[Callable[[Any], None]] = None,
+        on_error: Optional[Callable[[str], None]] = None,
+        on_progress: Optional[Callable[[Any], None]] = None,
+    ) -> PluginTaskHandle: ...
+
+
+class PluginSettings(Protocol):
+    """JSON-only settings isolated to one plugin ID."""
+
+    def get(self, key: str, default: Any = None) -> Any: ...
+
+    def set(self, key: str, value: Any) -> None: ...
+
+    def delete(self, key: str) -> None: ...
+
+    def as_dict(self) -> Mapping[str, Any]: ...
+
+
+class ReadOnlyDocumentService(Protocol):
+    """Read and subscribe to immutable active-document descriptors."""
+
+    @property
+    def current(self) -> DocumentDescriptor: ...
+
+    def subscribe(
+        self, callback: Callable[[DocumentDescriptor], None]
+    ) -> Callable[[], None]: ...
+
+
+class PluginDiagnostics(Protocol):
+    """Plugin-scoped diagnostic reporting service."""
+
+    def report(
+        self,
+        code: str,
+        message: str,
+        details: str = "",
+        severity: str = "error",
+    ) -> None: ...
+
+
+class PluginContext(Protocol):
+    """Services available while a plugin is active."""
+
+    commands: CommandRegistry
+    tasks: PluginTaskService
+    settings: PluginSettings
+    documents: ReadOnlyDocumentService
+    diagnostics: PluginDiagnostics
+
+
+class Plugin(Protocol):
+    """Object returned by a plugin's zero-argument factory."""
+
+    metadata: PluginMetadata
+
+    def activate(self, context: PluginContext) -> None: ...
+
+    def deactivate(self) -> None: ...
+
+
+__all__ = [
+    "PLUGIN_API_MAJOR",
+    "CommandRegistry",
+    "CommandSpec",
+    "DocumentDescriptor",
+    "Plugin",
+    "PluginCapability",
+    "PluginContext",
+    "PluginDiagnostic",
+    "PluginDiagnostics",
+    "PluginMetadata",
+    "PluginSettings",
+    "PluginTaskHandle",
+    "PluginTaskService",
+    "ReadOnlyDocumentService",
+]

--- a/libs/core/plugin_discovery.py
+++ b/libs/core/plugin_discovery.py
@@ -1,0 +1,189 @@
+"""Metadata-only discovery for installed labelImg++ plugins."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from importlib import metadata
+import re
+from typing import Optional, Tuple
+
+from labelimgplusplus.plugins import PluginDiagnostic
+
+
+ENTRY_POINT_GROUP = "labelimgplusplus.plugins"
+_VALID_PLUGIN_ID = re.compile(r"^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$")
+_NORMALIZE_ID = re.compile(r"[-_.]+")
+
+
+def is_valid_plugin_id(plugin_id):
+    """Return whether *plugin_id* is a valid canonical entry-point name."""
+    return isinstance(plugin_id, str) and bool(_VALID_PLUGIN_ID.fullmatch(plugin_id))
+
+
+def normalized_plugin_id(plugin_id):
+    """Return a deterministic comparison key for a plugin ID."""
+    return _NORMALIZE_ID.sub("-", plugin_id).lower()
+
+
+@dataclass(frozen=True)
+class PluginCandidate:
+    """An entry point plus provider data, without importing plugin code."""
+
+    id: str
+    reference: str
+    distribution: Optional[str]
+    distribution_version: Optional[str]
+    entry_point: object = field(compare=False, repr=False)
+    diagnostics: Tuple[PluginDiagnostic, ...] = ()
+
+    @property
+    def loadable(self):
+        return not self.diagnostics
+
+
+def select_plugin_entry_points(collection):
+    """Adapt legacy mapping/list and modern selectable entry-point results."""
+    select = getattr(collection, "select", None)
+    if callable(select):
+        return tuple(select(group=ENTRY_POINT_GROUP))
+    if isinstance(collection, dict):
+        return tuple(collection.get(ENTRY_POINT_GROUP, ()))
+    return tuple(
+        entry_point for entry_point in collection
+        if getattr(entry_point, "group", None) == ENTRY_POINT_GROUP
+    )
+
+
+def _provider_from_entry_point(entry_point):
+    distribution = getattr(entry_point, "dist", None)
+    if distribution is None:
+        return None, None
+    dist_metadata = getattr(distribution, "metadata", {})
+    name = None
+    try:
+        name = dist_metadata.get("Name")
+    except AttributeError:
+        pass
+    version = getattr(distribution, "version", None)
+    return name, version
+
+
+def _provider_index(distributions):
+    """Index distributions for Python versions whose EntryPoint lacks .dist."""
+    result = {}
+    for distribution in distributions:
+        dist_metadata = getattr(distribution, "metadata", {})
+        try:
+            name = dist_metadata.get("Name")
+        except AttributeError:
+            name = None
+        version = getattr(distribution, "version", None)
+        for entry_point in getattr(distribution, "entry_points", ()):
+            if getattr(entry_point, "group", None) != ENTRY_POINT_GROUP:
+                continue
+            key = (
+                getattr(entry_point, "name", None),
+                getattr(entry_point, "value", None),
+            )
+            result.setdefault(key, []).append((name, version))
+    return result
+
+
+def discover_plugins(entry_points_provider=None, distributions_provider=None):
+    """Discover plugin candidates without importing their target modules.
+
+    Providers are injectable to exercise the Python 3.8/3.9 and 3.10+
+    metadata collection shapes without patching global package metadata.
+    """
+    entry_points_provider = entry_points_provider or metadata.entry_points
+    distributions_provider = distributions_provider or metadata.distributions
+    entry_points = select_plugin_entry_points(entry_points_provider())
+
+    missing_provider = [
+        entry_point for entry_point in entry_points
+        if _provider_from_entry_point(entry_point)[0] is None
+    ]
+    fallback = {}
+    if missing_provider:
+        fallback = _provider_index(distributions_provider())
+
+    candidates = []
+    for entry_point in entry_points:
+        plugin_id = getattr(entry_point, "name", "")
+        reference = getattr(entry_point, "value", "")
+        provider_name, provider_version = _provider_from_entry_point(entry_point)
+        if provider_name is None:
+            providers = fallback.get((plugin_id, reference), ())
+            if len(providers) == 1:
+                provider_name, provider_version = providers[0]
+
+        diagnostics = []
+        if not is_valid_plugin_id(plugin_id):
+            diagnostics.append(PluginDiagnostic(
+                plugin_id=plugin_id or "<unknown>",
+                phase="discovery",
+                code="invalid_plugin_id",
+                message=("Plugin IDs must use lowercase letters, digits, dots, "
+                         "underscores, and hyphens."),
+            ))
+        if not provider_name or not provider_version:
+            diagnostics.append(PluginDiagnostic(
+                plugin_id=plugin_id or "<unknown>",
+                phase="discovery",
+                code="missing_provider_metadata",
+                message="The entry point has no complete provider name/version metadata.",
+            ))
+        candidates.append(PluginCandidate(
+            id=plugin_id,
+            reference=reference,
+            distribution=provider_name,
+            distribution_version=provider_version,
+            entry_point=entry_point,
+            diagnostics=tuple(diagnostics),
+        ))
+
+    by_id = {}
+    for candidate in candidates:
+        by_id.setdefault(candidate.id, []).append(candidate)
+    conflicts = {plugin_id for plugin_id, group in by_id.items() if len(group) > 1}
+    if conflicts:
+        updated = []
+        for candidate in candidates:
+            if candidate.id not in conflicts:
+                updated.append(candidate)
+                continue
+            diagnostic = PluginDiagnostic(
+                plugin_id=candidate.id,
+                phase="discovery",
+                code="duplicate_plugin_id",
+                message="Multiple installed distributions claim this plugin ID.",
+            )
+            updated.append(PluginCandidate(
+                id=candidate.id,
+                reference=candidate.reference,
+                distribution=candidate.distribution,
+                distribution_version=candidate.distribution_version,
+                entry_point=candidate.entry_point,
+                diagnostics=candidate.diagnostics + (diagnostic,),
+            ))
+        candidates = updated
+
+    return tuple(sorted(
+        candidates,
+        key=lambda item: (
+            normalized_plugin_id(item.id),
+            item.id,
+            item.distribution or "",
+            item.reference,
+        ),
+    ))
+
+
+__all__ = [
+    "ENTRY_POINT_GROUP",
+    "PluginCandidate",
+    "discover_plugins",
+    "is_valid_plugin_id",
+    "normalized_plugin_id",
+    "select_plugin_entry_points",
+]

--- a/libs/core/plugin_manager.py
+++ b/libs/core/plugin_manager.py
@@ -67,9 +67,15 @@ class PluginRecord:
 
 
 class _NullCommandHost:
-    def commit(self, plugin_id, commands, invoke):
-        del plugin_id, commands, invoke
+    def commit(self, plugin_id, commands, invoke, enabled):
+        del plugin_id, commands, invoke, enabled
         return lambda: None
+
+    def refresh_enablement(self):
+        pass
+
+    def forget(self, plugin_id):
+        del plugin_id
 
 
 class _ValidationFailure(Exception):
@@ -97,7 +103,20 @@ class PluginManager(QObject):
         self._document = DocumentDescriptor()
         self._records = []
         if not self.safe_mode:
-            discovered = tuple(candidates) if candidates is not None else discovery()
+            try:
+                discovered = (
+                    tuple(candidates) if candidates is not None
+                    else discovery())
+            except Exception as exc:
+                record = PluginRecord(
+                    id="<discovery>",
+                    state=PluginState.FAILED,
+                    enabled=False,
+                )
+                self._record_exception(
+                    record, "discovery", "discovery_failed", exc)
+                self._records.append(record)
+                return
             discovered = tuple(sorted(
                 discovered,
                 key=lambda item: (
@@ -181,6 +200,9 @@ class PluginManager(QObject):
             except Exception as exc:
                 self._record_exception(
                     record, "callback", "document_callback_failed", exc)
+        refresh = getattr(self.command_host, "refresh_enablement", None)
+        if callable(refresh):
+            refresh()
 
     def set_enabled(self, plugin_id, enabled):
         enabled_ids = set(self._enabled_ids())
@@ -199,6 +221,7 @@ class PluginManager(QObject):
         if any(record.id == plugin_id and record.is_active
                for record in self._records):
             raise RuntimeError("active plugins can only be forgotten after restart")
+        settings_before = deepcopy(self.settings.data)
         plugins = self._plugins_settings_copy()
         plugins["enabled"] = [
             item for item in plugins.get("enabled", ()) if item != plugin_id]
@@ -206,9 +229,23 @@ class PluginManager(QObject):
             values = plugins.get(section)
             if isinstance(values, dict):
                 values.pop(plugin_id, None)
-        self._replace_plugins_settings(plugins)
+        self.settings["plugins"] = plugins
+        forget_shortcuts = getattr(self.command_host, "forget", None)
+        try:
+            saved = (
+                forget_shortcuts(plugin_id)
+                if callable(forget_shortcuts) else None)
+            if saved is None:
+                saved = self.settings.save()
+        except Exception:
+            self.settings.data = settings_before
+            raise
+        if not saved:
+            self.settings.data = settings_before
+            return False
         self._records = [record for record in self._records
                          if record.id != plugin_id or record.candidate is not None]
+        return True
 
     def shutdown(self):
         if self._shutting_down:
@@ -258,6 +295,7 @@ class PluginManager(QObject):
                 state=state,
                 enabled=candidate.id in enabled,
                 candidate=candidate,
+                metadata=self._cached_metadata(candidate.id),
                 diagnostics=list(candidate.diagnostics),
             ))
         configured = set(enabled)
@@ -269,6 +307,7 @@ class PluginManager(QObject):
                 id=plugin_id,
                 state=PluginState.UNAVAILABLE,
                 enabled=plugin_id in enabled,
+                metadata=self._cached_metadata(plugin_id),
             ))
 
     def _activate(self, record):
@@ -319,7 +358,8 @@ class PluginManager(QObject):
                         "Command ID already registered: %s" % command_id)
                 staged[command_id] = command
             host_cleanup = self.command_host.commit(
-                record.id, dict(staged), self.invoke_command)
+                record.id, dict(staged), self.invoke_command,
+                self.command_enabled)
             if not callable(host_cleanup):
                 raise _ValidationFailure(
                     "invalid_command_host", "Command host did not return cleanup.")
@@ -332,6 +372,10 @@ class PluginManager(QObject):
             record.command_cleanup = host_cleanup
             record.state = PluginState.ACTIVE
             self._activation_order.append(record)
+            self._cache_metadata(record)
+            refresh = getattr(self.command_host, "refresh_enablement", None)
+            if callable(refresh):
+                refresh()
         except _ValidationFailure as exc:
             self.settings.data = settings_before
             if host_cleanup is not None:
@@ -343,6 +387,7 @@ class PluginManager(QObject):
             record.state = exc.state
             self._record_diagnostic(
                 record, "validation", exc.code, str(exc))
+            self._cache_metadata(record)
         except Exception as exc:
             self.settings.data = settings_before
             if host_cleanup is not None:
@@ -354,6 +399,7 @@ class PluginManager(QObject):
             record.state = PluginState.FAILED
             phase = "activation" if plugin is not None else "factory"
             self._record_exception(record, phase, "%s_failed" % phase, exc)
+            self._cache_metadata(record)
 
     def _validate_plugin(self, record, plugin, metadata_value):
         if not callable(getattr(plugin, "activate", None)):
@@ -487,6 +533,61 @@ class PluginManager(QObject):
     def _plugins_settings_copy(self):
         plugins = self.settings.get("plugins", {})
         return deepcopy(plugins) if isinstance(plugins, dict) else {}
+
+    def _cached_metadata(self, plugin_id):
+        cached = self._plugins_settings_copy().get("metadata", {})
+        value = cached.get(plugin_id) if isinstance(cached, dict) else None
+        if not isinstance(value, dict):
+            return None
+        try:
+            capabilities = tuple(
+                PluginCapability(item) for item in value["capabilities"])
+            return PluginMetadata(
+                id=plugin_id,
+                display_name=value["display_name"],
+                version=value["version"],
+                api_major=int(value["api_major"]),
+                capabilities=capabilities,
+                description=value.get("description", ""),
+                homepage=value.get("homepage", ""),
+            )
+        except (KeyError, TypeError, ValueError):
+            return None
+
+    def _cache_metadata(self, record):
+        value = record.metadata
+        if not isinstance(value, PluginMetadata) \
+                or value.id != record.id \
+                or not is_valid_plugin_id(value.id) \
+                or type(value.api_major) is not int \
+                or not isinstance(value.display_name, str) \
+                or not value.display_name.strip() \
+                or not isinstance(value.version, str) \
+                or not value.version.strip() \
+                or not isinstance(value.description, str) \
+                or not isinstance(value.homepage, str) \
+                or not isinstance(value.capabilities, tuple) \
+                or any(not isinstance(item, PluginCapability)
+                       for item in value.capabilities):
+            return
+        plugins = self._plugins_settings_copy()
+        cached = plugins.setdefault("metadata", {})
+        if not isinstance(cached, dict):
+            cached = {}
+            plugins["metadata"] = cached
+        cached[record.id] = {
+            "display_name": value.display_name,
+            "version": value.version,
+            "api_major": value.api_major,
+            "capabilities": [item.value for item in value.capabilities],
+            "description": value.description,
+            "homepage": value.homepage,
+        }
+        try:
+            self._replace_plugins_settings(plugins)
+        except Exception as exc:
+            self._record_exception(
+                record, "settings", "metadata_cache_failed", exc)
 
     def _replace_plugins_settings(self, plugins):
         before = deepcopy(self.settings.data)

--- a/libs/core/plugin_manager.py
+++ b/libs/core/plugin_manager.py
@@ -1,0 +1,504 @@
+"""Deterministic, failure-contained lifecycle for installed plugins."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from enum import Enum
+import os
+import traceback
+
+from PyQt5.QtCore import QObject
+
+from labelimgplusplus.plugins import (
+    PLUGIN_API_MAJOR,
+    DocumentDescriptor,
+    PluginCapability,
+    PluginDiagnostic,
+    PluginMetadata,
+)
+from libs.core.plugin_discovery import (
+    discover_plugins,
+    is_valid_plugin_id,
+    normalized_plugin_id,
+)
+from libs.core.plugin_registry import ActivationContext, validate_json_value
+
+
+class PluginState(str, Enum):
+    DISCOVERED = "discovered"
+    DISABLED = "disabled"
+    INCOMPATIBLE = "incompatible"
+    CONFLICTING = "conflicting"
+    LOADING = "loading"
+    ACTIVE = "active"
+    FAILED = "failed"
+    UNAVAILABLE = "unavailable"
+    SHUTTING_DOWN = "shutting_down"
+
+
+@dataclass
+class PluginRecord:
+    id: str
+    state: PluginState
+    enabled: bool
+    candidate: object = None
+    metadata: object = None
+    diagnostics: list = field(default_factory=list)
+    plugin: object = field(default=None, repr=False)
+    context: object = field(default=None, repr=False)
+    command_cleanup: object = field(default=None, repr=False)
+
+    @property
+    def is_active(self):
+        return self.state == PluginState.ACTIVE
+
+    @property
+    def provider(self):
+        return self.candidate.distribution if self.candidate else None
+
+    @property
+    def provider_version(self):
+        return self.candidate.distribution_version if self.candidate else None
+
+    @property
+    def reference(self):
+        return self.candidate.reference if self.candidate else None
+
+
+class _NullCommandHost:
+    def commit(self, plugin_id, commands, invoke):
+        del plugin_id, commands, invoke
+        return lambda: None
+
+
+class _ValidationFailure(Exception):
+    def __init__(self, code, message, state=PluginState.FAILED):
+        super().__init__(message)
+        self.code = code
+        self.state = state
+
+
+class PluginManager(QObject):
+    """Own plugin discovery, activation, services, and teardown."""
+
+    def __init__(self, settings, coordinator, candidates=None,
+                 discovery=discover_plugins, command_host=None, parent=None):
+        super().__init__(parent)
+        self.settings = settings
+        self.coordinator = coordinator
+        self.command_host = command_host or _NullCommandHost()
+        self.safe_mode = os.environ.get("LABELIMGPP_DISABLE_PLUGINS") == "1"
+        self._shutting_down = False
+        self._activation_order = []
+        self._commands = {}
+        self._command_owners = {}
+        self._document_subscriptions = []
+        self._document = DocumentDescriptor()
+        self._records = []
+        if not self.safe_mode:
+            discovered = tuple(candidates) if candidates is not None else discovery()
+            discovered = tuple(sorted(
+                discovered,
+                key=lambda item: (
+                    normalized_plugin_id(item.id), item.id,
+                    item.distribution or "", item.reference),
+            ))
+            self._build_records(discovered)
+
+    @property
+    def records(self):
+        return tuple(self._records)
+
+    @property
+    def document(self):
+        return self._document
+
+    @property
+    def is_shutting_down(self):
+        return self._shutting_down
+
+    @property
+    def active_commands(self):
+        return dict(self._commands)
+
+    def record_for(self, plugin_id):
+        for record in self._records:
+            if record.id == plugin_id:
+                return record
+        return None
+
+    def activate_enabled(self):
+        if self.safe_mode or self._shutting_down:
+            return
+        for record in self._records:
+            if (record.enabled
+                    and record.state == PluginState.DISCOVERED
+                    and record.candidate is not None):
+                self._activate(record)
+
+    def invoke_command(self, command_id):
+        record = self._command_owners.get(command_id)
+        command = self._commands.get(command_id)
+        if record is None or command is None or not record.is_active:
+            return False
+        try:
+            command.callback()
+            return True
+        except Exception as exc:
+            self._record_exception(
+                record, "callback", "command_callback_failed", exc)
+            return False
+
+    def command_enabled(self, command_id):
+        record = self._command_owners.get(command_id)
+        command = self._commands.get(command_id)
+        if record is None or command is None or not record.is_active:
+            return False
+        if command.enabled is None:
+            return True
+        try:
+            return bool(command.enabled(self._document))
+        except Exception as exc:
+            self._record_exception(
+                record, "callback", "enablement_callback_failed", exc)
+            return False
+
+    def publish_document(self, descriptor):
+        if not isinstance(descriptor, DocumentDescriptor):
+            raise TypeError("document updates must be DocumentDescriptor instances")
+        generation_changed = descriptor.generation != self._document.generation
+        self._document = descriptor
+        if generation_changed:
+            for record in self._activation_order:
+                if record.context is not None:
+                    record.context.tasks.cancel_all()
+        for record, callback in tuple(self._document_subscriptions):
+            if not record.is_active:
+                continue
+            try:
+                callback(descriptor)
+            except Exception as exc:
+                self._record_exception(
+                    record, "callback", "document_callback_failed", exc)
+
+    def set_enabled(self, plugin_id, enabled):
+        enabled_ids = set(self._enabled_ids())
+        if enabled:
+            enabled_ids.add(plugin_id)
+        else:
+            enabled_ids.discard(plugin_id)
+        plugins = self._plugins_settings_copy()
+        plugins["enabled"] = sorted(enabled_ids)
+        self._replace_plugins_settings(plugins)
+        for record in self._records:
+            if record.id == plugin_id:
+                record.enabled = bool(enabled)
+
+    def forget(self, plugin_id):
+        if any(record.id == plugin_id and record.is_active
+               for record in self._records):
+            raise RuntimeError("active plugins can only be forgotten after restart")
+        plugins = self._plugins_settings_copy()
+        plugins["enabled"] = [
+            item for item in plugins.get("enabled", ()) if item != plugin_id]
+        for section in ("config", "metadata"):
+            values = plugins.get(section)
+            if isinstance(values, dict):
+                values.pop(plugin_id, None)
+        self._replace_plugins_settings(plugins)
+        self._records = [record for record in self._records
+                         if record.id != plugin_id or record.candidate is not None]
+
+    def shutdown(self):
+        if self._shutting_down:
+            return
+        self._shutting_down = True
+        for record in reversed(self._activation_order):
+            record.state = PluginState.SHUTTING_DOWN
+            if record.context is not None:
+                record.context.tasks.shutdown()
+            try:
+                record.plugin.deactivate()
+            except Exception as exc:
+                self._record_exception(
+                    record, "deactivation", "deactivation_failed", exc)
+            try:
+                if record.command_cleanup is not None:
+                    record.command_cleanup()
+            except Exception as exc:
+                self._record_exception(
+                    record, "deactivation", "command_cleanup_failed", exc)
+            self._remove_record_registrations(record)
+            if record.context is not None:
+                record.context.close()
+            record.plugin = None
+            record.context = None
+            record.command_cleanup = None
+        self._activation_order = []
+
+    def _build_records(self, candidates):
+        enabled = set(self._enabled_ids())
+        available_ids = set()
+        for candidate in candidates:
+            available_ids.add(candidate.id)
+            codes = {item.code for item in candidate.diagnostics}
+            if "duplicate_plugin_id" in codes:
+                state = PluginState.CONFLICTING
+            elif "missing_provider_metadata" in codes:
+                state = PluginState.UNAVAILABLE
+            elif candidate.diagnostics:
+                state = PluginState.FAILED
+            elif candidate.id in enabled:
+                state = PluginState.DISCOVERED
+            else:
+                state = PluginState.DISABLED
+            self._records.append(PluginRecord(
+                id=candidate.id,
+                state=state,
+                enabled=candidate.id in enabled,
+                candidate=candidate,
+                diagnostics=list(candidate.diagnostics),
+            ))
+        configured = set(enabled)
+        config = self._plugins_settings_copy().get("config", {})
+        if isinstance(config, dict):
+            configured.update(key for key in config if isinstance(key, str))
+        for plugin_id in sorted(configured - available_ids):
+            self._records.append(PluginRecord(
+                id=plugin_id,
+                state=PluginState.UNAVAILABLE,
+                enabled=plugin_id in enabled,
+            ))
+
+    def _activate(self, record):
+        record.state = PluginState.LOADING
+        plugin = None
+        context = None
+        host_cleanup = None
+        activation_started = False
+        settings_before = deepcopy(self.settings.data)
+        try:
+            try:
+                factory = record.candidate.entry_point.load()
+            except ModuleNotFoundError as exc:
+                raise _ValidationFailure(
+                    "missing_dependency", str(exc)) from exc
+            if not callable(factory):
+                raise _ValidationFailure(
+                    "invalid_factory", "The entry point must resolve to a callable factory.")
+            try:
+                plugin = factory()
+            except ModuleNotFoundError as exc:
+                raise _ValidationFailure(
+                    "missing_dependency", str(exc)) from exc
+            metadata_value = getattr(plugin, "metadata", None)
+            self._validate_plugin(record, plugin, metadata_value)
+            record.metadata = metadata_value
+            context = ActivationContext(
+                self, record, self._plugin_config(record.id))
+            activation_started = True
+            try:
+                plugin.activate(context)
+            except ModuleNotFoundError as exc:
+                raise _ValidationFailure(
+                    "missing_dependency", str(exc)) from exc
+            if (context.commands.commands
+                    and PluginCapability.COMMANDS
+                    not in metadata_value.capabilities):
+                raise _ValidationFailure(
+                    "capability_not_declared",
+                    "Plugin registered commands without declaring the commands capability.",
+                )
+            staged = {}
+            for local_id, command in context.commands.commands.items():
+                command_id = "plugin.%s.%s" % (record.id, local_id)
+                if command_id in self._commands:
+                    raise _ValidationFailure(
+                        "command_collision",
+                        "Command ID already registered: %s" % command_id)
+                staged[command_id] = command
+            host_cleanup = self.command_host.commit(
+                record.id, dict(staged), self.invoke_command)
+            if not callable(host_cleanup):
+                raise _ValidationFailure(
+                    "invalid_command_host", "Command host did not return cleanup.")
+            context.commit()
+            self._commands.update(staged)
+            self._command_owners.update(
+                (command_id, record) for command_id in staged)
+            record.plugin = plugin
+            record.context = context
+            record.command_cleanup = host_cleanup
+            record.state = PluginState.ACTIVE
+            self._activation_order.append(record)
+        except _ValidationFailure as exc:
+            self.settings.data = settings_before
+            if host_cleanup is not None:
+                self._safe_cleanup(record, host_cleanup)
+            if context is not None:
+                context.close()
+            if activation_started:
+                self._safe_failed_deactivation(record, plugin)
+            record.state = exc.state
+            self._record_diagnostic(
+                record, "validation", exc.code, str(exc))
+        except Exception as exc:
+            self.settings.data = settings_before
+            if host_cleanup is not None:
+                self._safe_cleanup(record, host_cleanup)
+            if context is not None:
+                context.close()
+            if activation_started:
+                self._safe_failed_deactivation(record, plugin)
+            record.state = PluginState.FAILED
+            phase = "activation" if plugin is not None else "factory"
+            self._record_exception(record, phase, "%s_failed" % phase, exc)
+
+    def _validate_plugin(self, record, plugin, metadata_value):
+        if not callable(getattr(plugin, "activate", None)):
+            raise _ValidationFailure(
+                "invalid_plugin", "Plugin has no callable activate() method.")
+        if not callable(getattr(plugin, "deactivate", None)):
+            raise _ValidationFailure(
+                "invalid_plugin", "Plugin has no callable deactivate() method.")
+        if not isinstance(metadata_value, PluginMetadata):
+            raise _ValidationFailure(
+                "invalid_metadata", "Plugin metadata must be PluginMetadata.")
+        if metadata_value.id != record.id:
+            raise _ValidationFailure(
+                "metadata_id_mismatch",
+                "Entry-point ID %r does not match metadata ID %r."
+                % (record.id, metadata_value.id))
+        if not is_valid_plugin_id(metadata_value.id):
+            raise _ValidationFailure(
+                "invalid_plugin_id", "Plugin metadata contains an invalid ID.")
+        if type(metadata_value.api_major) is not int:
+            raise _ValidationFailure(
+                "invalid_metadata", "API major must be an integer.")
+        if metadata_value.api_major != PLUGIN_API_MAJOR:
+            raise _ValidationFailure(
+                "api_major_mismatch",
+                "Plugin requires API major %s; host provides %s."
+                % (metadata_value.api_major, PLUGIN_API_MAJOR),
+                PluginState.INCOMPATIBLE,
+            )
+        if (not isinstance(metadata_value.display_name, str)
+                or not metadata_value.display_name.strip()
+                or not isinstance(metadata_value.version, str)
+                or not metadata_value.version.strip()
+                or not isinstance(metadata_value.description, str)
+                or not isinstance(metadata_value.homepage, str)):
+            raise _ValidationFailure(
+                "invalid_metadata",
+                "Metadata text fields are invalid or required fields are empty.")
+        if not isinstance(metadata_value.capabilities, tuple):
+            raise _ValidationFailure(
+                "invalid_metadata", "Capabilities must be a tuple.")
+        if any(not isinstance(capability, PluginCapability)
+               for capability in metadata_value.capabilities):
+            raise _ValidationFailure(
+                "invalid_metadata",
+                "Capabilities must contain PluginCapability values.")
+        supported = {PluginCapability.COMMANDS}
+        unknown = [capability for capability in metadata_value.capabilities
+                   if capability not in supported]
+        if unknown:
+            raise _ValidationFailure(
+                "unsupported_capability",
+                "Unsupported plugin capabilities: %s" % ", ".join(map(str, unknown)),
+                PluginState.INCOMPATIBLE,
+            )
+
+    def _safe_failed_deactivation(self, record, plugin):
+        if plugin is None or not callable(getattr(plugin, "deactivate", None)):
+            return
+        try:
+            plugin.deactivate()
+        except Exception as exc:
+            self._record_exception(
+                record, "deactivation", "rollback_deactivation_failed", exc)
+
+    def _safe_cleanup(self, record, cleanup):
+        try:
+            rollback = getattr(cleanup, "rollback", cleanup)
+            rollback()
+        except Exception as exc:
+            self._record_exception(
+                record, "activation", "rollback_cleanup_failed", exc)
+
+    def _remove_record_registrations(self, record):
+        for command_id, owner in tuple(self._command_owners.items()):
+            if owner is record:
+                self._command_owners.pop(command_id, None)
+                self._commands.pop(command_id, None)
+        self._document_subscriptions = [
+            item for item in self._document_subscriptions if item[0] is not record]
+
+    def _add_document_subscription(self, record, callback):
+        self._document_subscriptions.append((record, callback))
+
+    def _remove_document_subscription(self, record, callback):
+        item = (record, callback)
+        if item in self._document_subscriptions:
+            self._document_subscriptions.remove(item)
+
+    def _record_diagnostic(self, record, phase, code, message, details="",
+                           severity="error"):
+        record.diagnostics.append(PluginDiagnostic(
+            plugin_id=record.id,
+            phase=phase,
+            code=code,
+            message=str(message),
+            details=str(details),
+            severity=severity,
+        ))
+
+    def _record_exception(self, record, phase, code, exc):
+        details = "".join(traceback.format_exception(
+            type(exc), exc, exc.__traceback__))
+        self._record_diagnostic(record, phase, code, str(exc), details)
+
+    def _enabled_ids(self):
+        values = self._plugins_settings_copy().get("enabled", ())
+        if not isinstance(values, list):
+            return ()
+        return tuple(item for item in values if isinstance(item, str))
+
+    def _plugin_config(self, plugin_id):
+        configs = self._plugins_settings_copy().get("config", {})
+        value = configs.get(plugin_id, {}) if isinstance(configs, dict) else {}
+        try:
+            validate_json_value(value, "plugins.config.%s" % plugin_id)
+        except ValueError:
+            return {}
+        return deepcopy(value) if isinstance(value, dict) else {}
+
+    def _persist_plugin_config(self, plugin_id, value):
+        validate_json_value(value, "plugins.config.%s" % plugin_id)
+        plugins = self._plugins_settings_copy()
+        configs = plugins.setdefault("config", {})
+        if not isinstance(configs, dict):
+            configs = {}
+            plugins["config"] = configs
+        configs[plugin_id] = deepcopy(value)
+        self._replace_plugins_settings(plugins)
+
+    def _plugins_settings_copy(self):
+        plugins = self.settings.get("plugins", {})
+        return deepcopy(plugins) if isinstance(plugins, dict) else {}
+
+    def _replace_plugins_settings(self, plugins):
+        before = deepcopy(self.settings.data)
+        self.settings["plugins"] = plugins
+        try:
+            saved = self.settings.save()
+        except Exception:
+            self.settings.data = before
+            raise
+        if not saved:
+            self.settings.data = before
+            raise OSError("could not persist plugin settings")
+
+
+__all__ = ["PluginManager", "PluginRecord", "PluginState"]

--- a/libs/core/plugin_registry.py
+++ b/libs/core/plugin_registry.py
@@ -1,0 +1,423 @@
+"""Transactional registries and restricted services for plugin activation."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import math
+import re
+import threading
+from types import MappingProxyType
+
+from PyQt5.QtCore import QObject, Qt, pyqtSlot
+
+from labelimgplusplus.plugins import CommandSpec
+from libs.core.task_coordinator import JobPriority
+
+
+_VALID_COMMAND_ID = re.compile(r"^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$")
+_RESERVED_SETTINGS_KEY = "__type__"
+
+
+def validate_json_value(value, path="value", seen=None):
+    """Raise ``ValueError`` unless *value* is strict, untagged JSON data."""
+    if value is None or isinstance(value, (str, bool, int)):
+        return
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("%s must not contain NaN or infinity" % path)
+        return
+    if seen is None:
+        seen = set()
+    if isinstance(value, list):
+        identity = id(value)
+        if identity in seen:
+            raise ValueError("%s must not contain cycles" % path)
+        seen.add(identity)
+        try:
+            for index, item in enumerate(value):
+                validate_json_value(item, "%s[%d]" % (path, index), seen)
+        finally:
+            seen.remove(identity)
+        return
+    if isinstance(value, dict):
+        identity = id(value)
+        if identity in seen:
+            raise ValueError("%s must not contain cycles" % path)
+        seen.add(identity)
+        try:
+            for key, item in value.items():
+                if not isinstance(key, str):
+                    raise ValueError("%s keys must be strings" % path)
+                if key == _RESERVED_SETTINGS_KEY:
+                    raise ValueError(
+                        "%s contains reserved key %r" % (path, key))
+                validate_json_value(item, "%s.%s" % (path, key), seen)
+        finally:
+            seen.remove(identity)
+        return
+    raise ValueError(
+        "%s is not JSON-compatible: %s" % (path, type(value).__name__))
+
+
+class StagedCommandRegistry:
+    """Collect commands without exposing the host's live registry."""
+
+    def __init__(self, plugin_id):
+        self._plugin_id = plugin_id
+        self._commands = {}
+        self._closed = False
+
+    @property
+    def commands(self):
+        return dict(self._commands)
+
+    def register(self, command):
+        if self._closed:
+            raise RuntimeError("command registry is closed")
+        if not isinstance(command, CommandSpec):
+            raise TypeError("commands must be CommandSpec instances")
+        if not _VALID_COMMAND_ID.fullmatch(command.id or ""):
+            raise ValueError("invalid command ID: %r" % command.id)
+        if command.id in self._commands:
+            raise ValueError("duplicate command ID: %s" % command.id)
+        if not isinstance(command.title, str) or not command.title.strip():
+            raise ValueError("command title must be a non-empty string")
+        if not callable(command.callback):
+            raise TypeError("command callback must be callable")
+        if not isinstance(command.description, str):
+            raise TypeError("command description must be a string")
+        if not isinstance(command.default_shortcut, str):
+            raise TypeError("command default shortcut must be a string")
+        if command.enabled is not None and not callable(command.enabled):
+            raise TypeError("command enablement predicate must be callable")
+        namespaced = "plugin.%s.%s" % (self._plugin_id, command.id)
+        self._commands[command.id] = command
+        return namespaced
+
+    def close(self):
+        self._closed = True
+
+
+class StagedPluginSettings:
+    """Plugin-isolated settings with activation-time write staging."""
+
+    def __init__(self, manager, plugin_id, initial):
+        self._manager = manager
+        self._plugin_id = plugin_id
+        self._data = deepcopy(initial) if isinstance(initial, dict) else {}
+        try:
+            validate_json_value(self._data, "plugin settings")
+        except ValueError:
+            self._data = {}
+        self._active = False
+        self._closed = False
+
+    def get(self, key, default=None):
+        self._validate_key(key)
+        return deepcopy(self._data.get(key, default))
+
+    def set(self, key, value):
+        self._ensure_open()
+        self._validate_key(key)
+        validate_json_value(value, "settings.%s" % key)
+        updated = deepcopy(self._data)
+        updated[key] = deepcopy(value)
+        if self._active:
+            self._manager._persist_plugin_config(self._plugin_id, updated)
+        self._data = updated
+
+    def delete(self, key):
+        self._ensure_open()
+        self._validate_key(key)
+        if key not in self._data:
+            return
+        updated = deepcopy(self._data)
+        del updated[key]
+        if self._active:
+            self._manager._persist_plugin_config(self._plugin_id, updated)
+        self._data = updated
+
+    def as_dict(self):
+        return MappingProxyType(deepcopy(self._data))
+
+    def commit(self):
+        self._ensure_open()
+        self._manager._persist_plugin_config(self._plugin_id, self._data)
+        self._active = True
+
+    def close(self):
+        self._closed = True
+
+    def _ensure_open(self):
+        if self._closed:
+            raise RuntimeError("plugin settings are closed")
+
+    @staticmethod
+    def _validate_key(key):
+        if not isinstance(key, str) or not key or key == _RESERVED_SETTINGS_KEY:
+            raise ValueError("plugin setting keys must be non-empty strings")
+
+
+class StagedDocumentService:
+    """Read-only document state with subscriptions staged until commit."""
+
+    def __init__(self, manager, record):
+        self._manager = manager
+        self._record = record
+        self._staged = []
+        self._committed = []
+        self._closed = False
+
+    @property
+    def current(self):
+        return self._manager.document
+
+    def subscribe(self, callback):
+        if self._closed:
+            raise RuntimeError("document service is closed")
+        if not callable(callback):
+            raise TypeError("document callback must be callable")
+        target = self._committed if self._record.is_active else self._staged
+        target.append(callback)
+        if self._record.is_active:
+            self._manager._add_document_subscription(self._record, callback)
+        active = True
+
+        def unsubscribe():
+            nonlocal active
+            if not active:
+                return
+            active = False
+            for callbacks in (self._staged, self._committed):
+                if callback in callbacks:
+                    callbacks.remove(callback)
+            self._manager._remove_document_subscription(self._record, callback)
+
+        return unsubscribe
+
+    def commit(self):
+        for callback in self._staged:
+            self._manager._add_document_subscription(self._record, callback)
+            self._committed.append(callback)
+        self._staged = []
+
+    def close(self):
+        for callback in list(self._committed):
+            self._manager._remove_document_subscription(self._record, callback)
+        self._committed = []
+        self._staged = []
+        self._closed = True
+
+
+class PluginDiagnosticService:
+    def __init__(self, manager, record):
+        self._manager = manager
+        self._record = record
+
+    def report(self, code, message, details="", severity="error"):
+        self._manager._record_diagnostic(
+            self._record, "plugin", code, message, details, severity)
+
+
+class _TaskBridge(QObject):
+    """QObject receiver that fences callbacks to the application thread."""
+
+    def __init__(self, service, handle, generation):
+        super().__init__(service._manager)
+        self._service = service
+        self._handle = handle
+        self._generation = generation
+        self._result_callback = None
+        self._error_callback = None
+        self._progress_callback = None
+
+    def configure(self, on_result, on_error, on_progress):
+        self._result_callback = on_result
+        self._error_callback = on_error
+        self._progress_callback = on_progress
+
+    def _deliverable(self):
+        if self._service is None or self._handle is None:
+            return False
+        return (
+            self._service.accepting
+            and self._service._record.is_active
+            and self._service._manager.document.generation == self._generation
+            and not self._handle.is_cancelled()
+        )
+
+    @pyqtSlot(object)
+    def result(self, value):
+        if self._deliverable() and self._result_callback is not None:
+            self._service._invoke_callback("result", self._result_callback, value)
+
+    @pyqtSlot(str)
+    def error(self, message):
+        if not self._deliverable():
+            return
+        self._service._manager._record_diagnostic(
+            self._service._record,
+            "task",
+            "task_failed",
+            message,
+        )
+        if self._error_callback is not None:
+            self._service._invoke_callback("error", self._error_callback, message)
+
+    @pyqtSlot(object)
+    def progress(self, value):
+        if self._deliverable() and self._progress_callback is not None:
+            self._service._invoke_callback(
+                "progress", self._progress_callback, value)
+
+    @pyqtSlot()
+    def finished(self):
+        if self._service is None:
+            return
+        self._service._finished(self._handle)
+        self.detach()
+        self.deleteLater()
+
+    def detach(self):
+        self._result_callback = None
+        self._error_callback = None
+        self._progress_callback = None
+        self._service = None
+        self._handle = None
+
+
+class PluginTaskServiceImpl:
+    """Plugin-scoped adapter over the coordinator background lane."""
+
+    def __init__(self, manager, record):
+        self._manager = manager
+        self._record = record
+        self._accepting = False
+        self._bridges = {}
+
+    @property
+    def accepting(self):
+        return self._accepting and not self._manager.is_shutting_down
+
+    @property
+    def handles(self):
+        return tuple(self._bridges)
+
+    def commit(self):
+        self._accepting = True
+
+    def submit(self, work, key=None, latest=False, on_result=None,
+               on_error=None, on_progress=None):
+        if not self.accepting:
+            raise RuntimeError("plugin tasks cannot start during activation or shutdown")
+        if not callable(work):
+            raise TypeError("task work must be callable")
+        for name, callback in (
+                ("result", on_result), ("error", on_error),
+                ("progress", on_progress)):
+            if callback is not None and not callable(callback):
+                raise TypeError("%s callback must be callable" % name)
+        if key is not None and (not isinstance(key, str) or not key):
+            raise ValueError("task key must be a non-empty string")
+        generation = self._manager.document.generation
+        namespaced_key = (
+            "plugin.%s.%s" % (self._record.id, key)
+            if key is not None else None)
+        ready = threading.Event()
+
+        def connected_work(handle):
+            ready.wait()
+            handle.check_cancelled()
+            return work(handle)
+
+        handle = self._manager.coordinator.submit(
+            "background",
+            connected_work,
+            priority=JobPriority.BULK,
+            key=namespaced_key,
+            latest=latest,
+            generation=generation,
+        )
+        bridge = _TaskBridge(self, handle, generation)
+        try:
+            bridge.configure(on_result, on_error, on_progress)
+            self._bridges[handle] = bridge
+            handle.result.connect(bridge.result, Qt.QueuedConnection)
+            handle.error.connect(bridge.error, Qt.QueuedConnection)
+            handle.progress.connect(bridge.progress, Qt.QueuedConnection)
+            handle.finished.connect(bridge.finished, Qt.QueuedConnection)
+        except Exception:
+            self._bridges.pop(handle, None)
+            handle.cancel()
+            bridge.detach()
+            bridge.deleteLater()
+            raise
+        finally:
+            ready.set()
+        return handle
+
+    def cancel_all(self):
+        for handle in tuple(self._bridges):
+            handle.cancel()
+
+    def shutdown(self):
+        self._accepting = False
+        for handle, bridge in tuple(self._bridges.items()):
+            handle.cancel()
+            bridge.detach()
+            bridge.deleteLater()
+        self._bridges.clear()
+
+    def _finished(self, handle):
+        self._bridges.pop(handle, None)
+
+    def _invoke_callback(self, kind, callback, value):
+        try:
+            callback(value)
+        except Exception as exc:
+            self._manager._record_exception(
+                self._record,
+                "callback",
+                "%s_callback_failed" % kind,
+                exc,
+            )
+
+
+class ActivationContext:
+    """Concrete context whose registrations can be committed or discarded."""
+
+    def __init__(self, manager, record, initial_settings):
+        self.commands = StagedCommandRegistry(record.id)
+        self.tasks = PluginTaskServiceImpl(manager, record)
+        self.settings = StagedPluginSettings(
+            manager, record.id, initial_settings)
+        self.documents = StagedDocumentService(manager, record)
+        self.diagnostics = PluginDiagnosticService(manager, record)
+        self._closed = False
+
+    def commit(self):
+        if self._closed:
+            raise RuntimeError("activation context is closed")
+        self.commands.close()
+        self.settings.commit()
+        self.documents.commit()
+        self.tasks.commit()
+
+    def close(self):
+        if self._closed:
+            return
+        self.tasks.shutdown()
+        self.documents.close()
+        self.settings.close()
+        self.commands.close()
+        self._closed = True
+
+
+__all__ = [
+    "ActivationContext",
+    "PluginTaskServiceImpl",
+    "StagedCommandRegistry",
+    "StagedDocumentService",
+    "StagedPluginSettings",
+    "validate_json_value",
+]

--- a/libs/core/shortcut_config.py
+++ b/libs/core/shortcut_config.py
@@ -60,6 +60,8 @@ class ShortcutConfig:
     """Manages keyboard shortcut configuration."""
 
     def __init__(self):
+        self._dynamic_defaults = {}
+        self._plugin_owners = {}
         self._shortcuts = dict(DEFAULT_SHORTCUTS)
 
     def get(self, action_name):
@@ -68,30 +70,127 @@ class ShortcutConfig:
 
     def set(self, action_name, shortcut):
         """Sets the shortcut for the given action name."""
+        if action_name not in DEFAULT_SHORTCUTS \
+                and action_name not in self._dynamic_defaults:
+            raise KeyError('unknown shortcut action: %s' % action_name)
+        if not isinstance(shortcut, str):
+            raise TypeError('shortcut must be a string')
         self._shortcuts[action_name] = shortcut
+
+    def register_plugin(self, action_name, default_shortcut='', plugin_id=None):
+        """Register a live plugin command while retaining stored overrides."""
+        if not isinstance(action_name, str) \
+                or not action_name.startswith('plugin.'):
+            raise ValueError('plugin shortcut IDs must start with plugin.')
+        if not isinstance(default_shortcut, str):
+            raise TypeError('default shortcut must be a string')
+        if plugin_id is not None \
+                and (not isinstance(plugin_id, str) or not plugin_id):
+            raise ValueError('plugin owner must be a non-empty string')
+        self._dynamic_defaults[action_name] = default_shortcut
+        if plugin_id is not None:
+            self._plugin_owners[action_name] = plugin_id
+        self._shortcuts.setdefault(action_name, default_shortcut)
+        return self._shortcuts[action_name]
+
+    def unregister_plugin(self, action_name, retain=True):
+        """Hide a plugin command, optionally discarding a staged default."""
+        self._dynamic_defaults.pop(action_name, None)
+        if not retain:
+            self._shortcuts.pop(action_name, None)
+            self._plugin_owners.pop(action_name, None)
+
+    def forget_plugin(self, plugin_id):
+        """Remove defaults and retained overrides for one forgotten plugin."""
+        owned = {
+            name for name, owner in self._plugin_owners.items()
+            if owner == plugin_id
+        }
+        for name in owned:
+            self._dynamic_defaults.pop(name, None)
+            self._shortcuts.pop(name, None)
+            self._plugin_owners.pop(name, None)
 
     def reset(self, action_name):
         """Resets a single action's shortcut to its default value."""
-        if action_name in DEFAULT_SHORTCUTS:
-            self._shortcuts[action_name] = DEFAULT_SHORTCUTS[action_name]
+        default = self.get_default(action_name)
+        if action_name in DEFAULT_SHORTCUTS \
+                or action_name in self._dynamic_defaults:
+            self._shortcuts[action_name] = default
 
     def reset_all(self):
         """Resets all shortcuts to their default values."""
+        retained = {
+            name: value for name, value in self._shortcuts.items()
+            if name.startswith('plugin.')
+            and name not in self._dynamic_defaults
+        }
         self._shortcuts = dict(DEFAULT_SHORTCUTS)
+        self._shortcuts.update(retained)
+        self._shortcuts.update(self._dynamic_defaults)
+        self._plugin_owners = {
+            name: owner for name, owner in self._plugin_owners.items()
+            if name in self._shortcuts
+        }
 
     def get_all(self):
         """Returns a copy of all current shortcuts."""
-        return dict(self._shortcuts)
+        visible = {
+            name: self._shortcuts.get(name, default)
+            for name, default in DEFAULT_SHORTCUTS.items()
+        }
+        for name, default in self._dynamic_defaults.items():
+            visible[name] = self._shortcuts.get(name, default)
+        return visible
+
+    def plugin_owners(self):
+        """Return the persisted command-to-plugin ownership index."""
+        return dict(self._plugin_owners)
+
+    def restore_plugin_owners(self, owners):
+        """Restore validated ownership for retained plugin shortcut keys."""
+        self._plugin_owners = {}
+        if not isinstance(owners, dict):
+            return
+        for name, owner in owners.items():
+            if (isinstance(name, str) and name.startswith('plugin.')
+                    and name in self._shortcuts
+                    and isinstance(owner, str) and owner):
+                self._plugin_owners[name] = owner
+
+    def owner_for(self, action_name):
+        return self._plugin_owners.get(action_name)
+
+    def set_plugin_owner(self, action_name, plugin_id):
+        if plugin_id is None:
+            self._plugin_owners.pop(action_name, None)
+        else:
+            self._plugin_owners[action_name] = plugin_id
+
+    def _snapshot(self):
+        return (
+            dict(self._shortcuts),
+            dict(self._dynamic_defaults),
+            dict(self._plugin_owners),
+        )
+
+    def _restore(self, snapshot):
+        shortcuts, dynamic_defaults, plugin_owners = snapshot
+        self._shortcuts = dict(shortcuts)
+        self._dynamic_defaults = dict(dynamic_defaults)
+        self._plugin_owners = dict(plugin_owners)
 
     def get_default(self, action_name):
         """Returns the default shortcut for the given action name."""
-        return DEFAULT_SHORTCUTS.get(action_name, '')
+        if action_name in DEFAULT_SHORTCUTS:
+            return DEFAULT_SHORTCUTS[action_name]
+        return self._dynamic_defaults.get(action_name, '')
 
     def find_conflict(self, shortcut, exclude_action=None):
         """Return action name that has this shortcut, or None."""
         if not shortcut:
             return None
-        for name, sc in self._shortcuts.items():
+        for name, sc in self.get_all().items():
             if name != exclude_action and sc == shortcut:
                 return name
         return None
@@ -106,9 +205,11 @@ class ShortcutConfig:
         corrupt config can never crash the load."""
         if not isinstance(data, dict):
             return
-        for key in DEFAULT_SHORTCUTS:
-            value = data.get(key)
-            if isinstance(value, str):
+        for key, value in data.items():
+            if not isinstance(value, str):
+                continue
+            if key in DEFAULT_SHORTCUTS or (
+                    isinstance(key, str) and key.startswith('plugin.')):
                 self._shortcuts[key] = value
 
     def export_json(self, file_path):

--- a/libs/widgets/pluginManagerDialog.py
+++ b/libs/widgets/pluginManagerDialog.py
@@ -1,0 +1,402 @@
+"""Host-owned plugin actions and the restart-oriented plugin manager UI."""
+
+from functools import partial
+from html import escape
+from urllib.parse import urlparse
+
+from PyQt5.QtCore import QThread, Qt
+from PyQt5.QtWidgets import (
+    QAction,
+    QApplication,
+    QDialog,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QMessageBox,
+    QPlainTextEdit,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+)
+
+from libs.core.plugin_manager import PluginState
+from libs.utils.constants import SETTING_SHORTCUTS
+from libs.utils.dpi import scale_px
+
+
+class QtPluginCommandHost:
+    """Create and own every QAction declared by an active plugin."""
+
+    def __init__(self, owner, menu, shortcut_config, action_map, settings):
+        self._owner = owner
+        self._menu = menu
+        self._shortcut_config = shortcut_config
+        self._action_map = action_map
+        self._settings = settings
+        self._actions = {}
+        self._plugin_actions = {}
+        self._plugin_shortcut_preexisting = {}
+        self._plugin_callbacks = {}
+        plugins = settings.get("plugins", {})
+        owners = (
+            plugins.get("shortcut_owners", {})
+            if isinstance(plugins, dict) else {})
+        self._shortcut_config.restore_plugin_owners(owners)
+        self._update_visibility()
+
+    @property
+    def actions(self):
+        return dict(self._actions)
+
+    def commit(self, plugin_id, commands, invoke, enabled):
+        self._assert_gui_thread()
+        if plugin_id in self._plugin_actions:
+            raise ValueError("plugin actions are already committed: %s" % plugin_id)
+        collisions = set(commands).intersection(self._action_map)
+        collisions.update(set(commands).intersection(self._actions))
+        if collisions:
+            raise ValueError(
+                "action IDs already exist: %s" % ", ".join(sorted(collisions)))
+        created = {}
+        registered = []
+        try:
+            for command_id, spec in commands.items():
+                preexisting = command_id in self._shortcut_config.to_dict()
+                previous_owner = self._shortcut_config.owner_for(command_id)
+                shortcut = self._shortcut_config.register_plugin(
+                    command_id, spec.default_shortcut, plugin_id)
+                registered.append(
+                    (command_id, preexisting, previous_owner))
+                action = QAction(spec.title, self._owner)
+                action.setObjectName(command_id)
+                action.setProperty("pluginCommandId", command_id)
+                action.setToolTip(spec.description)
+                action.setStatusTip(spec.description)
+                action.setShortcut(shortcut)
+                action.triggered.connect(partial(
+                    self._trigger, plugin_id, command_id))
+                action.setEnabled(False)
+                created[command_id] = action
+            for command_id, action in created.items():
+                self._menu.addAction(action)
+                self._action_map[command_id] = action
+                self._actions[command_id] = action
+            self._plugin_actions[plugin_id] = tuple(created)
+            self._plugin_shortcut_preexisting[plugin_id] = {
+                command_id: (preexisting, previous_owner)
+                for command_id, preexisting, previous_owner in registered
+            }
+            self._plugin_callbacks[plugin_id] = (invoke, enabled)
+            self._stage_shortcut_owners()
+            self._update_visibility()
+        except Exception:
+            for command_id, action in created.items():
+                self._menu.removeAction(action)
+                self._action_map.pop(command_id, None)
+                self._actions.pop(command_id, None)
+                action.deleteLater()
+            for command_id, preexisting, previous_owner in registered:
+                self._shortcut_config.unregister_plugin(
+                    command_id, retain=preexisting)
+                self._shortcut_config.set_plugin_owner(
+                    command_id, previous_owner)
+            self._stage_shortcut_owners()
+            self._update_visibility()
+            raise
+
+        cleaned = False
+
+        def cleanup():
+            nonlocal cleaned
+            if cleaned:
+                return
+            cleaned = True
+            self._remove_plugin(plugin_id)
+
+        def rollback():
+            nonlocal cleaned
+            if cleaned:
+                return
+            cleaned = True
+            self._remove_plugin(plugin_id, rollback=True)
+
+        cleanup.rollback = rollback
+
+        return cleanup
+
+    def refresh_enablement(self):
+        self._assert_gui_thread()
+        for plugin_id, command_ids in tuple(self._plugin_actions.items()):
+            callbacks = self._plugin_callbacks.get(plugin_id)
+            if callbacks is None:
+                continue
+            enabled = callbacks[1]
+            for command_id in command_ids:
+                action = self._actions.get(command_id)
+                if action is not None:
+                    action.setEnabled(bool(enabled(command_id)))
+
+    def forget(self, plugin_id):
+        snapshot = self._shortcut_config._snapshot()
+        try:
+            self._shortcut_config.forget_plugin(plugin_id)
+            self._settings[SETTING_SHORTCUTS] = self._shortcut_config.to_dict()
+            self._stage_shortcut_owners()
+            saved = self._settings.save()
+        except Exception:
+            self._shortcut_config._restore(snapshot)
+            raise
+        if not saved:
+            self._shortcut_config._restore(snapshot)
+        return saved
+
+    def _remove_plugin(self, plugin_id, rollback=False):
+        self._assert_gui_thread()
+        preexisting = self._plugin_shortcut_preexisting.pop(plugin_id, {})
+        for command_id in self._plugin_actions.pop(plugin_id, ()):
+            action = self._actions.pop(command_id, None)
+            self._action_map.pop(command_id, None)
+            existed, previous_owner = preexisting.get(
+                command_id, (False, None))
+            self._shortcut_config.unregister_plugin(
+                command_id,
+                retain=(not rollback or existed),
+            )
+            if rollback:
+                self._shortcut_config.set_plugin_owner(
+                    command_id, previous_owner)
+            if action is not None:
+                self._menu.removeAction(action)
+                action.deleteLater()
+        self._plugin_callbacks.pop(plugin_id, None)
+        self._stage_shortcut_owners()
+        self._update_visibility()
+
+    def _trigger(self, plugin_id, command_id, _checked=False):
+        self._assert_gui_thread()
+        callbacks = self._plugin_callbacks.get(plugin_id)
+        if callbacks is not None:
+            callbacks[0](command_id)
+
+    def _stage_shortcut_owners(self):
+        plugins = self._settings.get("plugins", {})
+        plugins = dict(plugins) if isinstance(plugins, dict) else {}
+        plugins["shortcut_owners"] = self._shortcut_config.plugin_owners()
+        self._settings["plugins"] = plugins
+
+    def _update_visibility(self):
+        self._menu.menuAction().setVisible(bool(self._actions))
+
+    @staticmethod
+    def _assert_gui_thread():
+        application = QApplication.instance()
+        if application is None or QThread.currentThread() != application.thread():
+            raise RuntimeError("plugin UI operations must run on QApplication.thread()")
+
+
+class PluginManagerDialog(QDialog):
+    """Inspect plugins and persist enablement for the next application start."""
+
+    _COLUMNS = (
+        "Plugin", "Provider", "Entry point", "Status",
+        "API major", "Capabilities", "Enabled", "Homepage",
+    )
+
+    def __init__(self, manager, parent=None):
+        super().__init__(parent)
+        self.manager = manager
+        self.setWindowTitle("Plugins")
+        self.setMinimumSize(scale_px(980), scale_px(600))
+
+        layout = QVBoxLayout(self)
+        warning = QLabel(
+            "Plugins are trusted in-process Python code with the same access "
+            "as labelImg++. Enable only packages whose publisher and source "
+            "you trust; a virtual environment is recommended.")
+        warning.setWordWrap(True)
+        layout.addWidget(warning)
+        if manager.safe_mode:
+            safe_mode = QLabel(
+                "Safe mode is active (LABELIMGPP_DISABLE_PLUGINS=1). "
+                "Discovery and loading were skipped.")
+            safe_mode.setWordWrap(True)
+            layout.addWidget(safe_mode)
+
+        self.table = QTableWidget(0, len(self._COLUMNS), self)
+        self.table.setHorizontalHeaderLabels(self._COLUMNS)
+        self.table.setSelectionBehavior(QTableWidget.SelectRows)
+        self.table.setSelectionMode(QTableWidget.SingleSelection)
+        self.table.setEditTriggers(QTableWidget.NoEditTriggers)
+        self.table.horizontalHeader().setSectionResizeMode(
+            0, QHeaderView.ResizeToContents)
+        self.table.horizontalHeader().setSectionResizeMode(
+            1, QHeaderView.ResizeToContents)
+        self.table.horizontalHeader().setSectionResizeMode(
+            2, QHeaderView.Stretch)
+        layout.addWidget(self.table)
+
+        self.restart_notice = QLabel("")
+        self.restart_notice.setWordWrap(True)
+        layout.addWidget(self.restart_notice)
+
+        details_label = QLabel("Diagnostics")
+        layout.addWidget(details_label)
+        self.diagnostics = QPlainTextEdit(self)
+        self.diagnostics.setReadOnly(True)
+        self.diagnostics.setPlaceholderText("No diagnostics for this plugin.")
+        layout.addWidget(self.diagnostics)
+
+        self.homepage = QLabel("")
+        self.homepage.setOpenExternalLinks(True)
+        layout.addWidget(self.homepage)
+
+        buttons = QHBoxLayout()
+        self.copy_button = QPushButton("Copy Diagnostics", self)
+        self.copy_button.clicked.connect(self._copy_diagnostics)
+        self.forget_button = QPushButton("Forget Unavailable Plugin", self)
+        self.forget_button.clicked.connect(self._forget_selected)
+        close_button = QPushButton("Close", self)
+        close_button.clicked.connect(self.accept)
+        buttons.addWidget(self.copy_button)
+        buttons.addWidget(self.forget_button)
+        buttons.addStretch()
+        buttons.addWidget(close_button)
+        layout.addLayout(buttons)
+
+        self._populate()
+        self.table.itemChanged.connect(self._enabled_changed)
+        self.table.currentCellChanged.connect(self._selection_changed)
+        if self.table.rowCount():
+            self.table.selectRow(0)
+            self._selection_changed(0, 0, -1, -1)
+        else:
+            self.forget_button.setEnabled(False)
+            self.copy_button.setEnabled(False)
+
+    def _populate(self):
+        self.table.blockSignals(True)
+        records = self.manager.records
+        self.table.setRowCount(len(records))
+        for row, record in enumerate(records):
+            metadata = record.metadata
+            display = metadata.display_name if metadata else record.id
+            plugin_item = QTableWidgetItem(display)
+            plugin_item.setData(Qt.UserRole, record)
+            plugin_item.setToolTip(record.id)
+            self.table.setItem(row, 0, plugin_item)
+            provider = record.provider or "Unavailable"
+            if record.provider_version:
+                provider += " " + record.provider_version
+            self.table.setItem(row, 1, QTableWidgetItem(provider))
+            self.table.setItem(
+                row, 2, QTableWidgetItem(record.reference or "Unavailable"))
+            self.table.setItem(row, 3, QTableWidgetItem(
+                self._status_text(record)))
+            api = str(metadata.api_major) if metadata else "Unknown until enabled"
+            capabilities = (
+                ", ".join(item.value for item in metadata.capabilities)
+                if metadata else "Unknown until enabled")
+            self.table.setItem(row, 4, QTableWidgetItem(api))
+            self.table.setItem(row, 5, QTableWidgetItem(capabilities))
+            enabled = QTableWidgetItem("")
+            enabled.setData(Qt.UserRole, record)
+            enabled.setFlags(
+                enabled.flags() | Qt.ItemIsUserCheckable | Qt.ItemIsEnabled)
+            enabled.setCheckState(Qt.Checked if record.enabled else Qt.Unchecked)
+            self.table.setItem(row, 6, enabled)
+            self.table.setItem(
+                row, 7, QTableWidgetItem(
+                    metadata.homepage if metadata and metadata.homepage else ""))
+        self.table.blockSignals(False)
+
+    @staticmethod
+    def _status_text(record):
+        status = record.state.value.replace("_", " ").title()
+        if record.state == PluginState.ACTIVE and not record.enabled:
+            return status + " (disable after restart)"
+        if record.state == PluginState.DISABLED and record.enabled:
+            return status + " (enable after restart)"
+        return status
+
+    def _enabled_changed(self, item):
+        if item.column() != 6:
+            return
+        record = item.data(Qt.UserRole)
+        enabled = item.checkState() == Qt.Checked
+        try:
+            self.manager.set_enabled(record.id, enabled)
+        except Exception as exc:
+            self.table.blockSignals(True)
+            item.setCheckState(Qt.Checked if record.enabled else Qt.Unchecked)
+            self.table.blockSignals(False)
+            QMessageBox.warning(self, "Plugin settings", str(exc))
+            return
+        self.table.item(item.row(), 3).setText(self._status_text(record))
+        self.restart_notice.setText(
+            "The change was saved and will take effect after labelImg++ restarts.")
+
+    def _selection_changed(self, current_row, _current_column,
+                           _previous_row, _previous_column):
+        record = self._record_at(current_row)
+        if record is None:
+            self.diagnostics.clear()
+            self.homepage.clear()
+            self.forget_button.setEnabled(False)
+            return
+        lines = []
+        for diagnostic in record.diagnostics:
+            lines.append(
+                "[%s] %s/%s: %s" % (
+                    diagnostic.severity.upper(), diagnostic.phase,
+                    diagnostic.code, diagnostic.message))
+            if diagnostic.details:
+                lines.append(diagnostic.details.rstrip())
+        self.diagnostics.setPlainText("\n\n".join(lines))
+        metadata = record.metadata
+        homepage = metadata.homepage if metadata else ""
+        try:
+            parsed = urlparse(homepage)
+            valid_homepage = (
+                parsed.scheme in ("http", "https") and bool(parsed.netloc))
+        except ValueError:
+            valid_homepage = False
+        if valid_homepage:
+            escaped = escape(homepage, quote=True)
+            self.homepage.setText(
+                '<a href="%s">%s</a>' % (escaped, escaped))
+        else:
+            self.homepage.clear()
+        self.copy_button.setEnabled(bool(lines))
+        self.forget_button.setEnabled(
+            record.state == PluginState.UNAVAILABLE and not record.is_active)
+
+    def _copy_diagnostics(self):
+        QApplication.clipboard().setText(self.diagnostics.toPlainText())
+
+    def _forget_selected(self):
+        record = self._record_at(self.table.currentRow())
+        if record is None:
+            return
+        try:
+            saved = self.manager.forget(record.id)
+        except Exception as exc:
+            QMessageBox.warning(self, "Forget plugin", str(exc))
+            return
+        if not saved:
+            QMessageBox.warning(
+                self, "Forget plugin",
+                "The plugin settings file could not be saved.")
+            return
+        self._populate()
+        self.restart_notice.setText(
+            "Unavailable plugin configuration and shortcuts were removed.")
+
+    def _record_at(self, row):
+        if row < 0 or row >= self.table.rowCount():
+            return None
+        item = self.table.item(row, 0)
+        return item.data(Qt.UserRole) if item is not None else None
+
+
+__all__ = ["PluginManagerDialog", "QtPluginCommandHost"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ py-modules = ["labelImgPlusPlus"]
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["libs*"]
+include = ["libs*", "labelimgplusplus*"]
 
 [tool.setuptools.package-data]
 "*" = ["data/*.txt", "resources/**/*"]

--- a/tests/core/test_plugin_discovery.py
+++ b/tests/core/test_plugin_discovery.py
@@ -1,0 +1,123 @@
+from types import SimpleNamespace
+
+from libs.core.plugin_discovery import (
+    ENTRY_POINT_GROUP,
+    discover_plugins,
+    select_plugin_entry_points,
+)
+
+
+class _Selectable(list):
+    def select(self, **params):
+        return _Selectable([
+            ep for ep in self
+            if all(getattr(ep, key) == value for key, value in params.items())
+        ])
+
+
+def _dist(name="example-plugin", version="1.2.3", entry_points=()):
+    return SimpleNamespace(
+        metadata={"Name": name}, version=version, entry_points=entry_points)
+
+
+def _entry(name, value="example:factory", dist=True, group=ENTRY_POINT_GROUP):
+    fields = {"name": name, "value": value, "group": group}
+    if dist:
+        fields["dist"] = _dist()
+    return SimpleNamespace(**fields)
+
+
+def test_selects_legacy_mapping_and_iterable_collections():
+    plugin = _entry("com.example.plugin")
+    other = _entry("other", group="console_scripts")
+    assert select_plugin_entry_points({ENTRY_POINT_GROUP: [plugin]}) == (plugin,)
+    assert select_plugin_entry_points([other, plugin]) == (plugin,)
+
+
+def test_selects_modern_collection_without_tuple_access():
+    plugin = _entry("com.example.plugin")
+    collection = _Selectable([plugin, _entry("other", group="other")])
+    assert select_plugin_entry_points(collection) == (plugin,)
+
+
+def test_discovery_is_deterministic_and_does_not_load_entry_points():
+    loaded = []
+    entries = _Selectable([
+        _entry("z.plugin"),
+        _entry("a_plugin"),
+        _entry("m-plugin"),
+    ])
+    for entry in entries:
+        entry.load = lambda: loaded.append(entry.name)
+
+    result = discover_plugins(lambda: entries)
+
+    assert [candidate.id for candidate in result] == [
+        "a_plugin", "m-plugin", "z.plugin"]
+    assert loaded == []
+    assert all(candidate.loadable for candidate in result)
+
+
+def test_duplicate_ids_disable_every_candidate():
+    first = _entry("same.plugin", "first:create")
+    second = _entry("same.plugin", "second:create")
+    second.dist = _dist("second-distribution", "2.0")
+
+    result = discover_plugins(lambda: [second, first])
+
+    assert len(result) == 2
+    assert all(not candidate.loadable for candidate in result)
+    assert all(
+        "duplicate_plugin_id" in {item.code for item in candidate.diagnostics}
+        for candidate in result
+    )
+
+
+def test_invalid_id_and_missing_provider_are_diagnostics():
+    candidate, = discover_plugins(
+        lambda: [_entry("Invalid ID", dist=False)],
+        distributions_provider=lambda: (),
+    )
+    assert {item.code for item in candidate.diagnostics} == {
+        "invalid_plugin_id", "missing_provider_metadata"}
+    assert not candidate.loadable
+
+
+def test_legacy_entry_point_provider_is_resolved_from_distribution():
+    entry = _entry("com.example.legacy", dist=False)
+    provider = _dist("legacy-provider", "4.5.6", [entry])
+
+    candidate, = discover_plugins(
+        lambda: {ENTRY_POINT_GROUP: [entry]},
+        distributions_provider=lambda: [provider],
+    )
+
+    assert candidate.distribution == "legacy-provider"
+    assert candidate.distribution_version == "4.5.6"
+    assert candidate.loadable
+
+
+def test_public_api_import_is_qt_free_in_clean_interpreter(tmp_path):
+    import os
+    import subprocess
+    import sys
+
+    root = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+    code = (
+        "import sys; import labelimgplusplus.plugins; "
+        "assert not any(name.startswith('PyQt') for name in sys.modules); "
+        "assert 'numpy' not in sys.modules; assert 'cv2' not in sys.modules; "
+        "assert 'av' not in sys.modules"
+    )
+    subprocess.run(
+        [sys.executable, "-c", code], cwd=root, check=True,
+        env={**os.environ, "PYTHONPATH": root},
+    )
+
+
+def test_package_configuration_includes_public_namespace():
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[2]
+    config = (root / "pyproject.toml").read_text(encoding="utf-8")
+    assert 'include = ["libs*", "labelimgplusplus*"]' in config

--- a/tests/core/test_plugin_manager.py
+++ b/tests/core/test_plugin_manager.py
@@ -494,3 +494,31 @@ def test_unavailable_config_is_retained_until_forget(tmp_path):
         assert "gone.plugin" not in settings.get("plugins")["config"]
     finally:
         _shutdown(manager, coordinator)
+
+
+def test_validated_metadata_is_cached_without_reloading_disabled_plugin(tmp_path):
+    plugin_id = "com.example.cached"
+    plugin = _Plugin(plugin_id)
+    settings, coordinator, manager = _host(
+        tmp_path, [plugin_id], [_candidate(plugin_id, lambda: plugin)])
+    try:
+        manager.activate_enabled()
+        cached = settings.get("plugins")["metadata"][plugin_id]
+        assert cached["api_major"] == 1
+        assert cached["capabilities"] == ["commands"]
+        manager.set_enabled(plugin_id, False)
+    finally:
+        _shutdown(manager, coordinator)
+
+    second_coordinator = TaskCoordinator(logical_cpus=1)
+    loads = []
+    second = PluginManager(
+        settings, second_coordinator,
+        candidates=[_candidate(plugin_id, lambda: loads.append(True))])
+    try:
+        record = second.record_for(plugin_id)
+        assert record.state == PluginState.DISABLED
+        assert record.metadata == plugin.metadata
+        assert loads == []
+    finally:
+        _shutdown(second, second_coordinator)

--- a/tests/core/test_plugin_manager.py
+++ b/tests/core/test_plugin_manager.py
@@ -1,0 +1,496 @@
+import sys
+import threading
+import time
+
+from PyQt5.QtCore import QCoreApplication
+
+from labelimgplusplus.plugins import (
+    CommandSpec,
+    DocumentDescriptor,
+    PluginCapability,
+    PluginMetadata,
+)
+from libs.core.plugin_discovery import PluginCandidate
+from libs.core.plugin_manager import PluginManager, PluginState
+from libs.core.plugin_registry import validate_json_value
+from libs.core.settings import Settings
+from libs.core.task_coordinator import TaskCoordinator
+
+
+def _wait_until(predicate, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        QCoreApplication.processEvents()
+        if predicate():
+            return True
+        time.sleep(0.002)
+    return False
+
+
+class _EntryPoint:
+    def __init__(self, plugin_id, factory=None, error=None):
+        self.name = plugin_id
+        self.value = "fixture:create_plugin"
+        self.group = "labelimgplusplus.plugins"
+        self._factory = factory
+        self._error = error
+
+    def load(self):
+        if self._error is not None:
+            raise self._error
+        return self._factory
+
+
+def _metadata(plugin_id, api_major=1, capabilities=None):
+    if capabilities is None:
+        capabilities = (PluginCapability.COMMANDS,)
+    return PluginMetadata(
+        id=plugin_id,
+        display_name="Fixture Plugin",
+        version="1.0.0",
+        api_major=api_major,
+        capabilities=capabilities,
+    )
+
+
+def _candidate(plugin_id, factory=None, error=None):
+    entry = _EntryPoint(plugin_id, factory, error)
+    return PluginCandidate(
+        id=plugin_id,
+        reference=entry.value,
+        distribution="fixture-distribution",
+        distribution_version="1.0.0",
+        entry_point=entry,
+    )
+
+
+class _Plugin:
+    def __init__(self, plugin_id, activate=None, deactivate=None,
+                 api_major=1, capabilities=None):
+        self.metadata = _metadata(plugin_id, api_major, capabilities)
+        self._activate = activate
+        self._deactivate = deactivate
+        self.context = None
+
+    def activate(self, context):
+        self.context = context
+        if self._activate is not None:
+            self._activate(context)
+
+    def deactivate(self):
+        if self._deactivate is not None:
+            self._deactivate()
+
+
+def _host(tmp_path, plugin_ids, candidates):
+    settings = Settings()
+    settings.path = str(tmp_path / "settings.json")
+    settings.data = {"plugins": {"enabled": list(plugin_ids), "config": {}}}
+    coordinator = TaskCoordinator(logical_cpus=1)
+    manager = PluginManager(settings, coordinator, candidates=candidates)
+    return settings, coordinator, manager
+
+
+def _shutdown(manager, coordinator):
+    manager.shutdown()
+    coordinator.shutdown()
+    QCoreApplication.processEvents()
+
+
+def test_valid_plugin_activation_commits_command_and_settings(tmp_path):
+    calls = []
+
+    def activate(context):
+        context.commands.register(CommandSpec(
+            id="review", title="Review", callback=lambda: calls.append("ran")))
+        context.settings.set("color", {"rgb": [1, 2, 3]})
+
+    plugin = _Plugin("com.example.review", activate)
+    settings, coordinator, manager = _host(
+        tmp_path, [plugin.metadata.id],
+        [_candidate(plugin.metadata.id, lambda: plugin)])
+    try:
+        manager.activate_enabled()
+        record = manager.record_for(plugin.metadata.id)
+        assert record.state == PluginState.ACTIVE
+        command_id = "plugin.com.example.review.review"
+        assert command_id in manager.active_commands
+        assert manager.invoke_command(command_id)
+        assert calls == ["ran"]
+        assert settings.get("plugins")["config"][plugin.metadata.id] == {
+            "color": {"rgb": [1, 2, 3]}}
+    finally:
+        _shutdown(manager, coordinator)
+
+
+def test_activation_rollback_discards_all_staged_state(tmp_path):
+    events = []
+
+    def activate(context):
+        context.commands.register(CommandSpec(
+            id="partial", title="Partial", callback=lambda: None))
+        context.settings.set("partial", True)
+        context.documents.subscribe(lambda document: events.append(document))
+        try:
+            context.tasks.submit(lambda handle: None)
+        except RuntimeError:
+            pass
+        raise RuntimeError("activation exploded")
+
+    plugin = _Plugin(
+        "com.example.rollback", activate,
+        deactivate=lambda: events.append("deactivated"))
+    settings, coordinator, manager = _host(
+        tmp_path, [plugin.metadata.id],
+        [_candidate(plugin.metadata.id, lambda: plugin)])
+    try:
+        manager.activate_enabled()
+        record = manager.record_for(plugin.metadata.id)
+        assert record.state == PluginState.FAILED
+        assert manager.active_commands == {}
+        assert settings.get("plugins")["config"] == {}
+        manager.publish_document(DocumentDescriptor(generation=1))
+        assert events == ["deactivated"]
+        assert "activation_failed" in {item.code for item in record.diagnostics}
+    finally:
+        _shutdown(manager, coordinator)
+
+
+def test_task_submission_during_activation_rejects_plugin(tmp_path):
+    plugin = _Plugin(
+        "com.example.eager",
+        lambda context: context.tasks.submit(lambda handle: None))
+    _settings, coordinator, manager = _host(
+        tmp_path, [plugin.metadata.id],
+        [_candidate(plugin.metadata.id, lambda: plugin)])
+    try:
+        manager.activate_enabled()
+        assert manager.record_for(plugin.metadata.id).state == PluginState.FAILED
+        assert coordinator.queue_depths()["background"] == 0
+    finally:
+        _shutdown(manager, coordinator)
+
+
+def test_command_registration_requires_declared_capability(tmp_path):
+    plugin = _Plugin(
+        "com.example.undeclared",
+        lambda context: context.commands.register(CommandSpec(
+            id="run", title="Run", callback=lambda: None)),
+        capabilities=(),
+    )
+    _settings, coordinator, manager = _host(
+        tmp_path, [plugin.metadata.id],
+        [_candidate(plugin.metadata.id, lambda: plugin)])
+    try:
+        manager.activate_enabled()
+        record = manager.record_for(plugin.metadata.id)
+        assert record.state == PluginState.FAILED
+        assert record.diagnostics[-1].code == "capability_not_declared"
+        assert manager.active_commands == {}
+    finally:
+        _shutdown(manager, coordinator)
+
+
+def test_api_mismatch_is_incompatible(tmp_path):
+    plugin = _Plugin("com.example.future", api_major=99)
+    _settings, coordinator, manager = _host(
+        tmp_path, [plugin.metadata.id],
+        [_candidate(plugin.metadata.id, lambda: plugin)])
+    try:
+        manager.activate_enabled()
+        record = manager.record_for(plugin.metadata.id)
+        assert record.state == PluginState.INCOMPATIBLE
+        assert record.diagnostics[-1].code == "api_major_mismatch"
+    finally:
+        _shutdown(manager, coordinator)
+
+
+def test_invalid_metadata_field_types_are_rejected(tmp_path):
+    capability_plugin = _Plugin("com.example.bad-capability")
+    capability_plugin.metadata = PluginMetadata(
+        id=capability_plugin.metadata.id,
+        display_name="Bad Capability",
+        version="1.0.0",
+        api_major=1,
+        capabilities=("commands",),
+    )
+    text_plugin = _Plugin("com.example.bad-text")
+    text_plugin.metadata = PluginMetadata(
+        id=text_plugin.metadata.id,
+        display_name=42,
+        version="1.0.0",
+        api_major=1,
+        capabilities=(PluginCapability.COMMANDS,),
+    )
+    plugins = (capability_plugin, text_plugin)
+    _settings, coordinator, manager = _host(
+        tmp_path, [plugin.metadata.id for plugin in plugins], [
+            _candidate(plugin.metadata.id, lambda plugin=plugin: plugin)
+            for plugin in plugins
+        ])
+    try:
+        manager.activate_enabled()
+        for plugin in plugins:
+            record = manager.record_for(plugin.metadata.id)
+            assert record.state == PluginState.FAILED
+            assert record.diagnostics[-1].code == "invalid_metadata"
+    finally:
+        _shutdown(manager, coordinator)
+
+
+def test_missing_dependency_and_malformed_factory_are_contained(tmp_path):
+    missing_id = "com.example.missing"
+    malformed_id = "com.example.malformed"
+    _settings, coordinator, manager = _host(
+        tmp_path, [missing_id, malformed_id], [
+            _candidate(missing_id, error=ModuleNotFoundError("missing_lib")),
+            _candidate(malformed_id, factory=object()),
+        ])
+    try:
+        manager.activate_enabled()
+        assert manager.record_for(missing_id).diagnostics[-1].code == "missing_dependency"
+        assert manager.record_for(malformed_id).diagnostics[-1].code == "invalid_factory"
+    finally:
+        _shutdown(manager, coordinator)
+
+
+def test_missing_dependency_from_factory_is_identified(tmp_path):
+    plugin_id = "com.example.factory-dependency"
+
+    def factory():
+        raise ModuleNotFoundError("factory_dependency")
+
+    _settings, coordinator, manager = _host(
+        tmp_path, [plugin_id], [_candidate(plugin_id, factory=factory)])
+    try:
+        manager.activate_enabled()
+        record = manager.record_for(plugin_id)
+        assert record.state == PluginState.FAILED
+        assert record.diagnostics[-1].code == "missing_dependency"
+    finally:
+        _shutdown(manager, coordinator)
+
+
+def test_json_settings_are_isolated_and_reject_reserved_tags(tmp_path):
+    plugins = []
+    candidates = []
+    for plugin_id in ("a.plugin", "b.plugin"):
+        plugin = _Plugin(
+            plugin_id, lambda context, value=plugin_id: context.settings.set(
+                "shared", value))
+        plugins.append(plugin)
+        candidates.append(_candidate(plugin_id, lambda plugin=plugin: plugin))
+    settings, coordinator, manager = _host(
+        tmp_path, [plugin.metadata.id for plugin in plugins], candidates)
+    try:
+        manager.activate_enabled()
+        configs = settings.get("plugins")["config"]
+        assert configs["a.plugin"]["shared"] == "a.plugin"
+        assert configs["b.plugin"]["shared"] == "b.plugin"
+        for bad in (
+            {"nested": {"__type__": "QColor"}},
+            {"tuple": (1, 2)},
+            {"nan": float("nan")},
+        ):
+            try:
+                validate_json_value(bad)
+            except ValueError:
+                pass
+            else:
+                raise AssertionError("invalid plugin JSON was accepted")
+    finally:
+        _shutdown(manager, coordinator)
+
+
+def test_document_generation_cancels_and_discards_stale_task(tmp_path):
+    gate = threading.Event()
+    delivered = []
+    plugin = _Plugin("com.example.tasks")
+    _settings, coordinator, manager = _host(
+        tmp_path, [plugin.metadata.id],
+        [_candidate(plugin.metadata.id, lambda: plugin)])
+    try:
+        manager.activate_enabled()
+
+        def work(handle):
+            gate.wait(1)
+            return "stale"
+
+        handle = plugin.context.tasks.submit(work, on_result=delivered.append)
+        manager.publish_document(DocumentDescriptor(generation=1))
+        assert handle.is_cancelled()
+        gate.set()
+        assert _wait_until(lambda: coordinator.queue_depths()["background"] == 0)
+        assert delivered == []
+    finally:
+        gate.set()
+        _shutdown(manager, coordinator)
+
+
+def test_duplicate_document_subscriptions_unsubscribe_independently(tmp_path):
+    delivered = []
+    unsubscribers = []
+
+    def activate(context):
+        def callback(document):
+            delivered.append(document.revision)
+
+        unsubscribers.append(context.documents.subscribe(callback))
+        unsubscribers.append(context.documents.subscribe(callback))
+
+    plugin = _Plugin("com.example.subscriptions", activate)
+    _settings, coordinator, manager = _host(
+        tmp_path, [plugin.metadata.id],
+        [_candidate(plugin.metadata.id, lambda: plugin)])
+    try:
+        manager.activate_enabled()
+        manager.publish_document(DocumentDescriptor(generation=1, revision=1))
+        assert delivered == [1, 1]
+        unsubscribers[0]()
+        manager.publish_document(DocumentDescriptor(generation=1, revision=2))
+        assert delivered == [1, 1, 2]
+        unsubscribers[1]()
+        manager.publish_document(DocumentDescriptor(generation=1, revision=3))
+        assert delivered == [1, 1, 2]
+    finally:
+        _shutdown(manager, coordinator)
+
+
+def test_immediate_task_progress_is_delivered(tmp_path):
+    progress = []
+    results = []
+    plugin = _Plugin("com.example.progress")
+    _settings, coordinator, manager = _host(
+        tmp_path, [plugin.metadata.id],
+        [_candidate(plugin.metadata.id, lambda: plugin)])
+    try:
+        manager.activate_enabled()
+
+        def work(handle):
+            handle.report_progress("connected")
+            return "done"
+
+        plugin.context.tasks.submit(
+            work, on_progress=progress.append, on_result=results.append)
+        assert _wait_until(lambda: results == ["done"])
+        assert progress == ["connected"]
+    finally:
+        _shutdown(manager, coordinator)
+
+
+def test_shutdown_cancels_live_work_and_releases_task_handles(tmp_path):
+    progress_queued = threading.Event()
+    unexpected = []
+    previous_excepthook = sys.excepthook
+    plugin = _Plugin("com.example.close-work")
+    _settings, coordinator, manager = _host(
+        tmp_path, [plugin.metadata.id],
+        [_candidate(plugin.metadata.id, lambda: plugin)])
+    sys.excepthook = lambda *args: unexpected.append(args)
+    try:
+        manager.activate_enabled()
+
+        def work(handle):
+            handle.report_progress("queued-before-shutdown")
+            progress_queued.set()
+            while True:
+                handle.check_cancelled()
+                time.sleep(0.001)
+
+        handle = plugin.context.tasks.submit(work, on_progress=lambda _value: None)
+        assert progress_queued.wait(1)
+        task_service = plugin.context.tasks
+        manager.shutdown()
+        assert handle.is_cancelled()
+        assert task_service.handles == ()
+        assert _wait_until(
+            lambda: coordinator.queue_depths()["background"] == 0)
+        QCoreApplication.processEvents()
+        assert unexpected == []
+    finally:
+        manager.shutdown()
+        coordinator.shutdown()
+        QCoreApplication.processEvents()
+        sys.excepthook = previous_excepthook
+
+
+def test_callback_failures_become_diagnostics(tmp_path):
+    def activate(context):
+        context.commands.register(CommandSpec(
+            id="fail", title="Fail",
+            callback=lambda: (_ for _ in ()).throw(RuntimeError("callback bad"))))
+        context.documents.subscribe(
+            lambda document: (_ for _ in ()).throw(RuntimeError("document bad")))
+
+    plugin = _Plugin("com.example.callbacks", activate)
+    _settings, coordinator, manager = _host(
+        tmp_path, [plugin.metadata.id],
+        [_candidate(plugin.metadata.id, lambda: plugin)])
+    try:
+        manager.activate_enabled()
+        assert not manager.invoke_command("plugin.com.example.callbacks.fail")
+        manager.publish_document(DocumentDescriptor(generation=1))
+        codes = {item.code for item in manager.record_for(plugin.metadata.id).diagnostics}
+        assert "command_callback_failed" in codes
+        assert "document_callback_failed" in codes
+    finally:
+        _shutdown(manager, coordinator)
+
+
+def test_shutdown_deactivates_in_reverse_and_continues_after_failure(tmp_path):
+    order = []
+    first = _Plugin(
+        "a.plugin",
+        deactivate=lambda: (
+            order.append("a"),
+            (_ for _ in ()).throw(RuntimeError("a failed")),
+        ))
+    second = _Plugin("b.plugin", deactivate=lambda: order.append("b"))
+    _settings, coordinator, manager = _host(
+        tmp_path, [first.metadata.id, second.metadata.id], [
+            _candidate(second.metadata.id, lambda: second),
+            _candidate(first.metadata.id, lambda: first),
+        ])
+    try:
+        manager.activate_enabled()
+        manager.shutdown()
+        manager.shutdown()
+        assert order == ["b", "a"]
+        assert "deactivation_failed" in {
+            item.code for item in manager.record_for("a.plugin").diagnostics}
+    finally:
+        coordinator.shutdown()
+
+
+def test_safe_mode_bypasses_discovery(monkeypatch, tmp_path):
+    settings = Settings()
+    settings.path = str(tmp_path / "settings.json")
+    coordinator = TaskCoordinator(logical_cpus=1)
+    called = []
+    monkeypatch.setenv("LABELIMGPP_DISABLE_PLUGINS", "1")
+    manager = PluginManager(
+        settings, coordinator, discovery=lambda: called.append(True))
+    try:
+        assert manager.safe_mode
+        assert manager.records == ()
+        assert called == []
+    finally:
+        _shutdown(manager, coordinator)
+
+
+def test_unavailable_config_is_retained_until_forget(tmp_path):
+    settings = Settings()
+    settings.path = str(tmp_path / "settings.json")
+    settings.data = {"plugins": {
+        "enabled": ["gone.plugin"],
+        "config": {"gone.plugin": {"keep": True}},
+    }}
+    coordinator = TaskCoordinator(logical_cpus=1)
+    manager = PluginManager(settings, coordinator, candidates=[])
+    try:
+        assert manager.record_for("gone.plugin").state == PluginState.UNAVAILABLE
+        assert settings.get("plugins")["config"]["gone.plugin"] == {"keep": True}
+        manager.forget("gone.plugin")
+        assert "gone.plugin" not in settings.get("plugins")["config"]
+    finally:
+        _shutdown(manager, coordinator)

--- a/tests/core/test_shortcut_config.py
+++ b/tests/core/test_shortcut_config.py
@@ -9,7 +9,10 @@ import unittest
 dir_name = os.path.abspath(os.path.dirname(__file__))
 sys.path.insert(0, os.path.join(dir_name, '..', '..'))
 
-from libs.core.shortcut_config import ShortcutConfig, DEFAULT_SHORTCUTS
+from libs.core.shortcut_config import (  # noqa: E402
+    DEFAULT_SHORTCUTS,
+    ShortcutConfig,
+)
 
 
 class TestShortcutConfigImport(unittest.TestCase):
@@ -49,6 +52,59 @@ class TestShortcutConfigImport(unittest.TestCase):
     def test_import_valid_applies(self):
         self.cfg.import_json(self._write('{"save": "Ctrl+K"}'))
         self.assertEqual(self.cfg.get('save'), 'Ctrl+K')
+
+    def test_plugin_override_is_retained_while_command_is_hidden(self):
+        command = 'plugin.com.example.review.run'
+        self.cfg.from_dict({command: 'Ctrl+Alt+R'})
+        self.assertNotIn(command, self.cfg.get_all())
+        self.assertEqual(self.cfg.to_dict()[command], 'Ctrl+Alt+R')
+
+        self.assertEqual(
+            self.cfg.register_plugin(
+                command, 'Ctrl+R', 'com.example.review'), 'Ctrl+Alt+R')
+        self.assertEqual(self.cfg.get_all()[command], 'Ctrl+Alt+R')
+        self.cfg.unregister_plugin(command)
+        self.assertNotIn(command, self.cfg.get_all())
+        self.assertEqual(self.cfg.to_dict()[command], 'Ctrl+Alt+R')
+
+        self.cfg.register_plugin(command, 'Ctrl+R', 'com.example.review')
+        self.cfg.unregister_plugin(command, retain=False)
+        self.assertNotIn(command, self.cfg.to_dict())
+
+    def test_dynamic_reset_conflicts_and_forget(self):
+        command = 'plugin.com.example.review.run'
+        self.cfg.register_plugin(
+            command, 'Ctrl+Alt+R', 'com.example.review')
+        self.cfg.set(command, 'Ctrl+Q')
+        self.assertEqual(self.cfg.find_conflict('Ctrl+Q', command), 'quit')
+        self.cfg.reset(command)
+        self.assertEqual(self.cfg.get(command), 'Ctrl+Alt+R')
+        self.cfg.set(command, 'Ctrl+Shift+R')
+        self.cfg.forget_plugin('com.example.review')
+        self.assertNotIn(command, self.cfg.to_dict())
+
+    def test_customized_builtin_is_visible_and_conflicts(self):
+        self.cfg.set('save', 'Ctrl+9')
+        self.assertEqual(self.cfg.get_all()['save'], 'Ctrl+9')
+        self.assertEqual(self.cfg.find_conflict('Ctrl+9'), 'save')
+        self.assertIsNone(
+            self.cfg.find_conflict(DEFAULT_SHORTCUTS['save']))
+
+    def test_forget_plugin_keeps_dot_prefixed_plugin_commands(self):
+        short_command = 'plugin.a.run'
+        long_command = 'plugin.a.b.run'
+        self.cfg.register_plugin(short_command, 'Ctrl+1', 'a')
+        self.cfg.register_plugin(long_command, 'Ctrl+2', 'a.b')
+        self.cfg.forget_plugin('a')
+        self.assertNotIn(short_command, self.cfg.to_dict())
+        self.assertIn(long_command, self.cfg.to_dict())
+        self.assertEqual(self.cfg.owner_for(long_command), 'a.b')
+
+    def test_unknown_non_plugin_keys_are_rejected(self):
+        self.cfg.from_dict({'not_a_real_action': 'Ctrl+9'})
+        self.assertNotIn('not_a_real_action', self.cfg.to_dict())
+        with self.assertRaises(KeyError):
+            self.cfg.set('not_a_real_action', 'Ctrl+9')
 
 
 if __name__ == '__main__':

--- a/tests/fixtures/plugin_distribution/pyproject.toml
+++ b/tests/fixtures/plugin_distribution/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "labelimgpp-test-plugin"
+version = "1.0.0"
+description = "Packaged entry-point fixture for labelImg++ plugin tests"
+requires-python = ">=3.8"
+
+[project.entry-points."labelimgplusplus.plugins"]
+"org.labelimgpp.fixture" = "labelimgpp_fixture_plugin:create_plugin"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/tests/fixtures/plugin_distribution/src/labelimgpp_fixture_plugin/__init__.py
+++ b/tests/fixtures/plugin_distribution/src/labelimgpp_fixture_plugin/__init__.py
@@ -1,0 +1,45 @@
+"""Separately packaged fixture used to qualify the public plugin API."""
+
+from labelimgplusplus.plugins import (
+    CommandSpec,
+    PluginCapability,
+    PluginMetadata,
+)
+
+
+EXECUTIONS = 0
+DEACTIVATIONS = 0
+
+
+class FixturePlugin:
+    metadata = PluginMetadata(
+        id="org.labelimgpp.fixture",
+        display_name="Packaged Fixture",
+        version="1.0.0",
+        api_major=1,
+        capabilities=(PluginCapability.COMMANDS,),
+        description="Verifies activation from a separately installed wheel.",
+        homepage="https://example.invalid/labelimgpp-fixture",
+    )
+
+    def activate(self, context):
+        context.settings.set("activated", True)
+        context.commands.register(CommandSpec(
+            id="execute",
+            title="Execute Fixture",
+            callback=self._execute,
+            default_shortcut="Ctrl+Alt+F",
+        ))
+
+    def deactivate(self):
+        global DEACTIVATIONS
+        DEACTIVATIONS += 1
+
+    @staticmethod
+    def _execute():
+        global EXECUTIONS
+        EXECUTIONS += 1
+
+
+def create_plugin():
+    return FixturePlugin()

--- a/tests/integration/test_plugin_packaging.py
+++ b/tests/integration/test_plugin_packaging.py
@@ -1,0 +1,134 @@
+"""Build and install a real external entry-point plugin wheel."""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import textwrap
+
+
+def _run(command, **kwargs):
+    subprocess.run(command, check=True, **kwargs)
+
+
+def _stage_base_project(root, destination):
+    destination.mkdir()
+    for name in (
+            "pyproject.toml", "setup.cfg", "MANIFEST.in", "README.rst",
+            "LICENSE", "labelImgPlusPlus.py", "resources.qrc"):
+        shutil.copy2(root / name, destination / name)
+    for name in ("libs", "labelimgplusplus", "resources", "data"):
+        shutil.copytree(
+            root / name, destination / name,
+            ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
+        )
+
+
+def test_packaged_plugin_lifecycle_and_removal(tmp_path):
+    root = Path(__file__).resolve().parents[2]
+    base_source = tmp_path / "base-source"
+    fixture_source = tmp_path / "fixture-source"
+    wheelhouse = tmp_path / "wheelhouse"
+    environment = tmp_path / "environment"
+    wheelhouse.mkdir()
+    _stage_base_project(root, base_source)
+    shutil.copytree(
+        root / "tests" / "fixtures" / "plugin_distribution",
+        fixture_source,
+    )
+
+    for source in (base_source, fixture_source):
+        _run([
+            sys.executable, "-m", "pip", "wheel", "--no-deps",
+            "--wheel-dir", str(wheelhouse), str(source),
+        ], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+
+    base_wheel, = wheelhouse.glob("labelimgplusplus-*.whl")
+    fixture_wheel, = wheelhouse.glob("labelimgpp_test_plugin-*.whl")
+    _run([sys.executable, "-m", "venv", "--system-site-packages", str(environment)])
+    python = environment / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+    _run([
+        str(python), "-m", "pip", "install", "--no-deps",
+        "--force-reinstall", str(base_wheel), str(fixture_wheel),
+    ], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+
+    settings_path = tmp_path / "settings.json"
+    lifecycle = tmp_path / "lifecycle.py"
+    lifecycle.write_text(textwrap.dedent("""
+        import os
+        import sys
+        from PyQt5.QtWidgets import QApplication
+        import labelImgPlusPlus
+        from libs.core.plugin_discovery import discover_plugins
+        from libs.core.plugin_manager import PluginManager, PluginState
+        from libs.core.settings import Settings
+        from libs.core.task_coordinator import TaskCoordinator
+
+        assert 'av' not in sys.modules
+        assert 'cv2' not in sys.modules
+        assert 'numpy' not in sys.modules
+        candidates = discover_plugins()
+        candidate = next(item for item in candidates
+                         if item.id == 'org.labelimgpp.fixture')
+        assert candidate.distribution == 'labelimgpp-test-plugin'
+        assert 'labelimgpp_fixture_plugin' not in sys.modules
+
+        app = QApplication.instance() or QApplication([])
+        settings = Settings()
+        settings.path = os.environ['PLUGIN_TEST_SETTINGS']
+        settings.data = {'plugins': {
+            'enabled': ['org.labelimgpp.fixture'], 'config': {}}}
+        coordinator = TaskCoordinator(logical_cpus=1)
+        manager = PluginManager(settings, coordinator, candidates=candidates)
+        manager.activate_enabled()
+        record = manager.record_for('org.labelimgpp.fixture')
+        assert record.state == PluginState.ACTIVE
+        assert manager.invoke_command(
+            'plugin.org.labelimgpp.fixture.execute')
+        import labelimgpp_fixture_plugin as fixture
+        assert fixture.EXECUTIONS == 1
+        assert settings.get('plugins')['config'][record.id]['activated'] is True
+        manager.set_enabled(record.id, False)
+        assert record.state == PluginState.ACTIVE
+        assert record.enabled is False
+        manager.shutdown()
+        assert fixture.DEACTIVATIONS == 1
+        coordinator.shutdown()
+    """), encoding="utf-8")
+    process_environment = dict(os.environ)
+    process_environment.pop("PYTHONPATH", None)
+    process_environment.update({
+        "QT_QPA_PLATFORM": "offscreen",
+        "PLUGIN_TEST_SETTINGS": str(settings_path),
+    })
+    _run([str(python), str(lifecycle)], cwd=tmp_path, env=process_environment)
+
+    _run([
+        str(python), "-m", "pip", "uninstall", "-y",
+        "labelimgpp-test-plugin",
+    ], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    removed = tmp_path / "removed.py"
+    removed.write_text(textwrap.dedent("""
+        import os
+        from PyQt5.QtWidgets import QApplication
+        from libs.core.plugin_discovery import discover_plugins
+        from libs.core.plugin_manager import PluginManager, PluginState
+        from libs.core.settings import Settings
+        from libs.core.task_coordinator import TaskCoordinator
+
+        assert all(item.id != 'org.labelimgpp.fixture'
+                   for item in discover_plugins())
+        app = QApplication.instance() or QApplication([])
+        settings = Settings()
+        settings.path = os.environ['PLUGIN_TEST_SETTINGS']
+        assert settings.load()
+        coordinator = TaskCoordinator(logical_cpus=1)
+        manager = PluginManager(settings, coordinator, candidates=[])
+        record = manager.record_for('org.labelimgpp.fixture')
+        assert record.state == PluginState.UNAVAILABLE
+        assert settings.get('plugins')['config'][record.id]['activated'] is True
+        manager.shutdown()
+        coordinator.shutdown()
+    """), encoding="utf-8")
+    _run([str(python), str(removed)], cwd=tmp_path, env=process_environment)

--- a/tests/integration/test_plugin_performance.py
+++ b/tests/integration/test_plugin_performance.py
@@ -1,0 +1,15 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+
+_PROFILE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "tools" / "performance" / "profile_plugins.py")
+_SPEC = spec_from_file_location("labelimgpp_plugin_profile", _PROFILE_PATH)
+_PROFILE = module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_PROFILE)
+
+
+def test_plugin_performance_and_teardown_gates():
+    result = _PROFILE.profile_plugins(runs=5)
+    _PROFILE.assert_budgets(result)

--- a/tests/integration/test_plugins.py
+++ b/tests/integration/test_plugins.py
@@ -1,0 +1,383 @@
+import json
+import threading
+import time
+
+from PyQt5.QtCore import QCoreApplication, QThread, Qt
+from PyQt5.QtGui import QImage
+from PyQt5.QtWidgets import QApplication, QMainWindow, QMenu
+
+import labelImgPlusPlus as application_module
+from labelimgplusplus.plugins import (
+    CommandSpec,
+    PluginCapability,
+    PluginMetadata,
+)
+from libs.core.plugin_discovery import PluginCandidate
+from libs.core.plugin_manager import PluginManager, PluginState
+from libs.core.settings import Settings
+from libs.core.shortcut_config import ShortcutConfig
+from libs.core.task_coordinator import TaskCoordinator
+from libs.widgets.pluginManagerDialog import (
+    PluginManagerDialog,
+    QtPluginCommandHost,
+)
+
+
+def _wait_until(predicate, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        QCoreApplication.processEvents()
+        if predicate():
+            return True
+        time.sleep(0.002)
+    return False
+
+
+class _EntryPoint:
+    name = "com.example.qt"
+    value = "qt_fixture:create_plugin"
+    group = "labelimgplusplus.plugins"
+
+    def __init__(self, factory):
+        self._factory = factory
+
+    def load(self):
+        return self._factory
+
+
+def _candidate(factory):
+    entry = _EntryPoint(factory)
+    return PluginCandidate(
+        id=entry.name,
+        reference=entry.value,
+        distribution="qt-fixture",
+        distribution_version="1.0.0",
+        entry_point=entry,
+    )
+
+
+class _QtPlugin:
+    metadata = PluginMetadata(
+        id="com.example.qt",
+        display_name="Qt Fixture",
+        version="1.0.0",
+        api_major=1,
+        capabilities=(PluginCapability.COMMANDS,),
+        homepage="https://example.invalid/plugin",
+    )
+
+    def __init__(self, events):
+        self.events = events
+        self.context = None
+
+    def activate(self, context):
+        self.context = context
+        context.documents.subscribe(self._document_changed)
+        context.commands.register(CommandSpec(
+            id="inspect",
+            title="Inspect Document",
+            description="Exercise the host-owned command path",
+            default_shortcut="Ctrl+Alt+I",
+            callback=self._run,
+            enabled=lambda document: document.kind == "image",
+        ))
+
+    def deactivate(self):
+        self.events.append(("deactivate", QThread.currentThread()))
+
+    def _document_changed(self, document):
+        self.events.append(
+            ("document", document, QThread.currentThread()))
+
+    def _run(self):
+        self.events.append(("command", QThread.currentThread()))
+
+        def work(handle):
+            handle.check_cancelled()
+            self.events.append(("worker", threading.get_ident()))
+            return "complete"
+
+        self.context.tasks.submit(
+            work,
+            on_result=lambda value: self.events.append(
+                ("result", value, QThread.currentThread())),
+        )
+
+
+def _isolated_window(monkeypatch, tmp_path, enabled, plugin):
+    settings = Settings()
+    settings.path = str(tmp_path / "settings.json")
+    settings.data = {"plugins": {
+        "enabled": [plugin.metadata.id] if enabled else [],
+        "config": {},
+    }}
+    settings.save()
+    monkeypatch.setattr(application_module, "Settings", lambda: settings)
+
+    def create_manager(host_settings, coordinator, parent=None):
+        return PluginManager(
+            host_settings, coordinator,
+            candidates=[_candidate(lambda: plugin)], parent=parent)
+
+    monkeypatch.setattr(application_module, "PluginManager", create_manager)
+    return application_module.MainWindow(), settings
+
+
+def _close_window(window):
+    window.dirty = False
+    window.close()
+    QCoreApplication.processEvents()
+
+
+def test_mainwindow_owns_actions_and_publishes_documents_on_gui_thread(
+        monkeypatch, tmp_path):
+    events = []
+    plugin = _QtPlugin(events)
+    window, _settings = _isolated_window(
+        monkeypatch, tmp_path, enabled=True, plugin=plugin)
+    app = QApplication.instance()
+    command_id = "plugin.com.example.qt.inspect"
+    try:
+        record = window.plugin_manager.record_for(plugin.metadata.id)
+        assert record.state == PluginState.ACTIVE
+        action = window._action_map[command_id]
+        assert action.parent() is window
+        assert action.thread() == app.thread()
+        assert window.menus.plugins.thread() == app.thread()
+        assert window.menus.plugins.menuAction().isVisible()
+        assert not action.isEnabled()
+        assert window.shortcut_config.get(command_id) == "Ctrl+Alt+I"
+
+        image_path = str(tmp_path / "document.png")
+        image = QImage(32, 24, QImage.Format_RGB32)
+        image.fill(0xFFFFFFFF)
+        assert image.save(image_path)
+        assert window.load_file(image_path)
+        assert action.isEnabled()
+        descriptor = window.plugin_manager.document
+        assert descriptor.kind == "image"
+        assert descriptor.source_path == image_path
+        assert descriptor.read_only is False
+
+        action.trigger()
+        assert _wait_until(
+            lambda: any(event[0] == "result" for event in events))
+        command = next(event for event in events if event[0] == "command")
+        result = next(event for event in events if event[0] == "result")
+        assert command[1] == app.thread()
+        assert result[1:] == ("complete", app.thread())
+        assert any(event[0] == "worker" for event in events)
+        assert all(
+            event[-1] == app.thread()
+            for event in events if event[0] == "document")
+
+        previous_generation = descriptor.generation
+        window.reset_state()
+        assert window.plugin_manager.document.kind == "none"
+        assert window.plugin_manager.document.generation > previous_generation
+        assert not action.isEnabled()
+    finally:
+        _close_window(window)
+
+    assert events[-1] == ("deactivate", app.thread())
+    assert command_id not in window._action_map
+
+
+def test_manager_enablement_is_saved_but_does_not_hot_load(
+        monkeypatch, tmp_path):
+    events = []
+    plugin = _QtPlugin(events)
+    loaded = []
+    settings = Settings()
+    settings.path = str(tmp_path / "settings.json")
+    settings.data = {"plugins": {"enabled": [], "config": {}}}
+    settings.save()
+    monkeypatch.setattr(application_module, "Settings", lambda: settings)
+
+    def create_manager(host_settings, coordinator, parent=None):
+        candidate = _candidate(lambda: (loaded.append(True), plugin)[1])
+        return PluginManager(
+            host_settings, coordinator, candidates=[candidate], parent=parent)
+
+    monkeypatch.setattr(application_module, "PluginManager", create_manager)
+    window = application_module.MainWindow()
+    dialog = PluginManagerDialog(window.plugin_manager, window)
+    try:
+        record = window.plugin_manager.record_for(plugin.metadata.id)
+        assert record.state == PluginState.DISABLED
+        assert loaded == []
+        assert not window.menus.plugins.menuAction().isVisible()
+        assert dialog.table.item(0, 4).text() == "Unknown until enabled"
+
+        enabled_item = dialog.table.item(0, 6)
+        enabled_item.setCheckState(Qt.Checked)
+        QCoreApplication.processEvents()
+        assert record.enabled is True
+        assert record.state == PluginState.DISABLED
+        assert loaded == []
+        assert "restart" in dialog.restart_notice.text().lower()
+        with open(settings.path, "r", encoding="utf-8") as settings_file:
+            persisted = json.load(settings_file)
+        assert persisted["plugins"]["enabled"] == [plugin.metadata.id]
+    finally:
+        dialog.close()
+        _close_window(window)
+
+
+def test_failed_host_commit_removes_actions_and_new_shortcut_defaults(tmp_path):
+    class FailingSettings(Settings):
+        def save(self):
+            return False
+
+    events = []
+    plugin = _QtPlugin(events)
+    owner = QMainWindow()
+    menu = QMenu("Plugins", owner)
+    shortcuts = ShortcutConfig()
+    action_map = {}
+    settings = FailingSettings()
+    settings.path = str(tmp_path / "settings.json")
+    settings.data = {"plugins": {
+        "enabled": [plugin.metadata.id], "config": {}}}
+    coordinator = TaskCoordinator(logical_cpus=1, parent=owner)
+    host = QtPluginCommandHost(
+        owner, menu, shortcuts, action_map, settings)
+    manager = PluginManager(
+        settings, coordinator,
+        candidates=[_candidate(lambda: plugin)],
+        command_host=host,
+        parent=owner,
+    )
+    command_id = "plugin.com.example.qt.inspect"
+    try:
+        manager.activate_enabled()
+        record = manager.record_for(plugin.metadata.id)
+        assert record.state == PluginState.FAILED
+        assert manager.active_commands == {}
+        assert host.actions == {}
+        assert action_map == {}
+        assert command_id not in shortcuts.to_dict()
+        assert not menu.menuAction().isVisible()
+    finally:
+        manager.shutdown()
+        coordinator.shutdown()
+        owner.close()
+
+
+def test_command_host_keeps_dispatchers_isolated_per_plugin(tmp_path):
+    owner = QMainWindow()
+    menu = QMenu("Plugins", owner)
+    shortcuts = ShortcutConfig()
+    settings = Settings()
+    settings.path = str(tmp_path / "settings.json")
+    settings.data = {"plugins": {"enabled": [], "config": {}}}
+    host = QtPluginCommandHost(owner, menu, shortcuts, {}, settings)
+    calls = []
+    first_id = "plugin.a.run"
+    second_id = "plugin.a.b.run"
+    first_cleanup = host.commit(
+        "a",
+        {first_id: CommandSpec(
+            id="run", title="First", callback=lambda: None)},
+        lambda command_id: calls.append(("a", command_id)),
+        lambda _command_id: True,
+    )
+    second_cleanup = host.commit(
+        "a.b",
+        {second_id: CommandSpec(
+            id="run", title="Second", callback=lambda: None)},
+        lambda command_id: calls.append(("a.b", command_id)),
+        lambda _command_id: True,
+    )
+    try:
+        host.refresh_enablement()
+        host.actions[first_id].trigger()
+        host.actions[second_id].trigger()
+        assert calls == [("a", first_id), ("a.b", second_id)]
+        first_cleanup()
+        host.actions[second_id].trigger()
+        assert calls[-1] == ("a.b", second_id)
+    finally:
+        first_cleanup()
+        second_cleanup()
+        owner.close()
+
+
+def test_manager_homepage_allows_only_escaped_web_links(tmp_path):
+    plugin = _QtPlugin([])
+    plugin.metadata = PluginMetadata(
+        id=plugin.metadata.id,
+        display_name=plugin.metadata.display_name,
+        version=plugin.metadata.version,
+        api_major=plugin.metadata.api_major,
+        capabilities=plugin.metadata.capabilities,
+        homepage='javascript:alert("plugin")',
+    )
+    settings = Settings()
+    settings.path = str(tmp_path / "settings.json")
+    settings.data = {"plugins": {
+        "enabled": [plugin.metadata.id], "config": {}}}
+    coordinator = TaskCoordinator(logical_cpus=1)
+    manager = PluginManager(
+        settings, coordinator, candidates=[_candidate(lambda: plugin)])
+    manager.activate_enabled()
+    dialog = PluginManagerDialog(manager)
+    try:
+        assert dialog.homepage.text() == ""
+        record = manager.record_for(plugin.metadata.id)
+        record.metadata = PluginMetadata(
+            id=plugin.metadata.id,
+            display_name=plugin.metadata.display_name,
+            version=plugin.metadata.version,
+            api_major=plugin.metadata.api_major,
+            capabilities=plugin.metadata.capabilities,
+            homepage='https://example.invalid/?q="><script>',
+        )
+        dialog._selection_changed(0, 0, -1, -1)
+        rendered = dialog.homepage.text()
+        assert rendered.startswith('<a href="https://')
+        assert "&quot;&gt;&lt;script&gt;" in rendered
+        assert "<script>" not in rendered
+    finally:
+        dialog.close()
+        manager.shutdown()
+        coordinator.shutdown()
+
+
+def test_failed_forget_keeps_record_settings_and_exact_shortcuts(tmp_path):
+    class FailingSettings(Settings):
+        def save(self):
+            return False
+
+    plugin_id = "a"
+    command_id = "plugin.a.run"
+    settings = FailingSettings()
+    settings.path = str(tmp_path / "settings.json")
+    settings.data = {
+        "plugins": {
+            "enabled": [],
+            "config": {plugin_id: {"retained": True}},
+            "shortcut_owners": {command_id: plugin_id},
+        },
+        "shortcuts": {command_id: "Ctrl+1"},
+    }
+    shortcuts = ShortcutConfig()
+    shortcuts.from_dict(settings.data["shortcuts"])
+    owner = QMainWindow()
+    host = QtPluginCommandHost(
+        owner, QMenu("Plugins", owner), shortcuts, {}, settings)
+    coordinator = TaskCoordinator(logical_cpus=1, parent=owner)
+    manager = PluginManager(
+        settings, coordinator, candidates=[], command_host=host, parent=owner)
+    try:
+        assert manager.record_for(plugin_id).state == PluginState.UNAVAILABLE
+        assert manager.forget(plugin_id) is False
+        assert manager.record_for(plugin_id) is not None
+        assert settings.data["plugins"]["config"][plugin_id] == {
+            "retained": True}
+        assert shortcuts.to_dict()[command_id] == "Ctrl+1"
+        assert shortcuts.owner_for(command_id) == plugin_id
+    finally:
+        manager.shutdown()
+        coordinator.shutdown()
+        owner.close()

--- a/tools/performance/profile_plugins.py
+++ b/tools/performance/profile_plugins.py
@@ -1,0 +1,291 @@
+"""Five-run qualification for the plugin architecture performance budgets."""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import math
+import os
+from pathlib import Path
+from types import SimpleNamespace
+import tempfile
+import threading
+import time
+import weakref
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt5.QtCore import QCoreApplication, QEvent
+from PyQt5.QtWidgets import QApplication, QMainWindow, QMenu
+
+from labelimgplusplus.plugins import (
+    CommandSpec,
+    DocumentDescriptor,
+    PluginCapability,
+    PluginMetadata,
+)
+from libs.core.plugin_discovery import (
+    ENTRY_POINT_GROUP,
+    PluginCandidate,
+    discover_plugins,
+)
+from libs.core.plugin_manager import PluginManager
+from libs.core.settings import Settings
+from libs.core.shortcut_config import ShortcutConfig
+from libs.core.task_coordinator import TaskCoordinator
+from libs.widgets.pluginManagerDialog import (
+    PluginManagerDialog,
+    QtPluginCommandHost,
+)
+
+
+BUDGETS_MS = {
+    "no_plugin_startup_p95_ms": 50.0,
+    "disabled_100_discovery_p95_ms": 100.0,
+    "manager_100_open_p95_ms": 100.0,
+    "cancellation_ack_p95_ms": 500.0,
+}
+_PROFILE_APPLICATION = None
+
+
+class _EntryPoint:
+    group = ENTRY_POINT_GROUP
+
+    def __init__(self, plugin_id, factory=None):
+        self.name = plugin_id
+        self.value = "benchmark_plugin:create_plugin"
+        self.dist = SimpleNamespace(
+            metadata={"Name": "benchmark-distribution"}, version="1.0.0")
+        self._factory = factory
+
+    def load(self):
+        return self._factory
+
+
+def _candidate(plugin_id, factory=None):
+    entry = _EntryPoint(plugin_id, factory)
+    return PluginCandidate(
+        id=plugin_id,
+        reference=entry.value,
+        distribution="benchmark-distribution",
+        distribution_version="1.0.0",
+        entry_point=entry,
+    )
+
+
+def _settings(path, enabled=()):
+    settings = Settings()
+    settings.path = str(path)
+    settings.data = {"plugins": {"enabled": list(enabled), "config": {}}}
+    return settings
+
+
+def _p95(values):
+    ordered = sorted(values)
+    return ordered[max(0, math.ceil(0.95 * len(ordered)) - 1)]
+
+
+def _measure(function, runs):
+    function()
+    values = []
+    for _index in range(runs):
+        started = time.perf_counter()
+        function()
+        values.append((time.perf_counter() - started) * 1000.0)
+    return _p95(values), values
+
+
+def _wait_until(predicate, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        QCoreApplication.processEvents()
+        if predicate():
+            return True
+        time.sleep(0.001)
+    return False
+
+
+class _BenchmarkPlugin:
+    metadata = PluginMetadata(
+        id="benchmark.plugin",
+        display_name="Benchmark Plugin",
+        version="1.0.0",
+        api_major=1,
+        capabilities=(PluginCapability.COMMANDS,),
+    )
+
+    def activate(self, context):
+        self.context = context
+        context.commands.register(CommandSpec(
+            id="run", title="Run", callback=self.run))
+
+    def deactivate(self):
+        pass
+
+    def run(self):
+        pass
+
+
+def _profile_no_plugins(settings_path):
+    coordinator = TaskCoordinator(logical_cpus=1)
+    manager = PluginManager(
+        _settings(settings_path), coordinator, discovery=discover_plugins)
+    manager.shutdown()
+    coordinator.shutdown()
+
+
+def _profile_disabled_discovery(entries):
+    candidates = discover_plugins(lambda: entries)
+    if len(candidates) != len(entries) or not all(item.loadable for item in candidates):
+        raise AssertionError("disabled discovery fixture was not fully discovered")
+
+
+def _profile_manager_open(candidates, settings_path):
+    coordinator = TaskCoordinator(logical_cpus=1)
+    manager = PluginManager(
+        _settings(settings_path), coordinator, candidates=candidates)
+    dialog = PluginManagerDialog(manager)
+    if dialog.table.rowCount() != 100:
+        raise AssertionError("plugin manager did not render all candidates")
+    dialog.close()
+    dialog.deleteLater()
+    QCoreApplication.sendPostedEvents(None, QEvent.DeferredDelete)
+    manager.shutdown()
+    coordinator.shutdown()
+
+
+def _profile_cancellation(settings_path):
+    coordinator = TaskCoordinator(logical_cpus=1)
+    settings = _settings(settings_path, ("benchmark.plugin",))
+    manager = PluginManager(
+        settings, coordinator,
+        candidates=[_candidate("benchmark.plugin", _BenchmarkPlugin)])
+    manager.activate_enabled()
+    record = manager.record_for("benchmark.plugin")
+    started = threading.Event()
+
+    def work(handle):
+        started.set()
+        while True:
+            handle.check_cancelled()
+            time.sleep(0.001)
+
+    record.context.tasks.submit(work)
+    if not started.wait(1):
+        raise AssertionError("plugin cancellation benchmark did not start")
+    before = time.perf_counter()
+    manager.publish_document(DocumentDescriptor(generation=1))
+    if not _wait_until(lambda: coordinator.queue_depths()["background"] == 0):
+        raise AssertionError("plugin task did not acknowledge cancellation")
+    elapsed_ms = (time.perf_counter() - before) * 1000.0
+    manager.shutdown()
+    coordinator.shutdown()
+    return elapsed_ms
+
+
+def _verify_teardown(settings_path):
+    owner = QMainWindow()
+    menu = QMenu("Plugins", owner)
+    shortcuts = ShortcutConfig()
+    action_map = {}
+    settings = _settings(settings_path, ("benchmark.plugin",))
+    coordinator = TaskCoordinator(logical_cpus=1, parent=owner)
+    host = QtPluginCommandHost(owner, menu, shortcuts, action_map, settings)
+    manager = PluginManager(
+        settings, coordinator,
+        candidates=[_candidate("benchmark.plugin", _BenchmarkPlugin)],
+        command_host=host,
+        parent=owner,
+    )
+    manager.activate_enabled()
+    record = manager.record_for("benchmark.plugin")
+    plugin = record.plugin
+    context = record.context
+    action = host.actions["plugin.benchmark.plugin.run"]
+    references = {
+        "plugin": weakref.ref(plugin),
+        "context": weakref.ref(context),
+        "action": weakref.ref(action),
+    }
+    manager.shutdown()
+    coordinator.shutdown()
+    if manager.active_commands or host.actions or record.plugin or record.context:
+        raise AssertionError("plugin registrations survived teardown")
+    del plugin, context, action
+    owner.close()
+    owner.deleteLater()
+    QCoreApplication.sendPostedEvents(None, QEvent.DeferredDelete)
+    gc.collect()
+    retained = [name for name, reference in references.items()
+                if reference() is not None]
+    if retained:
+        raise AssertionError("plugin teardown retained: %s" % ", ".join(retained))
+    return True
+
+
+def profile_plugins(runs=5):
+    global _PROFILE_APPLICATION
+    _PROFILE_APPLICATION = QApplication.instance() or QApplication([])
+    with tempfile.TemporaryDirectory(prefix="labelimgpp-plugin-profile-") as temp:
+        root = Path(temp)
+        no_plugin_p95, no_plugin_runs = _measure(
+            lambda: _profile_no_plugins(root / "no-plugin.json"), runs)
+        entries = tuple(
+            _EntryPoint("benchmark.disabled-%03d" % index)
+            for index in range(100))
+        discovery_p95, discovery_runs = _measure(
+            lambda: _profile_disabled_discovery(entries), runs)
+        candidates = tuple(
+            _candidate("benchmark.manager-%03d" % index)
+            for index in range(100))
+        manager_p95, manager_runs = _measure(
+            lambda: _profile_manager_open(
+                candidates, root / "manager.json"), runs)
+        _profile_cancellation(root / "cancel-warmup.json")
+        cancellation_runs = [
+            _profile_cancellation(root / ("cancel-%d.json" % index))
+            for index in range(runs)]
+        cancellation_p95 = _p95(cancellation_runs)
+        teardown_clean = _verify_teardown(root / "teardown.json")
+    return {
+        "runs": runs,
+        "no_plugin_startup_p95_ms": no_plugin_p95,
+        "disabled_100_discovery_p95_ms": discovery_p95,
+        "manager_100_open_p95_ms": manager_p95,
+        "cancellation_ack_p95_ms": cancellation_p95,
+        "teardown_clean": teardown_clean,
+        "samples_ms": {
+            "no_plugin_startup": no_plugin_runs,
+            "disabled_100_discovery": discovery_runs,
+            "manager_100_open": manager_runs,
+            "cancellation_ack": cancellation_runs,
+        },
+    }
+
+
+def assert_budgets(result):
+    failures = []
+    for name, budget in BUDGETS_MS.items():
+        if result[name] >= budget:
+            failures.append("%s %.3f >= %.3f" % (name, result[name], budget))
+    if not result["teardown_clean"]:
+        failures.append("plugin teardown retained registrations")
+    if failures:
+        raise AssertionError("; ".join(failures))
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--runs", type=int, default=5)
+    parser.add_argument("--assert-budgets", action="store_true")
+    args = parser.parse_args(argv)
+    result = profile_plugins(max(1, args.runs))
+    if args.assert_budgets:
+        assert_budgets(result)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add the Qt-free `labelimgplusplus.plugins` API-major-1 public contract and metadata-only PyPA entry-point discovery
- add transactional activation, namespaced JSON settings, generation-scoped background tasks, read-only document descriptors, structured diagnostics, and reverse teardown
- add host-owned plugin actions, retained dynamic shortcuts, restart-only enablement, safe mode, and the Tools → Plugins manager
- add a separately built fixture wheel, Python 3.8–3.13 focused CI, performance/teardown gates, PyInstaller boot coverage, and complete authoring/API/troubleshooting documentation

Refs #26.

#27 and #28 remain open and are blocked on this foundation being merged and documented.

## Test plan

- [x] `PYTHONPATH=. QT_QPA_PLATFORM=offscreen pytest -q` — 919 passed, 1 skipped
- [x] combined SAM + video matrix — 130 passed, 1 skipped
- [x] focused packaged plugin install/activate/execute/disable/uninstall lifecycle
- [x] Ruff on all changed Python inputs
- [x] compileall and Python 3.8 AST parsing
- [x] wheel/sdist content and dependency inspection
- [x] clean PyInstaller one-file artifact boot in plugin safe mode with no optional-feature hooks
- [x] five-run gates: no-plugin startup 10.80 ms p95; 100-entry discovery 0.19 ms p95; 100-row manager 2.70 ms p95; cancellation acknowledgement 1.10 ms p95; clean teardown

## Checklist

- [x] Tests added and passing
- [x] Documentation and HISTORY updated
- [x] Base dependencies and CLI contracts unchanged
- [x] Existing image/video formats, filenames, class ordering, synchronous APIs, and Qt ownership boundaries preserved
- [ ] Cross-version GitHub Actions pending
- [ ] Mypy not configured in this repository

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for installing and managing Python plugins through **Tools → Plugins…**.
  * Plugins can provide commands, shortcuts, settings, document access, background tasks, and diagnostics.
  * Added restart-required activation, safe mode, and an option to disable plugins for recovery.
  * Plugin settings are stored in JSON with improved retention and reset options.

* **Documentation**
  * Added plugin authoring guidance, API reference, architecture details, troubleshooting information, and release documentation.

* **Tests**
  * Expanded validation for plugin discovery, packaging, lifecycle behavior, performance, and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->