### PR TITLE
fix(plugins): remediate architecture audit findings

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,12 @@ Unreleased
 * Qualify a separately installed fixture wheel on Python 3.8 through 3.13 and
   add five-run startup, 100-entry discovery/manager, cancellation, and teardown
   gates.
+* Restrict plugin tasks to a plain cancellation/progress facade, preserve
+  worker tracebacks through GUI-thread error delivery, validate diagnostic
+  fields transactionally, and render malformed diagnostics defensively.
+* Apply empty shortcut values to active plugin actions after reset/import and
+  make the plugin qualification profiler runnable directly from outside the
+  repository.
 
 3.0.0 (2026-08-09)
 ------------------

--- a/docs/guides/plugin-authoring.md
+++ b/docs/guides/plugin-authoring.md
@@ -159,14 +159,41 @@ def run(self):
 Plugin task keys are host-namespaced. `latest=True` cooperatively cancels the
 previous task with the same local key. The host also cancels plugin work on a
 document-generation change and plugin shutdown, and discards stale results.
-Worker functions must call `check_cancelled()` around expensive steps. Result,
-error, and progress callbacks run on the GUI thread and are converted to
-diagnostics if they raise.
+The submitter and worker receive the same plain `PluginTaskHandle` facade; it
+does not expose Qt signals, a `QObject` parent, coordinator metadata, or an
+atomic non-cancellable phase. The host detaches it from internal work after
+completion or shutdown.
+
+Worker functions must call `check_cancelled()` around expensive steps. It
+raises `concurrent.futures.CancelledError`, so use that standard exception if
+worker-local cleanup is needed:
+
+```python
+from concurrent.futures import CancelledError
+
+try:
+    handle.check_cancelled()
+    result = analyze_file(source_path)
+except CancelledError:
+    release_worker_resources()
+    raise
+```
+
+Result, error, and progress callbacks run on the GUI thread and are converted
+to diagnostics if they raise. A worker exception skips `on_result`, passes its
+message to `on_error`, and records a `task_failed` diagnostic with the complete
+formatted worker traceback in `details`.
 
 Workers may return immutable/plain values or detached `QImage` values. They
 must not create `QPixmap`, widgets, `QAction`, or mutable Shape/Canvas/video
 objects, and must not use unmanaged global thread pools for host-integrated
 work.
+
+Diagnostic `code`, `message`, `details`, and `severity` values must all be
+strings, and `code` and `severity` must be non-empty. Invalid diagnostic
+reporting during activation rolls back the complete activation transaction;
+invalid reporting from a command, document, or task callback is contained as a
+normal callback diagnostic.
 
 ## Observe documents
 

--- a/docs/reference/plugin-api-v1.md
+++ b/docs/reference/plugin-api-v1.md
@@ -43,7 +43,9 @@ Python 3.8/3.9 collection shapes and selectable Python 3.10–3.13 collections.
 
 Structured diagnostics contain `plugin_id`, `phase`, `code`, `message`,
 `details`, and `severity`. The manager preserves tracebacks in `details` for
-load, lifecycle, task, and callback failures.
+load, lifecycle, task, and callback failures. Plugin-reported `code`,
+`message`, `details`, and `severity` values must all be strings; `code` and
+`severity` must be non-empty.
 
 ### `DocumentDescriptor`
 
@@ -111,9 +113,18 @@ submit(
 
 Work runs on the existing bounded background lane and receives a handle with
 `cancel()`, `is_cancelled()`, `check_cancelled()`, and
-`report_progress(value)`. Callbacks return to the GUI thread. Keys are
-plugin-namespaced; results from an old generation or shutting-down plugin are
-discarded.
+`report_progress(value)`. The submitter and worker receive the same plain
+Python facade. It is not a `QObject` or the coordinator's internal job handle,
+and it exposes no Qt signals, parent, job metadata, or non-cancellable phase.
+The host weakly attaches it to internal work and detaches it after completion
+or shutdown, so retaining a finished handle cannot retain host internals.
+
+`check_cancelled()` raises `concurrent.futures.CancelledError`. Callbacks
+return to the GUI thread. Keys are plugin-namespaced; results from an old
+generation or shutting-down plugin are discarded. A worker exception records
+a `task_failed` diagnostic whose `details` preserve the formatted worker
+traceback. `on_error`, when supplied, receives the exception message on the
+GUI thread; `on_result` is not called for failures.
 
 ### `settings`
 
@@ -132,7 +143,10 @@ changes, resets, and close transitions.
 ### `diagnostics`
 
 `report(code, message, details="", severity="error")` adds a plugin-scoped
-diagnostic visible in **Tools → Plugins…**.
+diagnostic visible in **Tools → Plugins…**. Every argument must be a string,
+and `code` and `severity` must be non-empty. Invalid reporting during
+activation rejects and rolls back the activation. Invalid reporting from a
+runtime callback is contained as that callback's diagnostic.
 
 ## Thread and trust contract
 

--- a/docs/testing-plan.md
+++ b/docs/testing-plan.md
@@ -59,6 +59,14 @@ documented in `docs/performance.md`.
 - The workstation profiler performs one warm-up and five measured runs and
   emits `summary.json`, `trace.json`, `resources.csv`, cProfile output, a
   comparison report, and optionally a py-spy flamegraph.
+- The plugin qualification profiler can be executed directly by file path
+  from any working directory. From the repository root, run:
+
+  ```bash
+  repository_root=$(pwd)
+  (cd /tmp && python "$repository_root/tools/performance/profile_plugins.py" \
+    --runs 5 --assert-budgets)
+  ```
 
 ## Coverage Gaps
 

--- a/libs/core/plugin_manager.py
+++ b/libs/core/plugin_manager.py
@@ -37,6 +37,40 @@ class PluginState(str, Enum):
     SHUTTING_DOWN = "shutting_down"
 
 
+def _diagnostic_field(diagnostic, name, default):
+    try:
+        if isinstance(diagnostic, dict):
+            value = diagnostic.get(name, default)
+        else:
+            value = getattr(diagnostic, name, default)
+    except Exception:
+        return default
+    if value is None:
+        return default
+    if isinstance(value, str):
+        return value
+    try:
+        return str(value)
+    except Exception:
+        return default
+
+
+def normalize_plugin_diagnostic(plugin_id, diagnostic):
+    """Return a render-safe canonical diagnostic for host storage."""
+    normalized_id = plugin_id if isinstance(plugin_id, str) else "<unknown>"
+    code = _diagnostic_field(diagnostic, "code", "invalid_diagnostic")
+    severity = _diagnostic_field(diagnostic, "severity", "error")
+    return PluginDiagnostic(
+        plugin_id=_diagnostic_field(diagnostic, "plugin_id", normalized_id),
+        phase=_diagnostic_field(diagnostic, "phase", "unknown"),
+        code=code or "invalid_diagnostic",
+        message=_diagnostic_field(
+            diagnostic, "message", "Malformed plugin diagnostic."),
+        details=_diagnostic_field(diagnostic, "details", ""),
+        severity=severity or "error",
+    )
+
+
 @dataclass
 class PluginRecord:
     id: str
@@ -48,6 +82,12 @@ class PluginRecord:
     plugin: object = field(default=None, repr=False)
     context: object = field(default=None, repr=False)
     command_cleanup: object = field(default=None, repr=False)
+
+    def __post_init__(self):
+        self.diagnostics = [
+            normalize_plugin_diagnostic(self.id, diagnostic)
+            for diagnostic in self.diagnostics
+        ]
 
     @property
     def is_active(self):
@@ -279,7 +319,11 @@ class PluginManager(QObject):
         available_ids = set()
         for candidate in candidates:
             available_ids.add(candidate.id)
-            codes = {item.code for item in candidate.diagnostics}
+            diagnostics = [
+                normalize_plugin_diagnostic(candidate.id, item)
+                for item in candidate.diagnostics
+            ]
+            codes = {item.code for item in diagnostics}
             if "duplicate_plugin_id" in codes:
                 state = PluginState.CONFLICTING
             elif "missing_provider_metadata" in codes:
@@ -296,7 +340,7 @@ class PluginManager(QObject):
                 enabled=candidate.id in enabled,
                 candidate=candidate,
                 metadata=self._cached_metadata(candidate.id),
-                diagnostics=list(candidate.diagnostics),
+                diagnostics=diagnostics,
             ))
         configured = set(enabled)
         config = self._plugins_settings_copy().get("config", {})
@@ -491,12 +535,26 @@ class PluginManager(QObject):
 
     def _record_diagnostic(self, record, phase, code, message, details="",
                            severity="error"):
+        fields = {
+            "phase": phase,
+            "code": code,
+            "message": message,
+            "details": details,
+            "severity": severity,
+        }
+        for name, value in fields.items():
+            if not isinstance(value, str):
+                raise TypeError("diagnostic %s must be a string" % name)
+        if not code:
+            raise ValueError("diagnostic code must be non-empty")
+        if not severity:
+            raise ValueError("diagnostic severity must be non-empty")
         record.diagnostics.append(PluginDiagnostic(
             plugin_id=record.id,
             phase=phase,
             code=code,
-            message=str(message),
-            details=str(details),
+            message=message,
+            details=details,
             severity=severity,
         ))
 
@@ -602,4 +660,9 @@ class PluginManager(QObject):
             raise OSError("could not persist plugin settings")
 
 
-__all__ = ["PluginManager", "PluginRecord", "PluginState"]
+__all__ = [
+    "PluginManager",
+    "PluginRecord",
+    "PluginState",
+    "normalize_plugin_diagnostic",
+]

--- a/libs/core/plugin_registry.py
+++ b/libs/core/plugin_registry.py
@@ -2,16 +2,21 @@
 
 from __future__ import annotations
 
+from concurrent.futures import CancelledError
+from dataclasses import dataclass
 from copy import deepcopy
 import math
 import re
 import threading
+import traceback
 from types import MappingProxyType
+from typing import Optional
+import weakref
 
 from PyQt5.QtCore import QObject, Qt, pyqtSlot
 
 from labelimgplusplus.plugins import CommandSpec
-from libs.core.task_coordinator import JobPriority
+from libs.core.task_coordinator import JobCancelled, JobPriority
 
 
 _VALID_COMMAND_ID = re.compile(r"^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$")
@@ -219,6 +224,65 @@ class PluginDiagnosticService:
             self._record, "plugin", code, message, details, severity)
 
 
+class _PluginTaskHandle:
+    """Plain plugin task facade with no Qt or coordinator surface."""
+
+    __slots__ = ("_cancelled", "_handle_ref")
+
+    def __init__(self, handle):
+        self._cancelled = threading.Event()
+        self._handle_ref = weakref.ref(handle)
+
+    def cancel(self):
+        self._cancelled.set()
+        handle = self._handle_ref() if self._handle_ref is not None else None
+        if handle is not None:
+            handle.cancel()
+
+    def is_cancelled(self):
+        if self._cancelled.is_set():
+            return True
+        handle = self._handle_ref() if self._handle_ref is not None else None
+        if handle is not None and handle.is_cancelled():
+            self._cancelled.set()
+            return True
+        return False
+
+    def check_cancelled(self):
+        if self.is_cancelled():
+            raise CancelledError()
+
+    def report_progress(self, value):
+        handle = self._handle_ref() if self._handle_ref is not None else None
+        if handle is not None and not self._cancelled.is_set():
+            handle.report_progress(value)
+
+
+def _detach_task_handle(handle):
+    coordinator_handle = (
+        handle._handle_ref() if handle._handle_ref is not None else None)
+    if coordinator_handle is not None and coordinator_handle.is_cancelled():
+        handle._cancelled.set()
+    handle._handle_ref = None
+
+
+@dataclass(frozen=True)
+class _TaskOutcome:
+    result: object = None
+    message: Optional[str] = None
+    details: str = ""
+
+    @property
+    def failed(self):
+        return self.message is not None
+
+    @classmethod
+    def from_exception(cls, exc):
+        details = "".join(traceback.format_exception(
+            type(exc), exc, exc.__traceback__))
+        return cls(message=str(exc), details=details)
+
+
 class _TaskBridge(QObject):
     """QObject receiver that fences callbacks to the application thread."""
 
@@ -247,9 +311,23 @@ class _TaskBridge(QObject):
         )
 
     @pyqtSlot(object)
-    def result(self, value):
-        if self._deliverable() and self._result_callback is not None:
-            self._service._invoke_callback("result", self._result_callback, value)
+    def result(self, outcome):
+        if not self._deliverable():
+            return
+        if outcome.failed:
+            self._service._manager._record_diagnostic(
+                self._service._record,
+                "task",
+                "task_failed",
+                outcome.message,
+                outcome.details,
+            )
+            if self._error_callback is not None:
+                self._service._invoke_callback(
+                    "error", self._error_callback, outcome.message)
+        elif self._result_callback is not None:
+            self._service._invoke_callback(
+                "result", self._result_callback, outcome.result)
 
     @pyqtSlot(str)
     def error(self, message):
@@ -275,8 +353,6 @@ class _TaskBridge(QObject):
         if self._service is None:
             return
         self._service._finished(self._handle)
-        self.detach()
-        self.deleteLater()
 
     def detach(self):
         self._result_callback = None
@@ -294,6 +370,7 @@ class PluginTaskServiceImpl:
         self._record = record
         self._accepting = False
         self._bridges = {}
+        self._latest_by_key = {}
 
     @property
     def accepting(self):
@@ -325,12 +402,19 @@ class PluginTaskServiceImpl:
             if key is not None else None)
         ready = threading.Event()
 
-        def connected_work(handle):
-            ready.wait()
-            handle.check_cancelled()
-            return work(handle)
+        facade = None
 
-        handle = self._manager.coordinator.submit(
+        def connected_work(_coordinator_handle):
+            ready.wait()
+            try:
+                facade.check_cancelled()
+                return _TaskOutcome(result=work(facade))
+            except CancelledError as exc:
+                raise JobCancelled() from exc
+            except Exception as exc:
+                return _TaskOutcome.from_exception(exc)
+
+        coordinator_handle = self._manager.coordinator.submit(
             "background",
             connected_work,
             priority=JobPriority.BULK,
@@ -338,38 +422,56 @@ class PluginTaskServiceImpl:
             latest=latest,
             generation=generation,
         )
-        bridge = _TaskBridge(self, handle, generation)
+        facade = _PluginTaskHandle(coordinator_handle)
+        bridge = _TaskBridge(self, facade, generation)
         try:
             bridge.configure(on_result, on_error, on_progress)
-            self._bridges[handle] = bridge
-            handle.result.connect(bridge.result, Qt.QueuedConnection)
-            handle.error.connect(bridge.error, Qt.QueuedConnection)
-            handle.progress.connect(bridge.progress, Qt.QueuedConnection)
-            handle.finished.connect(bridge.finished, Qt.QueuedConnection)
+            if latest and namespaced_key is not None:
+                previous = self._latest_by_key.get(namespaced_key)
+                if previous is not None:
+                    previous.cancel()
+                    self._release(previous)
+                self._latest_by_key[namespaced_key] = facade
+            self._bridges[facade] = bridge
+            coordinator_handle.result.connect(bridge.result, Qt.QueuedConnection)
+            coordinator_handle.error.connect(bridge.error, Qt.QueuedConnection)
+            coordinator_handle.progress.connect(
+                bridge.progress, Qt.QueuedConnection)
+            coordinator_handle.finished.connect(
+                bridge.finished, Qt.QueuedConnection)
         except Exception:
-            self._bridges.pop(handle, None)
-            handle.cancel()
-            bridge.detach()
-            bridge.deleteLater()
+            facade.cancel()
+            self._release(facade, bridge)
             raise
         finally:
             ready.set()
-        return handle
+        return facade
 
     def cancel_all(self):
         for handle in tuple(self._bridges):
             handle.cancel()
+            self._release(handle)
 
     def shutdown(self):
         self._accepting = False
-        for handle, bridge in tuple(self._bridges.items()):
+        for handle in tuple(self._bridges):
             handle.cancel()
-            bridge.detach()
-            bridge.deleteLater()
-        self._bridges.clear()
+            self._release(handle)
+        self._latest_by_key.clear()
 
     def _finished(self, handle):
+        self._release(handle)
+
+    def _release(self, handle, bridge=None):
+        bridge = bridge or self._bridges.pop(handle, None)
         self._bridges.pop(handle, None)
+        for key, latest_handle in tuple(self._latest_by_key.items()):
+            if latest_handle is handle:
+                self._latest_by_key.pop(key, None)
+        _detach_task_handle(handle)
+        if bridge is not None:
+            bridge.detach()
+            bridge.deleteLater()
 
     def _invoke_callback(self, kind, callback, value):
         try:

--- a/libs/widgets/pluginManagerDialog.py
+++ b/libs/widgets/pluginManagerDialog.py
@@ -20,7 +20,7 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
 )
 
-from libs.core.plugin_manager import PluginState
+from libs.core.plugin_manager import PluginState, normalize_plugin_diagnostic
 from libs.utils.constants import SETTING_SHORTCUTS
 from libs.utils.dpi import scale_px
 
@@ -346,6 +346,7 @@ class PluginManagerDialog(QDialog):
             return
         lines = []
         for diagnostic in record.diagnostics:
+            diagnostic = normalize_plugin_diagnostic(record.id, diagnostic)
             lines.append(
                 "[%s] %s/%s: %s" % (
                     diagnostic.severity.upper(), diagnostic.phase,

--- a/libs/widgets/shortcutsDialog.py
+++ b/libs/widgets/shortcutsDialog.py
@@ -86,10 +86,8 @@ class ShortcutsDialog(QDialog):
         conflict = self.config.find_conflict(shortcut, exclude_action=action_name)
         self._pending[action_name] = shortcut
 
-        # Apply immediately to QAction
-        if action_name in self.action_map:
-            self.action_map[action_name].setShortcut(shortcut)
         self.config.set(action_name, shortcut)
+        self._sync_action_shortcuts((action_name,))
 
         # Highlight conflict
         widget = self.table.cellWidget(row, 1)
@@ -105,10 +103,7 @@ class ShortcutsDialog(QDialog):
     def _reset_all(self):
         self.config.reset_all()
         self._pending = dict(self.config.get_all())
-        for name, act in self.action_map.items():
-            sc = self.config.get(name)
-            if sc:
-                act.setShortcut(sc)
+        self._sync_action_shortcuts()
         self._refresh_table()
 
     def _reset_selected(self):
@@ -118,9 +113,16 @@ class ShortcutsDialog(QDialog):
         name = self.table.item(row, 0).data(Qt.UserRole)
         self.config.reset(name)
         self._pending[name] = self.config.get(name)
-        if name in self.action_map:
-            self.action_map[name].setShortcut(self.config.get(name))
+        self._sync_action_shortcuts((name,))
         self._refresh_table()
+
+    def _sync_action_shortcuts(self, action_names=None):
+        names = self.action_map if action_names is None else action_names
+        for name in names:
+            action = self.action_map.get(name)
+            shortcut = self.config.get(name)
+            if action is not None and shortcut is not None:
+                action.setShortcut(shortcut)
 
     def _refresh_table(self):
         self.table.clearContents()
@@ -143,10 +145,7 @@ class ShortcutsDialog(QDialog):
             QMessageBox.warning(self, 'Import failed', str(e))
             return
         self._pending = dict(self.config.get_all())
-        for name, act in self.action_map.items():
-            sc = self.config.get(name)
-            if sc:
-                act.setShortcut(sc)
+        self._sync_action_shortcuts()
         self._refresh_table()
 
     def apply_theme(self, theme):

--- a/tests/core/test_plugin_manager.py
+++ b/tests/core/test_plugin_manager.py
@@ -1,8 +1,12 @@
+from concurrent.futures import CancelledError
+import gc
 import sys
 import threading
 import time
+import weakref
 
-from PyQt5.QtCore import QCoreApplication
+from PyQt5.QtCore import QCoreApplication, QEvent, QObject, QThread
+from PyQt5.QtWidgets import QApplication
 
 from labelimgplusplus.plugins import (
     CommandSpec,
@@ -14,7 +18,7 @@ from libs.core.plugin_discovery import PluginCandidate
 from libs.core.plugin_manager import PluginManager, PluginState
 from libs.core.plugin_registry import validate_json_value
 from libs.core.settings import Settings
-from libs.core.task_coordinator import TaskCoordinator
+from libs.core.task_coordinator import JobHandle, TaskCoordinator
 
 
 def _wait_until(predicate, timeout=2.0):
@@ -319,6 +323,12 @@ def test_document_generation_cancels_and_discards_stale_task(tmp_path):
         handle = plugin.context.tasks.submit(work, on_result=delivered.append)
         manager.publish_document(DocumentDescriptor(generation=1))
         assert handle.is_cancelled()
+        try:
+            handle.check_cancelled()
+        except CancelledError:
+            pass
+        else:
+            raise AssertionError("plugin cancellation did not use CancelledError")
         gate.set()
         assert _wait_until(lambda: coordinator.queue_depths()["background"] == 0)
         assert delivered == []
@@ -378,6 +388,116 @@ def test_immediate_task_progress_is_delivered(tmp_path):
         _shutdown(manager, coordinator)
 
 
+def test_plugin_task_uses_same_plain_restricted_facade_in_worker(tmp_path):
+    worker_handles = []
+    results = []
+    plugin = _Plugin("com.example.facade")
+    _settings, coordinator, manager = _host(
+        tmp_path, [plugin.metadata.id],
+        [_candidate(plugin.metadata.id, lambda: plugin)])
+    try:
+        manager.activate_enabled()
+
+        def work(handle):
+            worker_handles.append(handle)
+            return "done"
+
+        caller_handle = plugin.context.tasks.submit(
+            work, on_result=results.append)
+        assert _wait_until(lambda: results == ["done"])
+        assert worker_handles == [caller_handle]
+        assert not isinstance(caller_handle, (QObject, JobHandle))
+        for name in (
+            "parent",
+            "thread",
+            "job_id",
+            "generation",
+            "key",
+            "result",
+            "error",
+            "progress",
+            "finished",
+            "begin_non_cancellable",
+        ):
+            assert not hasattr(caller_handle, name)
+        assert {
+            name for name in dir(type(caller_handle)) if not name.startswith("_")
+        } == {
+            "cancel", "check_cancelled", "is_cancelled", "report_progress"}
+    finally:
+        _shutdown(manager, coordinator)
+
+
+def test_latest_plugin_task_cancels_and_releases_previous_facade(tmp_path):
+    first_started = threading.Event()
+    first_cancelled = threading.Event()
+    results = []
+    plugin = _Plugin("com.example.latest")
+    _settings, coordinator, manager = _host(
+        tmp_path, [plugin.metadata.id],
+        [_candidate(plugin.metadata.id, lambda: plugin)])
+    try:
+        manager.activate_enabled()
+
+        def first_work(handle):
+            first_started.set()
+            try:
+                while True:
+                    handle.check_cancelled()
+                    time.sleep(0.001)
+            except CancelledError:
+                first_cancelled.set()
+                raise
+
+        first = plugin.context.tasks.submit(
+            first_work, key="scan", latest=True, on_result=results.append)
+        assert first_started.wait(1)
+        second = plugin.context.tasks.submit(
+            lambda handle: "current",
+            key="scan",
+            latest=True,
+            on_result=results.append,
+        )
+        assert first is not second
+        assert _wait_until(lambda: results == ["current"])
+        assert first.is_cancelled()
+        assert first_cancelled.wait(1)
+        assert plugin.context.tasks.handles == ()
+    finally:
+        _shutdown(manager, coordinator)
+
+
+def test_task_failure_preserves_traceback_and_reports_on_gui_thread(tmp_path):
+    errors = []
+    results = []
+    plugin = _Plugin("com.example.task-failure")
+    _settings, coordinator, manager = _host(
+        tmp_path, [plugin.metadata.id],
+        [_candidate(plugin.metadata.id, lambda: plugin)])
+    try:
+        manager.activate_enabled()
+
+        def worker_frame(_handle):
+            raise LookupError("worker exploded")
+
+        plugin.context.tasks.submit(
+            worker_frame,
+            on_result=results.append,
+            on_error=lambda message: errors.append(
+                (message, QThread.currentThread())),
+        )
+        assert _wait_until(lambda: bool(errors))
+        diagnostic = manager.record_for(plugin.metadata.id).diagnostics[-1]
+        assert diagnostic.code == "task_failed"
+        assert diagnostic.message == "worker exploded"
+        assert "LookupError: worker exploded" in diagnostic.details
+        assert "in worker_frame" in diagnostic.details
+        assert errors == [("worker exploded", QApplication.instance().thread())]
+        assert results == []
+    finally:
+        _shutdown(manager, coordinator)
+
+
 def test_shutdown_cancels_live_work_and_releases_task_handles(tmp_path):
     progress_queued = threading.Event()
     unexpected = []
@@ -412,6 +532,129 @@ def test_shutdown_cancels_live_work_and_releases_task_handles(tmp_path):
         coordinator.shutdown()
         QCoreApplication.processEvents()
         sys.excepthook = previous_excepthook
+
+
+def test_retained_plugin_facade_detaches_after_host_shutdown(tmp_path):
+    started = threading.Event()
+    stopped = threading.Event()
+
+    def work(handle):
+        started.set()
+        try:
+            while True:
+                handle.check_cancelled()
+                time.sleep(0.001)
+        except CancelledError:
+            stopped.set()
+            raise
+
+    def run_host():
+        plugin = _Plugin("com.example.retained-facade")
+        _settings, coordinator, manager = _host(
+            tmp_path, [plugin.metadata.id],
+            [_candidate(plugin.metadata.id, lambda: plugin)])
+        manager.activate_enabled()
+        retained = plugin.context.tasks.submit(work)
+        assert started.wait(1)
+        coordinator_handle_ref = weakref.ref(retained._handle_ref())
+        manager.shutdown()
+        coordinator.shutdown()
+        assert stopped.wait(1)
+        assert _wait_until(
+            lambda: coordinator.queue_depths()["background"] == 0)
+        assert retained.is_cancelled()
+        assert retained._handle_ref is None
+        plugin.context = None
+        manager.deleteLater()
+        coordinator.deleteLater()
+        QCoreApplication.sendPostedEvents(None, QEvent.DeferredDelete)
+        return retained, coordinator_handle_ref
+
+    retained, coordinator_handle_ref = run_host()
+    gc.collect()
+    assert retained.is_cancelled()
+    assert coordinator_handle_ref() is None
+
+
+def test_invalid_activation_diagnostic_rolls_back_transaction(tmp_path):
+    def activate(context):
+        context.settings.set("partial", True)
+        context.diagnostics.report("bad", "invalid", severity=None)
+
+    plugin = _Plugin("com.example.invalid-activation-diagnostic", activate)
+    settings, coordinator, manager = _host(
+        tmp_path, [plugin.metadata.id],
+        [_candidate(plugin.metadata.id, lambda: plugin)])
+    try:
+        manager.activate_enabled()
+        record = manager.record_for(plugin.metadata.id)
+        assert record.state == PluginState.FAILED
+        assert settings.get("plugins")["config"] == {}
+        assert record.diagnostics[-1].code == "activation_failed"
+        assert "diagnostic severity must be a string" in (
+            record.diagnostics[-1].details)
+    finally:
+        _shutdown(manager, coordinator)
+
+
+def test_invalid_runtime_diagnostic_becomes_callback_failure(tmp_path):
+    def activate(context):
+        context.commands.register(CommandSpec(
+            id="report",
+            title="Report",
+            callback=lambda: context.diagnostics.report(
+                "runtime", "invalid", severity=None),
+        ))
+
+    plugin = _Plugin("com.example.invalid-runtime-diagnostic", activate)
+    _settings, coordinator, manager = _host(
+        tmp_path, [plugin.metadata.id],
+        [_candidate(plugin.metadata.id, lambda: plugin)])
+    try:
+        manager.activate_enabled()
+        assert not manager.invoke_command(
+            "plugin.com.example.invalid-runtime-diagnostic.report")
+        record = manager.record_for(plugin.metadata.id)
+        assert record.state == PluginState.ACTIVE
+        assert record.diagnostics[-1].code == "command_callback_failed"
+        assert "diagnostic severity must be a string" in (
+            record.diagnostics[-1].details)
+    finally:
+        _shutdown(manager, coordinator)
+
+
+def test_plugin_diagnostic_report_requires_valid_string_fields(tmp_path):
+    plugin = _Plugin("com.example.diagnostic-fields")
+    _settings, coordinator, manager = _host(
+        tmp_path, [plugin.metadata.id],
+        [_candidate(plugin.metadata.id, lambda: plugin)])
+    try:
+        manager.activate_enabled()
+        diagnostics = plugin.context.diagnostics
+        invalid = (
+            ((None, "message", "", "error"), TypeError),
+            (("code", None, "", "error"), TypeError),
+            (("code", "message", None, "error"), TypeError),
+            (("code", "message", "", None), TypeError),
+            (("", "message", "", "error"), ValueError),
+            (("code", "message", "", ""), ValueError),
+        )
+        for arguments, exception_type in invalid:
+            try:
+                diagnostics.report(*arguments)
+            except exception_type:
+                pass
+            else:
+                raise AssertionError(
+                    "invalid diagnostic fields were accepted: %r" % (
+                        arguments,))
+        diagnostics.report("valid", "message", "details", "warning")
+        recorded = manager.record_for(plugin.metadata.id).diagnostics
+        assert len(recorded) == 1
+        assert recorded[0].code == "valid"
+        assert recorded[0].severity == "warning"
+    finally:
+        _shutdown(manager, coordinator)
 
 
 def test_callback_failures_become_diagnostics(tmp_path):

--- a/tests/integration/test_plugin_performance.py
+++ b/tests/integration/test_plugin_performance.py
@@ -1,5 +1,9 @@
+import json
 from importlib.util import module_from_spec, spec_from_file_location
+import os
 from pathlib import Path
+import subprocess
+import sys
 
 
 _PROFILE_PATH = (
@@ -13,3 +17,19 @@ _SPEC.loader.exec_module(_PROFILE)
 def test_plugin_performance_and_teardown_gates():
     result = _PROFILE.profile_plugins(runs=5)
     _PROFILE.assert_budgets(result)
+
+
+def test_plugin_profiler_runs_by_path_outside_repository(tmp_path):
+    environment = os.environ.copy()
+    environment.setdefault("QT_QPA_PLATFORM", "offscreen")
+    completed = subprocess.run(
+        [sys.executable, str(_PROFILE_PATH), "--runs", "1"],
+        cwd=tmp_path,
+        env=environment,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    result = json.loads(completed.stdout)
+    assert result["runs"] == 1
+    assert result["teardown_clean"] is True

--- a/tests/integration/test_plugins.py
+++ b/tests/integration/test_plugins.py
@@ -10,6 +10,7 @@ import labelImgPlusPlus as application_module
 from labelimgplusplus.plugins import (
     CommandSpec,
     PluginCapability,
+    PluginDiagnostic,
     PluginMetadata,
 )
 from libs.core.plugin_discovery import PluginCandidate
@@ -338,6 +339,47 @@ def test_manager_homepage_allows_only_escaped_web_links(tmp_path):
         assert rendered.startswith('<a href="https://')
         assert "&quot;&gt;&lt;script&gt;" in rendered
         assert "<script>" not in rendered
+    finally:
+        dialog.close()
+        manager.shutdown()
+        coordinator.shutdown()
+
+
+def test_manager_renders_malformed_diagnostics_defensively(tmp_path):
+    plugin = _QtPlugin([])
+    settings = Settings()
+    settings.path = str(tmp_path / "settings.json")
+    settings.data = {"plugins": {
+        "enabled": [plugin.metadata.id], "config": {}}}
+    coordinator = TaskCoordinator(logical_cpus=1)
+    manager = PluginManager(
+        settings, coordinator, candidates=[_candidate(lambda: plugin)])
+    manager.activate_enabled()
+    record = manager.record_for(plugin.metadata.id)
+    record.diagnostics.extend([
+        PluginDiagnostic(
+            plugin_id=plugin.metadata.id,
+            phase="runtime",
+            code="missing-severity",
+            message="severity was None",
+            severity=None,
+        ),
+        {
+            "phase": None,
+            "code": "",
+            "message": None,
+            "details": None,
+            "severity": None,
+        },
+        object(),
+    ])
+    dialog = PluginManagerDialog(manager)
+    try:
+        dialog._selection_changed(0, 0, -1, -1)
+        rendered = dialog.diagnostics.toPlainText()
+        assert "[ERROR] runtime/missing-severity: severity was None" in rendered
+        assert "unknown/invalid_diagnostic" in rendered
+        assert "Malformed plugin diagnostic." in rendered
     finally:
         dialog.close()
         manager.shutdown()

--- a/tests/widgets/test_dialogs.py
+++ b/tests/widgets/test_dialogs.py
@@ -1,7 +1,10 @@
 """Tests for dialog widgets (ColorDialog, LabelDialog)."""
+import json
 import os
 import sys
+import tempfile
 import unittest
+from unittest.mock import patch
 
 # Set offscreen platform for headless testing
 if 'QT_QPA_PLATFORM' not in os.environ:
@@ -11,12 +14,11 @@ dir_name = os.path.abspath(os.path.dirname(__file__))
 sys.path.insert(0, os.path.join(dir_name, '..', '..'))
 sys.path.insert(0, os.path.join(dir_name, '..', '..', 'libs'))
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QColor
-from PyQt5.QtWidgets import QApplication, QWidget, QDialogButtonBox
+from PyQt5.QtGui import QColor  # noqa: E402
+from PyQt5.QtWidgets import QAction, QApplication, QWidget  # noqa: E402
 
-from libs.widgets.colorDialog import ColorDialog
-from libs.widgets.labelDialog import LabelDialog
+from libs.widgets.colorDialog import ColorDialog  # noqa: E402
+from libs.widgets.labelDialog import LabelDialog  # noqa: E402
 
 # Create QApplication for tests
 app = QApplication.instance() or QApplication(sys.argv)
@@ -243,6 +245,65 @@ class TestShortcutsDialogTheme(unittest.TestCase):
         fg = dialog.table.item(0, 2).foreground().color()
         expected = hex_to_qcolor(get_theme_colors(Theme.LIGHT)['text_secondary'])
         self.assertEqual(fg, expected)
+
+    def test_reset_all_clears_empty_plugin_shortcut_and_skips_unknown_action(self):
+        from libs.core.shortcut_config import ShortcutConfig
+        from libs.widgets.shortcutsDialog import ShortcutsDialog
+
+        config = ShortcutConfig()
+        command = 'plugin.com.example.empty.run'
+        config.register_plugin(command, '', 'com.example.empty')
+        config.set(command, 'Ctrl+Alt+R')
+        plugin_action = QAction()
+        plugin_action.setShortcut('Ctrl+Alt+R')
+        save_action = QAction()
+        save_action.setShortcut(config.get('save'))
+        unknown_action = QAction()
+        unknown_action.setShortcut('Alt+U')
+        dialog = ShortcutsDialog(config, {
+            command: plugin_action,
+            'save': save_action,
+            'not_a_real_action': unknown_action,
+        })
+
+        dialog._reset_all()
+
+        self.assertEqual(plugin_action.shortcut().toString(), '')
+        self.assertEqual(save_action.shortcut().toString(), config.get('save'))
+        self.assertEqual(unknown_action.shortcut().toString(), 'Alt+U')
+
+    def test_import_applies_empty_shortcut_to_live_plugin_action(self):
+        from libs.core.shortcut_config import ShortcutConfig
+        from libs.widgets.shortcutsDialog import ShortcutsDialog
+
+        config = ShortcutConfig()
+        command = 'plugin.com.example.empty.run'
+        config.register_plugin(command, 'Ctrl+Alt+R', 'com.example.empty')
+        plugin_action = QAction()
+        plugin_action.setShortcut('Ctrl+Alt+R')
+        save_action = QAction()
+        save_action.setShortcut(config.get('save'))
+        unknown_action = QAction()
+        unknown_action.setShortcut('Alt+U')
+        dialog = ShortcutsDialog(config, {
+            command: plugin_action,
+            'save': save_action,
+            'not_a_real_action': unknown_action,
+        })
+        descriptor, path = tempfile.mkstemp(suffix='.json')
+        try:
+            with os.fdopen(descriptor, 'w') as stream:
+                json.dump({command: ''}, stream)
+            with patch(
+                    'libs.widgets.shortcutsDialog.QFileDialog.getOpenFileName',
+                    return_value=(path, 'JSON (*.json)')):
+                dialog._import()
+        finally:
+            os.unlink(path)
+
+        self.assertEqual(plugin_action.shortcut().toString(), '')
+        self.assertEqual(save_action.shortcut().toString(), config.get('save'))
+        self.assertEqual(unknown_action.shortcut().toString(), 'Alt+U')
 
 
 class TestSplitDialogValidation(unittest.TestCase):

--- a/tools/performance/profile_plugins.py
+++ b/tools/performance/profile_plugins.py
@@ -8,33 +8,44 @@ import json
 import math
 import os
 from pathlib import Path
-from types import SimpleNamespace
+import sys
 import tempfile
 import threading
 import time
+from types import SimpleNamespace
 import weakref
+
+
+REPOSITORY_ROOT = os.path.abspath(os.path.join(
+    os.path.dirname(__file__), '..', '..'))
+if REPOSITORY_ROOT not in sys.path:
+    sys.path.insert(0, REPOSITORY_ROOT)
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
-from PyQt5.QtCore import QCoreApplication, QEvent
-from PyQt5.QtWidgets import QApplication, QMainWindow, QMenu
+from PyQt5.QtCore import QCoreApplication, QEvent  # noqa: E402
+from PyQt5.QtWidgets import (  # noqa: E402
+    QApplication,
+    QMainWindow,
+    QMenu,
+)
 
-from labelimgplusplus.plugins import (
+from labelimgplusplus.plugins import (  # noqa: E402
     CommandSpec,
     DocumentDescriptor,
     PluginCapability,
     PluginMetadata,
 )
-from libs.core.plugin_discovery import (
+from libs.core.plugin_discovery import (  # noqa: E402
     ENTRY_POINT_GROUP,
     PluginCandidate,
     discover_plugins,
 )
-from libs.core.plugin_manager import PluginManager
-from libs.core.settings import Settings
-from libs.core.shortcut_config import ShortcutConfig
-from libs.core.task_coordinator import TaskCoordinator
-from libs.widgets.pluginManagerDialog import (
+from libs.core.plugin_manager import PluginManager  # noqa: E402
+from libs.core.settings import Settings  # noqa: E402
+from libs.core.shortcut_config import ShortcutConfig  # noqa: E402
+from libs.core.task_coordinator import TaskCoordinator  # noqa: E402
+from libs.widgets.pluginManagerDialog import (  # noqa: E402
     PluginManagerDialog,
     QtPluginCommandHost,
 )


### PR DESCRIPTION
## Summary

- replace the plugin-visible coordinator `JobHandle` with a plain, weakly attached task facade and preserve worker tracebacks through GUI-thread error delivery
- validate plugin diagnostics transactionally, normalize stored records, and render malformed diagnostics defensively
- synchronize empty shortcut values to live plugin actions after reset/import and make the plugin profiler runnable from any working directory
- document the hardened API-major-1 contracts without changing entry points, settings keys, or `TaskCoordinator` behavior

This is follow-up hardening for #26. It does not change the state or scope of #27 or #28.

## Validation

- plugin compatibility group: `53 passed`
- full ordinary suite: `938 passed, 1 skipped`
- combined SAM/video suite: `130 passed, 1 skipped`
- changed-file Ruff checks and compile checks: passed
- Python 3.8 grammar parse: 183 files passed
- wheel/sdist build, Twine check, content inspection, installed-wheel safe mode: passed
- clean base-only PyInstaller safe-mode boot: passed
- direct five-run plugin profiler: all budgets passed; teardown clean

Repository-wide Ruff still reports the existing legacy baseline outside the changed files. SonarCloud credentials/configuration and its separate existing failure are intentionally not part of this remediation.
