### PR TITLE
release: labelImg++ 3.2.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,66 @@
 History
 =======
 
+3.2.0 (2026-08-11)
+------------------
+
+Workspace release replacing the legacy toolbar-and-dock layout with the
+Balanced modern annotation workspace. Existing annotation formats, filenames,
+command-line entry points, plugin APIs, document methods, shortcut identifiers,
+and Python 3.8 through 3.13 support remain compatible.
+
+Balanced Workspace
+~~~~~~~~~~~~~~~~~~
+
+* Replace the legacy toolbar with a fixed 52-logical-pixel tool rail for
+  Select, Bounding Box, Polygon, Smart Select, and Keypoints. The rail binds
+  directly to the existing authoritative actions, reflects their live enabled
+  and checked states, and always shows configured shortcuts in its tooltips.
+* Add a responsive 44-logical-pixel command bar and compact action-backed
+  canvas controls for zoom, fit modes, 100 percent scale, and annotation
+  visibility.
+* Replace the floating right docks with a fixed, collapsible Objects/Files
+  inspector. Its validated width, selected tab, and collapsed state persist
+  independently while obsolete dock and toolbar settings remain serialized for
+  downgrade compatibility.
+* Embed Empty, Canvas, and Gallery pages in the central workspace. Gallery Mode
+  no longer opens a detached maximized window, and the video timeline now sits
+  directly beneath the canvas instead of in a dock.
+* Add an Empty page with existing recent paths and direct image, folder, and
+  video entry points. Exactly one supported local file or directory can also be
+  opened by drag and drop; rejected drops leave the current document unchanged.
+* Keep the native status bar alive as a hidden compatibility message bus while
+  mirroring saved, dirty, read-only, dimensions, object count, progress,
+  warning, active-tool, shortcut, and zoom state into a slim visible strip.
+
+Unified Annotation Inspector
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Replace the nested Rectangle, Polygon, and Track tabs with one model-backed,
+  searchable object list. Image rows represent canonical canvas shapes; video
+  rows represent stable track identifiers, including tracks absent from the
+  current frame.
+* Synchronize canvas and inspector selection with guarded identity updates and
+  route contextual class, difficult, color, keypoint, span, keyframe, and
+  pending-review edits through undoable model mutations.
+* Keep annotation geometry owned exclusively by the canvas and video model,
+  preserve ``label_list`` as a compatibility alias, and retain legacy pending
+  video observations and their accept/reject workflow.
+
+Visual and Compatibility Qualification
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Vendor only the five required official Feather SVGs and their MIT license in
+  Qt resources; Smart Select now defaults to ``S`` under the existing
+  ``sam_mode`` shortcut identifier.
+* Preserve the hidden legacy status-bar API, settings round-tripping, plugin
+  snapshots, and GUI-thread boundaries while removing all runtime floating
+  docks, detached Gallery windows, nested annotation tabs, and text-under-icon
+  toolbar presentation.
+* Qualify Empty, Image, Gallery, Video, collapsed-inspector, read-only, dark,
+  and true 2x-DPI states at 1366x768 and 1440x900, alongside structural Qt,
+  settings, selection, undo, plugin, SAM, and video coverage.
+
 3.1.0 (2026-08-11)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ polygons, and keypoints, designed for machine learning and computer vision
 projects. It is forked from the original LabelImg with significant
 enhancements.
 
-    **Version 3.1.0 (stable).** Install with
+    **Version 3.2.0 (stable).** Install with
     ``pip install labelimgplusplus``.
 
 .. image:: https://raw.githubusercontent.com/abhiksark/labelImg-plus-plus/c7fbd5fc08a561206b210706143a50023c82a782/resources/demo/demo.gif
@@ -55,9 +55,12 @@ Workflow and Interface
     Full undo/redo for annotation actions. Press **Ctrl+Z** to undo and
     **Ctrl+Shift+Z** to redo.
 
-**Gallery Mode with Annotation Preview**
-    Visual thumbnail gallery showing all images with bounding box and polygon
-    overlays directly on thumbnails across all five annotation formats.
+**Balanced Modern Workspace**
+    A fixed annotation-tool rail, compact command bar, unified Objects/Files
+    inspector, integrated video timeline, and visible document status keep the
+    active canvas uncluttered. Gallery Mode is embedded in the same workspace,
+    so the annotation tools, inspector, and status remain available while
+    browsing thumbnail previews across all five annotation formats.
 
     - Colored borders indicate status: Gray (no labels), Blue (has labels), Green (verified)
     - Bounding boxes use compact corner markers; polygons use outline previews
@@ -66,16 +69,16 @@ Workflow and Interface
     - Press **Ctrl+G** to toggle gallery mode
 
 **Modern UI with Feather Icons**
-    Clean, modern interface with beautiful Feather icons and improved visual design.
+    Official Feather icons provide a consistent, accessible tool vocabulary.
 
 **Responsive DPI Scaling**
     Icons and UI elements scale properly on high-DPI displays (4K, Retina).
 
-**Expandable Toolbar**
-    Click the chevron at the bottom of the toolbar to expand/collapse and show full button labels.
-
-**Consolidated File Menu**
-    Open File, Open Dir, and Change Save Dir combined into a single dropdown for cleaner toolbar.
+**Unified Object Inspector**
+    Search and edit rectangles, polygons, keypoints, and video tracks in one
+    Objects view. The Files view keeps the compact file list, thumbnails, and
+    annotation-status filter close at hand, and the inspector can be collapsed
+    when maximum canvas space is needed.
 
 **Direct Ultralytics Dataset Export**
     Choose **Tools → Export Ultralytics Dataset…** to create a ready-to-train
@@ -346,7 +349,7 @@ Or use **Menu > File > Reset All**
 Release History
 ---------------
 
-This source tree identifies itself as **3.1.0**, the stable 3.1 release. See
+This source tree identifies itself as **3.2.0**, the stable 3.2 release. See
 the `release history
 <https://github.com/abhiksark/labelImg-plus-plus/blob/master/HISTORY.rst>`__ for
 version-by-version changes and `GitHub Releases

--- a/build-tools/README.md
+++ b/build-tools/README.md
@@ -11,8 +11,8 @@ Normal releases are published by the tag workflow. The tag must exactly match
 the package version, point to a commit on ``origin/master``, and be pushed only
 after the release pull request and ``master`` CI pass:
 ```bash
-git tag -a v3.1.0 -m "labelImg++ 3.1.0"
-git push origin v3.1.0
+git tag -a v3.2.0 -m "labelImg++ 3.2.0"
+git push origin v3.2.0
 ```
 
 The workflow tests Python 3.8 through 3.13, tests the optional SAM dependency

--- a/labelimgplusplus.egg-info/PKG-INFO
+++ b/labelimgplusplus.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.1
 Name: labelimgplusplus
-Version: 3.1.0
+Version: 3.2.0
 Summary: labelImg++ is an enhanced graphical image annotation tool with Gallery Mode for browsing and labeling images
 Author-email: Abhik Sarkar <abhiksark@gmail.com>
 License: Copyright (c) <2015-Present> Tzutalin
@@ -78,7 +78,7 @@ polygons, and keypoints, designed for machine learning and computer vision
 projects. It is forked from the original LabelImg with significant
 enhancements.
 
-    **Version 3.1.0 (stable).** Install with
+    **Version 3.2.0 (stable).** Install with
     ``pip install labelimgplusplus``.
 
 .. image:: https://raw.githubusercontent.com/abhiksark/labelImg-plus-plus/c7fbd5fc08a561206b210706143a50023c82a782/resources/demo/demo.gif
@@ -107,9 +107,12 @@ Workflow and Interface
     Full undo/redo for annotation actions. Press **Ctrl+Z** to undo and
     **Ctrl+Shift+Z** to redo.
 
-**Gallery Mode with Annotation Preview**
-    Visual thumbnail gallery showing all images with bounding box and polygon
-    overlays directly on thumbnails across all five annotation formats.
+**Balanced Modern Workspace**
+    A fixed annotation-tool rail, compact command bar, unified Objects/Files
+    inspector, integrated video timeline, and visible document status keep the
+    active canvas uncluttered. Gallery Mode is embedded in the same workspace,
+    so the annotation tools, inspector, and status remain available while
+    browsing thumbnail previews across all five annotation formats.
 
     - Colored borders indicate status: Gray (no labels), Blue (has labels), Green (verified)
     - Bounding boxes use compact corner markers; polygons use outline previews
@@ -118,16 +121,16 @@ Workflow and Interface
     - Press **Ctrl+G** to toggle gallery mode
 
 **Modern UI with Feather Icons**
-    Clean, modern interface with beautiful Feather icons and improved visual design.
+    Official Feather icons provide a consistent, accessible tool vocabulary.
 
 **Responsive DPI Scaling**
     Icons and UI elements scale properly on high-DPI displays (4K, Retina).
 
-**Expandable Toolbar**
-    Click the chevron at the bottom of the toolbar to expand/collapse and show full button labels.
-
-**Consolidated File Menu**
-    Open File, Open Dir, and Change Save Dir combined into a single dropdown for cleaner toolbar.
+**Unified Object Inspector**
+    Search and edit rectangles, polygons, keypoints, and video tracks in one
+    Objects view. The Files view keeps the compact file list, thumbnails, and
+    annotation-status filter close at hand, and the inspector can be collapsed
+    when maximum canvas space is needed.
 
 **Direct Ultralytics Dataset Export**
     Choose **Tools → Export Ultralytics Dataset…** to create a ready-to-train
@@ -398,7 +401,7 @@ Or use **Menu > File > Reset All**
 Release History
 ---------------
 
-This source tree identifies itself as **3.1.0**, the stable 3.1 release. See
+This source tree identifies itself as **3.2.0**, the stable 3.2 release. See
 the `release history
 <https://github.com/abhiksark/labelImg-plus-plus/blob/master/HISTORY.rst>`__ for
 version-by-version changes and `GitHub Releases

--- a/libs/__init__.py
+++ b/libs/__init__.py
@@ -1,7 +1,7 @@
 # libs/__init__.py
 """LabelImg++ library package."""
 
-__version__ = '3.1.0'
+__version__ = '3.2.0'
 __version_info__ = tuple(__version__.split('.'))
 
 # Re-export subpackages for convenient access

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "labelimgplusplus"
-version = "3.1.0"
+version = "3.2.0"
 description = "labelImg++ is an enhanced graphical image annotation tool with Gallery Mode for browsing and labeling images"
 readme = "README.rst"
 license = {file = "LICENSE"}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.1.0
+current_version = 3.2.0
 commit = True
 tag = True
 


### PR DESCRIPTION
## Summary

Prepare the qualified Balanced workspace line for labelImg++ 3.2.0.

- synchronize package, runtime, bumpversion, tracked metadata, and release instructions at 3.2.0
- document the fixed tool rail, responsive command bar, unified Objects/Files inspector, embedded Gallery, integrated timeline, and visible status strip
- record compatibility guarantees and the fixed-resolution/light/dark/high-DPI qualification matrix
- remove README guidance for the retired expandable legacy toolbar presentation

## Compatibility

- Python 3.8 through 3.13 remain supported
- annotation formats, filenames, CLI entry points, plugin API major, document methods, shortcut IDs, and legacy pending video observations remain compatible
- `[sam]` and `[video]` remain independently optional
- obsolete toolbar/dock settings remain serialized for downgrade round-tripping

## Local verification

- final feature suite: 977 passed, 1 skipped
- focused release/workspace checks: 20 passed
- release-version consistency: passed
- Python 3.8 AST parsing, compileall, Qt resource verification, and `git diff --check`: passed
- wheel and sdist build plus `twine check`: passed
- clean wheel install, 3.2.0 metadata, all three CLI entry points, and runtime package contents: passed
- isolated base-only PyInstaller executable boot: passed

## Promotion gates

- squash-merge this PR to `dev` only after all required CI passes
- fast-forward `master` to that exact tested `dev` commit and wait for `master` CI
- create `v3.2.0` on that exact `master` commit
- require the tag workflow to test and publish the exact distributions before creating the GitHub Release