### PR TITLE
fix: ignore queued catalog refreshes after shutdown

### DIFF
--- a/labelImgPlusPlus.py
+++ b/labelImgPlusPlus.py
@@ -2373,13 +2373,17 @@ class MainWindow(QMainWindow, WindowMixin):
         return None
 
     def _ensure_annotation_catalog(self):
+        coordinator = getattr(self, 'task_coordinator', None)
+        if coordinator is None or coordinator.is_shutting_down:
+            return False
         snapshot = getattr(self, 'dataset_snapshot', None)
         if snapshot is None or not snapshot.image_paths:
-            return
+            return False
         if (self.annotation_catalog.snapshot is not snapshot
                 or (not self.annotation_catalog.entries
                     and self.annotation_catalog._handle is None)):
             self.annotation_catalog.start(snapshot)
+        return True
 
     def _on_catalog_batch(self, statuses):
         converted = {
@@ -6586,7 +6590,11 @@ class MainWindow(QMainWindow, WindowMixin):
     # Statistics methods (Issue #19) - Stats shown in gallery mode
     def _refresh_all_statistics(self):
         """Complete label data in the shared catalog, then aggregate it."""
-        self._ensure_annotation_catalog()
+        # A refresh may already be queued when closeEvent shuts the worker
+        # lanes down. Submitting from that late Qt callback raises inside a
+        # slot and aborts the process, so closed windows must be inert.
+        if not self._ensure_annotation_catalog():
+            return
         self.annotation_catalog.request_statistics()
 
     def _update_current_image_stats(self):

--- a/tests/integration/test_async_workflows.py
+++ b/tests/integration/test_async_workflows.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')
 
-from PyQt5.QtCore import QThread
+from PyQt5.QtCore import QThread, QTimer
 from PyQt5.QtGui import QImage, QPixmap
 from PyQt5.QtWidgets import QMessageBox
 
@@ -124,6 +124,23 @@ def test_failed_standalone_open_restores_snapshot_generation(tmp_path):
     finally:
         window.dirty = False
         window.close()
+
+
+def test_queued_statistics_refresh_is_inert_after_window_shutdown(tmp_path):
+    app, window = get_main_app()
+    image_path = str(tmp_path / 'image.png')
+    _image(image_path, 0xFFFFFFFF)
+    window.import_dir_images(str(tmp_path))
+    window.dirty = False
+    window.close()
+
+    # Reproduce the delayed Gallery refresh that can outlive closeEvent. An
+    # exception escaping this PyQt slot aborts the interpreter instead of
+    # becoming an ordinary assertion failure.
+    QTimer.singleShot(0, window._refresh_all_statistics)
+    app.processEvents()
+    app.processEvents()
+    assert window.task_coordinator.is_shutting_down
 
 
 def test_cancelled_standalone_open_does_not_advance_generation(tmp_path):


### PR DESCRIPTION
## Summary
- make annotation-catalog startup inert once the window task coordinator begins shutdown
- prevent queued Gallery status/statistics callbacks from submitting jobs after close
- add an explicit regression for a delayed statistics refresh delivered after `closeEvent`

## Root cause
A queued Gallery refresh could outlive its window. The callback called `TaskCoordinator.submit()` after shutdown, and the exception escaped a PyQt slot, aborting the Python process instead of appearing as a normal test failure.

## Verification
- changed-file Ruff and `git diff --check`
- `17 passed` focused async-workflow suite
- `51 passed` across three duplicate ordered async-workflow runs in one process
- `1000 passed, 1 skipped` full ordinary suite