### PR TITLE
release: labelImg++ 3.3.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,56 @@
 History
 =======
 
+3.3.0 (2026-08-12)
+------------------
+
+Faster-annotation release adding non-modal class confirmation and selectable
+Smart Select geometry while preserving the 3.2 workspace, annotation formats,
+filenames, command-line entry points, plugin APIs, shortcut identifiers, and
+Python 3.8 through 3.13 support.
+
+Inline Class Confirmation
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Keep completed Box, Polygon, Smart Select, and video geometry in a transient
+  provisional layer until its class is confirmed. Provisional geometry is
+  excluded from canonical canvas shapes, the Objects inspector, dirty state,
+  saves, plugin snapshots, and undo history.
+* Open a non-modal, screen-clamped class picker beside new geometry with
+  filtering, arrow-key navigation, valid new-class entry, Enter confirmation,
+  and Escape cancellation. Confirmation preserves the active tool and canvas
+  focus so repeated annotation remains uninterrupted.
+* Commit confirmed image or video geometry through one ``CreateShapeCommand``.
+  Video confirmation creates an accepted manual anchor; cancellation leaves
+  both the in-memory model and durable project unchanged.
+* Retain session-only last-class memory. Default-label mode bypasses the picker,
+  while single-class mode bypasses it only after the first class is confirmed
+  in the current session.
+
+Smart Select Output Modes
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Add the frozen plain-data ``SamResult(polygon, bounds)`` contract. SAM workers
+  return a simplified polygon and tight, non-zero, half-open bounds for the
+  same largest mask component without mutating Qt or document state.
+* Add a contextual Box/Polygon selector that appears only while Smart Select is
+  active. Its validated ``sam/outputMode`` setting defaults to ``polygon`` and
+  persists independently of model settings.
+* Route both output types through the provisional picker and the same image and
+  video undo path. Existing stale-generation and cancellation guards remain in
+  place, and ONNX Runtime, NumPy, OpenCV, and model loading stay lazy.
+
+Qualification
+~~~~~~~~~~~~~
+
+* Cover image and video confirmation, cancellation, focus, filtering, repeated
+  annotation, bypass modes, output bounds, simplification, persistence, stale
+  SAM results, manual video anchors, and one-step undo.
+* Qualify the picker and Smart Select selector in light and dark themes at 1x
+  and true 2x DPI using 1366x768 and 1440x900 logical approval sizes.
+* Make queued Gallery and annotation-catalog refreshes inert after window
+  shutdown so late Qt callbacks cannot submit work to a stopped coordinator.
+
 3.2.0 (2026-08-11)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ polygons, and keypoints, designed for machine learning and computer vision
 projects. It is forked from the original LabelImg with significant
 enhancements.
 
-    **Version 3.2.0 (stable).** Install with
+    **Version 3.3.0 (stable).** Install with
     ``pip install labelimgplusplus``.
 
 .. image:: https://raw.githubusercontent.com/abhiksark/labelImg-plus-plus/c7fbd5fc08a561206b210706143a50023c82a782/resources/demo/demo.gif
@@ -79,6 +79,18 @@ Workflow and Interface
     Objects view. The Files view keeps the compact file list, thumbnails, and
     annotation-status filter close at hand, and the inspector can be collapsed
     when maximum canvas space is needed.
+
+**Faster Class Confirmation**
+    New boxes, polygons, Smart Select results, and video geometry remain
+    provisional while a non-modal class picker opens beside the annotation.
+    Filter or enter a class, press **Enter** to commit one undoable annotation,
+    or press **Escape** to discard it without changing the document. Default
+    labels and established single-class sessions bypass the picker.
+
+**Smart Select Output Modes**
+    While Smart Select is active, choose **Box** or **Polygon** from the compact
+    canvas control. The choice persists between sessions, and either result
+    follows the same provisional class-confirmation and undo workflow.
 
 **Direct Ultralytics Dataset Export**
     Choose **Tools → Export Ultralytics Dataset…** to create a ready-to-train
@@ -349,7 +361,7 @@ Or use **Menu > File > Reset All**
 Release History
 ---------------
 
-This source tree identifies itself as **3.2.0**, the stable 3.2 release. See
+This source tree identifies itself as **3.3.0**, the stable 3.3 release. See
 the `release history
 <https://github.com/abhiksark/labelImg-plus-plus/blob/master/HISTORY.rst>`__ for
 version-by-version changes and `GitHub Releases

--- a/build-tools/README.md
+++ b/build-tools/README.md
@@ -11,8 +11,8 @@ Normal releases are published by the tag workflow. The tag must exactly match
 the package version, point to a commit on ``origin/master``, and be pushed only
 after the release pull request and ``master`` CI pass:
 ```bash
-git tag -a v3.2.0 -m "labelImg++ 3.2.0"
-git push origin v3.2.0
+git tag -a v3.3.0 -m "labelImg++ 3.3.0"
+git push origin v3.3.0
 ```
 
 The workflow tests Python 3.8 through 3.13, tests the optional SAM dependency

--- a/labelimgplusplus.egg-info/PKG-INFO
+++ b/labelimgplusplus.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.1
 Name: labelimgplusplus
-Version: 3.2.0
+Version: 3.3.0
 Summary: labelImg++ is an enhanced graphical image annotation tool with Gallery Mode for browsing and labeling images
 Author-email: Abhik Sarkar <abhiksark@gmail.com>
 License: Copyright (c) <2015-Present> Tzutalin
@@ -78,7 +78,7 @@ polygons, and keypoints, designed for machine learning and computer vision
 projects. It is forked from the original LabelImg with significant
 enhancements.
 
-    **Version 3.2.0 (stable).** Install with
+    **Version 3.3.0 (stable).** Install with
     ``pip install labelimgplusplus``.
 
 .. image:: https://raw.githubusercontent.com/abhiksark/labelImg-plus-plus/c7fbd5fc08a561206b210706143a50023c82a782/resources/demo/demo.gif
@@ -131,6 +131,18 @@ Workflow and Interface
     Objects view. The Files view keeps the compact file list, thumbnails, and
     annotation-status filter close at hand, and the inspector can be collapsed
     when maximum canvas space is needed.
+
+**Faster Class Confirmation**
+    New boxes, polygons, Smart Select results, and video geometry remain
+    provisional while a non-modal class picker opens beside the annotation.
+    Filter or enter a class, press **Enter** to commit one undoable annotation,
+    or press **Escape** to discard it without changing the document. Default
+    labels and established single-class sessions bypass the picker.
+
+**Smart Select Output Modes**
+    While Smart Select is active, choose **Box** or **Polygon** from the compact
+    canvas control. The choice persists between sessions, and either result
+    follows the same provisional class-confirmation and undo workflow.
 
 **Direct Ultralytics Dataset Export**
     Choose **Tools → Export Ultralytics Dataset…** to create a ready-to-train
@@ -401,7 +413,7 @@ Or use **Menu > File > Reset All**
 Release History
 ---------------
 
-This source tree identifies itself as **3.2.0**, the stable 3.2 release. See
+This source tree identifies itself as **3.3.0**, the stable 3.3 release. See
 the `release history
 <https://github.com/abhiksark/labelImg-plus-plus/blob/master/HISTORY.rst>`__ for
 version-by-version changes and `GitHub Releases

--- a/libs/__init__.py
+++ b/libs/__init__.py
@@ -1,7 +1,7 @@
 # libs/__init__.py
 """LabelImg++ library package."""
 
-__version__ = '3.2.0'
+__version__ = '3.3.0'
 __version_info__ = tuple(__version__.split('.'))
 
 # Re-export subpackages for convenient access

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "labelimgplusplus"
-version = "3.2.0"
+version = "3.3.0"
 description = "labelImg++ is an enhanced graphical image annotation tool with Gallery Mode for browsing and labeling images"
 readme = "README.rst"
 license = {file = "LICENSE"}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.2.0
+current_version = 3.3.0
 commit = True
 tag = True
 


### PR DESCRIPTION
## Summary

Prepare the 3.3.0 faster-annotation release after the inline class picker, selectable Smart Select geometry, shutdown hardening, and embedded Feather license passed qualification.

## Release gates

- full local suite: 1000 passed, 1 skipped
- plugin suite: 53 passed
- combined SAM/video suite: 140 passed, 1 skipped
- Python 3.8 AST parsing and compileall
- changed-file Ruff and `git diff --check`
- wheel/sdist build and Twine validation
- clean wheel metadata, feature-content, compiled-license, and optional-import checks
- clean installed boot for `labelimgpp`, `labelimgplusplus`, and `labelImgPlusPlus`
- prerequisite resource CI: 24 required jobs passed across Python 3.8–3.13 and platform smokes