### PR TITLE
feat(video): add propagation contracts and gap-aware schema v2

### DIFF
--- a/labelImgPlusPlus.py
+++ b/labelImgPlusPlus.py
@@ -246,6 +246,7 @@ class MainWindow(QMainWindow, WindowMixin):
         self.video_observations = ()
         self.video_frame_states = ()
         self.video_classes = ()
+        self.video_gaps = ()
         self.video_model = None
         self._selected_video_track_id = None
         self._video_open_request_id = 0
@@ -3287,10 +3288,12 @@ class MainWindow(QMainWindow, WindowMixin):
         self.video_observations = prepared.observations
         self.video_frame_states = prepared.frame_states
         self.video_classes = prepared.classes
+        self.video_gaps = prepared.gaps
         self.video_model = VideoProjectModel(
             snapshot.revision, tracks=prepared.tracks,
             observations=prepared.observations,
-            frame_states=prepared.frame_states, classes=prepared.classes)
+            frame_states=prepared.frame_states, classes=prepared.classes,
+            gaps=prepared.gaps)
         self._document_revision = snapshot.revision
         self.m_img_list = []
         self._path_to_idx = {}
@@ -3357,7 +3360,11 @@ class MainWindow(QMainWindow, WindowMixin):
             '%s %s%s' % (__appname__, snapshot.source_path, suffix))
         self.update_status_bar()
         self.canvas.setFocus(True)
-        self.status('Opened video %s' % os.path.basename(snapshot.source_path))
+        if prepared.warning:
+            self.status(prepared.warning, delay=15000)
+        else:
+            self.status(
+                'Opened video %s' % os.path.basename(snapshot.source_path))
         self._plugin_document_ready = True
         self._publish_plugin_document(new_generation=True, force=True)
 
@@ -3511,6 +3518,7 @@ class MainWindow(QMainWindow, WindowMixin):
         self.video_observations = tuple(model.observations.values())
         self.video_frame_states = tuple(model.frame_states.values())
         self.video_classes = tuple(model.classes)
+        self.video_gaps = tuple(model.gaps.values())
 
     def _on_video_model_mutation(self):
         if not self._ensure_video_editable():
@@ -4084,6 +4092,7 @@ class MainWindow(QMainWindow, WindowMixin):
             image_format=values['image_format'],
             jpeg_quality=values['jpeg_quality'],
             class_order=state.classes,
+            gaps=state.gaps,
             range_start_pts=range_start_pts,
             range_end_pts=range_end_pts,
             sample_every_frames=sample_every_frames)

--- a/labelimgplusplus.egg-info/SOURCES.txt
+++ b/labelimgplusplus.egg-info/SOURCES.txt
@@ -40,6 +40,7 @@ libs/core/video_decoder.py
 libs/core/video_export.py
 libs/core/video_model.py
 libs/core/video_project.py
+libs/core/video_propagation.py
 libs/core/video_session.py
 libs/core/video_tracking.py
 libs/core/video_types.py

--- a/libs/__init__.py
+++ b/libs/__init__.py
@@ -1,11 +1,18 @@
 # libs/__init__.py
 """LabelImg++ library package."""
 
+import importlib
+
 __version__ = '3.3.0'
 __version_info__ = tuple(__version__.split('.'))
 
-# Re-export subpackages for convenient access
-from libs import core as core
-from libs import formats as formats
-from libs import utils as utils
-from libs import widgets as widgets
+__all__ = ['core', 'formats', 'utils', 'widgets']
+
+
+def __getattr__(name):
+    """Retain convenient subpackage access without eager Qt imports."""
+    if name not in __all__:
+        raise AttributeError(name)
+    module = importlib.import_module('libs.' + name)
+    globals()[name] = module
+    return module

--- a/libs/core/__init__.py
+++ b/libs/core/__init__.py
@@ -1,12 +1,33 @@
 # libs/core/__init__.py
 """Core data structures and logic."""
 
-from libs.core.shape import Shape, DEFAULT_LINE_COLOR, DEFAULT_FILL_COLOR
-from libs.core.commands import UndoStack, CreateShapeCommand, DeleteShapeCommand, MoveShapeCommand, EditLabelCommand
-from libs.core.settings import Settings
+import importlib
 
 __all__ = [
     'Shape', 'DEFAULT_LINE_COLOR', 'DEFAULT_FILL_COLOR',
     'UndoStack', 'CreateShapeCommand', 'DeleteShapeCommand', 'MoveShapeCommand', 'EditLabelCommand',
     'Settings',
 ]
+
+_EXPORTS = {
+    'Shape': ('libs.core.shape', 'Shape'),
+    'DEFAULT_LINE_COLOR': ('libs.core.shape', 'DEFAULT_LINE_COLOR'),
+    'DEFAULT_FILL_COLOR': ('libs.core.shape', 'DEFAULT_FILL_COLOR'),
+    'UndoStack': ('libs.core.commands', 'UndoStack'),
+    'CreateShapeCommand': ('libs.core.commands', 'CreateShapeCommand'),
+    'DeleteShapeCommand': ('libs.core.commands', 'DeleteShapeCommand'),
+    'MoveShapeCommand': ('libs.core.commands', 'MoveShapeCommand'),
+    'EditLabelCommand': ('libs.core.commands', 'EditLabelCommand'),
+    'Settings': ('libs.core.settings', 'Settings'),
+}
+
+
+def __getattr__(name):
+    """Preserve public exports while plain-data modules remain Qt-free."""
+    try:
+        module_name, attribute = _EXPORTS[name]
+    except KeyError:
+        raise AttributeError(name)
+    value = getattr(importlib.import_module(module_name), attribute)
+    globals()[name] = value
+    return value

--- a/libs/core/video_decoder.py
+++ b/libs/core/video_decoder.py
@@ -124,6 +124,8 @@ class PreparedVideoOpen:
     observations: tuple
     frame_states: tuple
     classes: tuple
+    gaps: tuple = ()
+    warning: object = None
 
 
 class VideoDecoderSession:

--- a/libs/core/video_export.py
+++ b/libs/core/video_export.py
@@ -192,7 +192,8 @@ def export_video_frames(request, handle):
             observations=tuple(
                 item for item in request.observations
                 if item.review_state == 'accepted'),
-            frame_states=request.frame_states, classes=request.class_order)
+            frame_states=request.frame_states, classes=request.class_order,
+            gaps=request.gaps)
         class_order = list(request.class_order)
         for track in request.tracks:
             if track.label not in class_order:

--- a/libs/core/video_model.py
+++ b/libs/core/video_model.py
@@ -4,7 +4,8 @@ from dataclasses import dataclass, replace
 import uuid
 
 from libs.core.video_types import (
-    FrameStateRecord, ObservationRecord, TrackRecord, VideoSaveRequest,
+    FrameStateRecord, ObservationRecord, TrackGapRecord, TrackRecord,
+    VideoSaveRequest,
 )
 
 
@@ -21,6 +22,7 @@ class VideoModelState:
     observations: tuple
     frame_states: tuple
     classes: tuple
+    gaps: tuple = ()
 
 
 def _interpolate_keypoints(left, right, ratio):
@@ -67,18 +69,23 @@ class VideoProjectModel:
     """Mutable only on the GUI thread; workers receive immutable deltas."""
 
     def __init__(self, revision=0, tracks=(), observations=(),
-                 frame_states=(), classes=()):
+                 frame_states=(), classes=(), gaps=()):
         self.durable_revision = int(revision)
         self.revision = int(revision)
         self.tracks = {item.track_id: item for item in tracks}
         self.observations = {
             (item.track_id, int(item.pts)): item for item in observations}
         self.frame_states = {int(item.pts): item for item in frame_states}
+        self.gaps = {
+            (item.track_id, int(item.start_pts), int(item.end_pts)): item
+            for item in gaps}
         self.classes = list(classes)
         self._changed_tracks = {}
         self._changed_observations = {}
         self._changed_frames = {}
+        self._changed_gaps = {}
         self._deleted_observations = {}
+        self._deleted_gaps = {}
         self._deleted_tracks = {}
         self._classes_changed_revision = None
 
@@ -93,13 +100,16 @@ class VideoProjectModel:
                          key=lambda item: (item.pts, item.track_id))),
             tuple(sorted(self.frame_states.values(),
                          key=lambda item: item.pts)),
-            tuple(self.classes))
+            tuple(self.classes),
+            tuple(sorted(self.gaps.values(), key=lambda item: (
+                item.start_pts, item.end_pts, item.track_id))))
 
     def restore_state(self, state):
         self._advance()
         revision = self.revision
         old_track_ids = set(self.tracks)
         old_observation_keys = set(self.observations)
+        old_gap_keys = set(self.gaps)
         self.tracks = {
             item.track_id: replace(item, revision=revision)
             for item in state.tracks}
@@ -109,14 +119,21 @@ class VideoProjectModel:
         self.frame_states = {
             item.pts: replace(item, revision=revision)
             for item in state.frame_states}
+        self.gaps = {
+            (item.track_id, item.start_pts, item.end_pts): replace(
+                item, revision=revision)
+            for item in getattr(state, 'gaps', ())}
         self.classes = list(state.classes)
         self._changed_tracks.update(self.tracks)
         self._changed_observations.update(self.observations)
         self._changed_frames.update(self.frame_states)
+        self._changed_gaps.update(self.gaps)
         for track_id in old_track_ids - set(self.tracks):
             self._deleted_tracks[track_id] = revision
         for key in old_observation_keys - set(self.observations):
             self._deleted_observations[key] = revision
+        for key in old_gap_keys - set(self.gaps):
+            self._deleted_gaps[key] = revision
         self._classes_changed_revision = revision
 
     def _advance(self):
@@ -198,6 +215,40 @@ class VideoProjectModel:
         self._deleted_observations.pop(key, None)
         return value
 
+    def upsert_gap(self, gap):
+        if not isinstance(gap, TrackGapRecord):
+            raise TypeError('gap must be a TrackGapRecord')
+        if int(gap.end_pts) < int(gap.start_pts):
+            raise ValueError('gap end_pts must be greater than or equal to start_pts')
+        if gap.track_id not in self.tracks:
+            raise KeyError(gap.track_id)
+        revision = self._advance()
+        key = (gap.track_id, int(gap.start_pts), int(gap.end_pts))
+        value = replace(
+            gap, start_pts=key[1], end_pts=key[2], revision=revision)
+        self.gaps[key] = value
+        self._changed_gaps[key] = value
+        self._deleted_gaps.pop(key, None)
+        track = replace(self.tracks[gap.track_id], revision=revision)
+        self.tracks[gap.track_id] = track
+        self._changed_tracks[gap.track_id] = track
+        return value
+
+    def delete_gap(self, track_id, start_pts, end_pts):
+        key = (track_id, int(start_pts), int(end_pts))
+        if key not in self.gaps:
+            return False
+        revision = self._advance()
+        del self.gaps[key]
+        self._changed_gaps.pop(key, None)
+        self._deleted_gaps[key] = revision
+        track = self.tracks.get(track_id)
+        if track is not None:
+            track = replace(track, revision=revision)
+            self.tracks[track_id] = track
+            self._changed_tracks[track_id] = track
+        return True
+
     def review(self, track_id, pts, review_state):
         if review_state not in ('accepted', 'pending', 'rejected'):
             raise ValueError('invalid review state: %s' % review_state)
@@ -248,6 +299,11 @@ class VideoProjectModel:
                 del self.observations[key]
                 self._changed_observations.pop(key, None)
                 self._deleted_observations[key] = revision
+        for key in tuple(self.gaps):
+            if key[0] == track_id:
+                del self.gaps[key]
+                self._changed_gaps.pop(key, None)
+                self._deleted_gaps[key] = revision
 
     def set_frame_verified(self, pts, verified):
         revision = self._advance()
@@ -267,6 +323,10 @@ class VideoProjectModel:
             render = ('pending' if exact.review_state == 'pending'
                       else 'exact')
             return MaterializedTrack(track, exact, render)
+        if any(item.track_id == track_id
+               and item.start_pts <= int(pts) <= item.end_pts
+               for item in self.gaps.values()):
+            return None
         if track.shape_type != 'rectangle':
             return None
         anchors = sorted(
@@ -303,15 +363,23 @@ class VideoProjectModel:
         frames = tuple(
             value for value in self._changed_frames.values()
             if value.revision <= target)
+        gaps = tuple(
+            value for value in self._changed_gaps.values()
+            if value.revision <= target)
         deleted_observations = tuple(
             key for key, revision in self._deleted_observations.items()
             if revision <= target)
         deleted_tracks = tuple(
             key for key, revision in self._deleted_tracks.items()
             if revision <= target)
+        deleted_gaps = tuple(
+            key for key, revision in self._deleted_gaps.items()
+            if revision <= target)
         touched = set(item.track_id for item in observations)
         touched.update(item.track_id for item in tracks)
         touched.update(key[0] for key in deleted_observations)
+        touched.update(item.track_id for item in gaps)
+        touched.update(key[0] for key in deleted_gaps)
         classes = (tuple(self.classes)
                    if self._classes_changed_revision is not None
                    and self._classes_changed_revision <= target else ())
@@ -320,7 +388,8 @@ class VideoProjectModel:
             tracks=tracks, observations=observations,
             deleted_observations=deleted_observations,
             deleted_tracks=deleted_tracks, frame_states=frames,
-            classes=classes, touched_tracks=tuple(sorted(touched)))
+            classes=classes, touched_tracks=tuple(sorted(touched)),
+            gaps=gaps, deleted_gaps=deleted_gaps)
 
     def mark_saved(self, target_revision):
         target_revision = int(target_revision)
@@ -334,11 +403,17 @@ class VideoProjectModel:
         self._changed_frames = {
             key: value for key, value in self._changed_frames.items()
             if value.revision > target_revision}
+        self._changed_gaps = {
+            key: value for key, value in self._changed_gaps.items()
+            if value.revision > target_revision}
         self._deleted_observations = {
             key: value for key, value in self._deleted_observations.items()
             if value > target_revision}
         self._deleted_tracks = {
             key: value for key, value in self._deleted_tracks.items()
+            if value > target_revision}
+        self._deleted_gaps = {
+            key: value for key, value in self._deleted_gaps.items()
             if value > target_revision}
         if (self._classes_changed_revision is not None
                 and self._classes_changed_revision <= target_revision):

--- a/libs/core/video_project.py
+++ b/libs/core/video_project.py
@@ -8,13 +8,15 @@ import shutil
 import sqlite3
 
 from libs.core.video_types import (
-    FrameStateRecord, ObservationRecord, TrackRecord, VideoFingerprint,
+    FrameStateRecord, ObservationRecord, TrackGapRecord, TrackRecord,
+    VideoFingerprint,
 )
 
 
 PROJECT_SUFFIX = '.labelimgpp.sqlite'
 APPLICATION_ID = 0x4C495050  # ASCII-ish "LIPP", stored in SQLite's header.
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
+LEGACY_SCHEMA_VERSION = 1
 SAMPLE_BYTES = 1024 * 1024
 
 
@@ -49,6 +51,9 @@ class ProjectContents:
     observations: tuple
     frame_states: tuple
     classes: tuple
+    gaps: tuple = ()
+    read_only: bool = False
+    warning: object = None
 
 
 @dataclass(frozen=True)
@@ -90,6 +95,14 @@ def _connect(path):
     return connection
 
 
+def _connect_read_only(path):
+    uri = 'file:%s?mode=ro' % os.path.abspath(path)
+    connection = sqlite3.connect(uri, uri=True, timeout=5.0)
+    connection.execute('PRAGMA foreign_keys=ON')
+    connection.execute('PRAGMA busy_timeout=5000')
+    return connection
+
+
 def _validate_existing(path):
     uri = 'file:%s?mode=ro' % os.path.abspath(path)
     connection = sqlite3.connect(uri, uri=True, timeout=5.0)
@@ -107,9 +120,52 @@ def _validate_existing(path):
         raise NewerSchemaError(
             'project schema %s is newer than supported schema %s' %
             (version, SCHEMA_VERSION))
-    if version != SCHEMA_VERSION:
+    if version not in (LEGACY_SCHEMA_VERSION, SCHEMA_VERSION):
         raise UnknownProjectError(
             'unsupported LabelImg++ video project schema %s' % version)
+    return int(version)
+
+
+def _require_current_schema(path):
+    version = _validate_existing(path)
+    if version != SCHEMA_VERSION:
+        raise UnknownProjectError(
+            'LabelImg++ video project schema %s is read-only; expected %s' %
+            (version, SCHEMA_VERSION))
+    return version
+
+
+def _track_gaps_schema_sql():
+    return """
+    CREATE TABLE track_gaps (
+        track_id TEXT NOT NULL REFERENCES tracks(track_id) ON DELETE CASCADE,
+        start_pts INTEGER NOT NULL,
+        end_pts INTEGER NOT NULL CHECK (end_pts >= start_pts),
+        reason TEXT NOT NULL CHECK (length(reason) > 0),
+        backend TEXT NOT NULL CHECK (length(backend) > 0),
+        revision INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (track_id, start_pts, end_pts)
+    );
+    CREATE INDEX track_gaps_pts_idx ON track_gaps(start_pts, end_pts);
+    """
+
+
+def _create_track_gaps_schema(connection):
+    connection.execute("""
+        CREATE TABLE track_gaps (
+            track_id TEXT NOT NULL
+                REFERENCES tracks(track_id) ON DELETE CASCADE,
+            start_pts INTEGER NOT NULL,
+            end_pts INTEGER NOT NULL CHECK (end_pts >= start_pts),
+            reason TEXT NOT NULL CHECK (length(reason) > 0),
+            backend TEXT NOT NULL CHECK (length(backend) > 0),
+            revision INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (track_id, start_pts, end_pts)
+        )
+    """)
+    connection.execute(
+        'CREATE INDEX track_gaps_pts_idx '
+        'ON track_gaps(start_pts, end_pts)')
 
 
 def _schema_sql():
@@ -172,14 +228,39 @@ def _schema_sql():
         verified INTEGER NOT NULL DEFAULT 0 CHECK (verified IN (0, 1)),
         revision INTEGER NOT NULL DEFAULT 0
     );
+    %s
     CREATE INDEX observations_pts_idx ON observations(pts);
     CREATE INDEX observations_review_idx
         ON observations(review_state, pts);
-    """
+    """ % _track_gaps_schema_sql()
+
+
+def _migrate_v1_to_v2(path):
+    """Upgrade one writable v1 project without a partial schema state."""
+    connection = _connect(path)
+    try:
+        connection.execute('BEGIN IMMEDIATE')
+        version = int(connection.execute(
+            'PRAGMA user_version').fetchone()[0])
+        if version != LEGACY_SCHEMA_VERSION:
+            raise UnknownProjectError(
+                'expected schema %s for migration, found %s' %
+                (LEGACY_SCHEMA_VERSION, version))
+        _create_track_gaps_schema(connection)
+        connection.execute(
+            'UPDATE project_meta SET schema_version=? WHERE singleton=1',
+            (SCHEMA_VERSION,))
+        connection.execute('PRAGMA user_version=%d' % SCHEMA_VERSION)
+        connection.commit()
+    except Exception:
+        connection.rollback()
+        raise
+    finally:
+        connection.close()
 
 
 def initialize_project(path, session):
-    """Create schema v1 after a source and its first frame were decoded."""
+    """Create schema v2 after a source and its first frame were decoded."""
     path = os.path.abspath(os.fspath(path))
     if os.path.exists(path):
         _validate_existing(path)
@@ -241,7 +322,10 @@ def validate_project_source(path, source_path, fingerprint, update_path=True):
         stored = VideoFingerprint(int(row[0]), int(row[1]), row[2])
         if not stored.content_matches(fingerprint):
             raise VideoSourceChanged(
-                'video content does not match the project fingerprint')
+                'video content does not match the project fingerprint '
+                '(expected %s bytes/%s, found %s bytes/%s)' % (
+                    stored.size, stored.sampled_sha256[:12],
+                    fingerprint.size, fingerprint.sampled_sha256[:12]))
         source_path = os.path.abspath(source_path)
         if update_path and source_path != os.path.abspath(row[3]):
             relative = os.path.relpath(source_path, os.path.dirname(path))
@@ -298,9 +382,27 @@ def _observation_from_row(row):
         anchor=bool(row[7]), quality=row[8], revision=int(row[9]))
 
 
-def load_project(path):
-    _validate_existing(path)
-    connection = _connect(path)
+def _gap_from_row(row):
+    return TrackGapRecord(
+        track_id=row[0], start_pts=int(row[1]), end_pts=int(row[2]),
+        reason=row[3], backend=row[4], revision=int(row[5]))
+
+
+def load_project(path, read_only=False):
+    version = _validate_existing(path)
+    effective_read_only = bool(read_only)
+    warning = None
+    if version == LEGACY_SCHEMA_VERSION and not effective_read_only:
+        try:
+            _migrate_v1_to_v2(path)
+            version = SCHEMA_VERSION
+        except Exception as exc:
+            effective_read_only = True
+            warning = (
+                'Could not upgrade this video project to schema 2. '
+                'It was reopened read-only; make a backup and check write '
+                'permissions or free disk space before retrying. (%s)' % exc)
+    connection = _connect_read_only(path)
     try:
         revision = int(connection.execute(
             'SELECT durable_revision FROM project_meta WHERE singleton=1'
@@ -319,8 +421,15 @@ def load_project(path):
             'SELECT pts, verified, revision FROM frame_state ORDER BY pts'))
         classes = tuple(row[0] for row in connection.execute(
             'SELECT label FROM classes ORDER BY class_index'))
+        gaps = ()
+        if version >= 2:
+            gaps = tuple(_gap_from_row(row) for row in connection.execute(
+                'SELECT track_id, start_pts, end_pts, reason, backend, '
+                'revision FROM track_gaps '
+                'ORDER BY start_pts, end_pts, track_id'))
         return ProjectContents(
-            revision, tracks, observations, frame_states, classes)
+            revision, tracks, observations, frame_states, classes,
+            gaps=gaps, read_only=effective_read_only, warning=warning)
     finally:
         connection.close()
 
@@ -342,7 +451,7 @@ def _rebuild_segments(connection, track_id):
 
 def save_project_delta(request, cancelled=None, begin_commit=None):
     """Apply one immutable revision delta in a guarded transaction."""
-    _validate_existing(request.project_path)
+    _require_current_schema(request.project_path)
     if cancelled is not None and cancelled():
         return None
     connection = _connect(request.project_path)
@@ -360,6 +469,11 @@ def save_project_delta(request, cancelled=None, begin_commit=None):
             connection.execute(
                 'DELETE FROM observations WHERE track_id=? AND pts=?',
                 (track_id, int(pts)))
+        for track_id, start_pts, end_pts in request.deleted_gaps:
+            connection.execute(
+                'DELETE FROM track_gaps WHERE track_id=? '
+                'AND start_pts=? AND end_pts=?',
+                (track_id, int(start_pts), int(end_pts)))
         for track_id in request.deleted_tracks:
             connection.execute(
                 'DELETE FROM tracks WHERE track_id=?', (track_id,))
@@ -392,6 +506,15 @@ def save_project_delta(request, cancelled=None, begin_commit=None):
                  int(observation.present), observation.source,
                  observation.review_state, int(observation.anchor),
                  observation.quality, int(observation.revision)))
+        for gap in request.gaps:
+            connection.execute(
+                'INSERT INTO track_gaps (track_id, start_pts, end_pts, '
+                'reason, backend, revision) VALUES (?, ?, ?, ?, ?, ?) '
+                'ON CONFLICT(track_id, start_pts, end_pts) DO UPDATE SET '
+                'reason=excluded.reason, backend=excluded.backend, '
+                'revision=excluded.revision',
+                (gap.track_id, int(gap.start_pts), int(gap.end_pts),
+                 gap.reason, gap.backend, int(gap.revision)))
         for state in request.frame_states:
             connection.execute(
                 'INSERT INTO frame_state (pts, verified, revision) '
@@ -405,6 +528,7 @@ def save_project_delta(request, cancelled=None, begin_commit=None):
                 tuple(enumerate(request.classes)))
         touched = set(request.touched_tracks)
         touched.update(item.track_id for item in request.observations)
+        touched.update(item.track_id for item in request.gaps)
         touched.update(item.track_id for item in request.tracks)
         for track_id in sorted(touched):
             if connection.execute(
@@ -429,7 +553,7 @@ def save_project_delta(request, cancelled=None, begin_commit=None):
 
 
 def checkpoint_project(path):
-    _validate_existing(path)
+    _require_current_schema(path)
     connection = _connect(path)
     try:
         connection.execute('PRAGMA wal_checkpoint(TRUNCATE)').fetchall()

--- a/libs/core/video_propagation.py
+++ b/libs/core/video_propagation.py
@@ -1,0 +1,9 @@
+"""Qt-free interface for whole-video propagation backends."""
+
+
+class PropagationBackend:
+    """Stateless adapter implemented by portable and optional backends."""
+
+    def propagate(self, request, direction, cancelled, emit_batch):
+        """Return a final result while streaming immutable preview batches."""
+        raise NotImplementedError

--- a/libs/core/video_session.py
+++ b/libs/core/video_session.py
@@ -48,24 +48,34 @@ def prepare_video_open(path, project_path=None, read_only=False,
         if project_path is None:
             contents = None
             revision = 0
+            effective_read_only = bool(read_only)
         elif os.path.exists(project_path):
             validate_project_source(
                 project_path, source_path, decoder.fingerprint,
-                update_path=not read_only)
-            contents = load_project(project_path)
+                update_path=False)
+            contents = load_project(project_path, read_only=read_only)
             revision = contents.revision
+            effective_read_only = bool(read_only or contents.read_only)
+            if not effective_read_only:
+                validate_project_source(
+                    project_path, source_path, decoder.fingerprint,
+                    update_path=True)
         else:
             draft = decoder.snapshot(project_path, initial, read_only=read_only)
             contents = initialize_project(project_path, draft)
             revision = contents.revision
+            effective_read_only = bool(read_only or contents.read_only)
         snapshot = decoder.snapshot(
-            project_path, initial, revision=revision, read_only=read_only)
+            project_path, initial, revision=revision,
+            read_only=effective_read_only)
         return PreparedVideoOpen(
             snapshot=snapshot, decoder=decoder,
             tracks=contents.tracks if contents else (),
             observations=contents.observations if contents else (),
             frame_states=contents.frame_states if contents else (),
-            classes=contents.classes if contents else ())
+            classes=contents.classes if contents else (),
+            gaps=contents.gaps if contents else (),
+            warning=contents.warning if contents else None)
     except Exception:
         decoder.close()
         raise

--- a/libs/core/video_types.py
+++ b/libs/core/video_types.py
@@ -233,6 +233,7 @@ class VideoExportRequest:
     image_format: str = 'jpg'
     jpeg_quality: int = 95
     class_order: tuple = ()
+    gaps: tuple = ()
     range_start_pts: object = None
     range_end_pts: object = None
     sample_every_frames: object = None

--- a/libs/core/video_types.py
+++ b/libs/core/video_types.py
@@ -121,6 +121,16 @@ class FrameStateRecord:
 
 
 @dataclass(frozen=True)
+class TrackGapRecord:
+    track_id: str
+    start_pts: int
+    end_pts: int
+    reason: str
+    backend: str
+    revision: int = 0
+
+
+@dataclass(frozen=True)
 class VideoSaveRequest:
     project_path: str
     expected_durable_revision: int
@@ -132,6 +142,52 @@ class VideoSaveRequest:
     frame_states: tuple = ()
     classes: tuple = ()
     touched_tracks: tuple = ()
+    gaps: tuple = ()
+    deleted_gaps: tuple = ()
+
+
+@dataclass(frozen=True)
+class PropagationRequest:
+    request_id: int
+    generation: int
+    document_revision: int
+    source_path: str
+    fingerprint: VideoFingerprint
+    stream_index: int
+    time_base_num: int
+    time_base_den: int
+    start_pts: int
+    end_pts: int
+    current_pts: int
+    direction: int
+    seeds: tuple
+    manual_anchors: tuple
+    track_revisions: tuple
+
+
+@dataclass(frozen=True)
+class PropagationBatch:
+    request_id: int
+    generation: int
+    direction: int
+    observations: tuple = ()
+    gaps: tuple = ()
+    processed_frames: int = 0
+    total_frames: int = 0
+    active_tracks: int = 0
+    completed_tracks: int = 0
+    eta_seconds: object = None
+    finished: bool = False
+
+
+@dataclass(frozen=True)
+class PropagationResult:
+    request_id: int
+    generation: int
+    document_revision: int
+    observations: tuple = ()
+    gaps: tuple = ()
+    failures: tuple = ()
 
 
 @dataclass(frozen=True)

--- a/tests/core/test_video_propagation_contract.py
+++ b/tests/core/test_video_propagation_contract.py
@@ -1,0 +1,60 @@
+from dataclasses import FrozenInstanceError
+import importlib
+import sys
+
+import pytest
+
+from libs.core.video_propagation import PropagationBackend
+from libs.core.video_types import (
+    ObservationRecord, PropagationBatch, PropagationRequest,
+    PropagationResult, TrackGapRecord, VideoFingerprint,
+)
+
+
+def _request():
+    fingerprint = VideoFingerprint(100, 20, 'abc')
+    seed = ObservationRecord('track-1', 10, (1, 2, 3, 4))
+    return PropagationRequest(
+        request_id=7, generation=8, document_revision=9,
+        source_path='/media/clip.mp4', fingerprint=fingerprint,
+        stream_index=0, time_base_num=1, time_base_den=30,
+        start_pts=0, end_pts=90, current_pts=10, direction=1,
+        seeds=(seed,), manual_anchors=(seed,),
+        track_revisions=(('track-1', 9),))
+
+
+def test_propagation_contracts_are_frozen_plain_data():
+    request = _request()
+    gap = TrackGapRecord(
+        'track-1', 11, 20, 'occluded', 'opencv', revision=10)
+    batch = PropagationBatch(
+        7, 8, 1, gaps=(gap,), processed_frames=4, total_frames=20,
+        active_tracks=1, completed_tracks=0, eta_seconds=1.5)
+    result = PropagationResult(
+        7, 8, 9, gaps=(gap,), failures=(('track-2', 'scene_cut'),))
+
+    assert request.manual_anchors == request.seeds
+    assert batch.gaps == (gap,)
+    assert result.failures == (('track-2', 'scene_cut'),)
+    with pytest.raises(FrozenInstanceError):
+        gap.reason = 'changed'
+    with pytest.raises(FrozenInstanceError):
+        request.direction = -1
+
+
+def test_contract_and_backend_modules_do_not_import_qt_or_optionals():
+    before = set(sys.modules)
+    importlib.reload(importlib.import_module('libs.core.video_types'))
+    importlib.reload(importlib.import_module('libs.core.video_propagation'))
+    imported = set(sys.modules) - before
+    assert not any(name.startswith('PyQt') for name in imported)
+    assert 'av' not in imported
+    assert 'cv2' not in imported
+    assert 'numpy' not in imported
+
+
+def test_backend_interface_is_explicit_and_stateless():
+    backend = PropagationBackend()
+    assert backend.__dict__ == {}
+    with pytest.raises(NotImplementedError):
+        backend.propagate(_request(), 1, lambda: False, lambda _batch: None)

--- a/tests/core/test_video_propagation_contract.py
+++ b/tests/core/test_video_propagation_contract.py
@@ -1,5 +1,6 @@
 from dataclasses import FrozenInstanceError
-import importlib
+import json
+import subprocess
 import sys
 
 import pytest
@@ -43,10 +44,17 @@ def test_propagation_contracts_are_frozen_plain_data():
 
 
 def test_contract_and_backend_modules_do_not_import_qt_or_optionals():
-    before = set(sys.modules)
-    importlib.reload(importlib.import_module('libs.core.video_types'))
-    importlib.reload(importlib.import_module('libs.core.video_propagation'))
-    imported = set(sys.modules) - before
+    script = """
+import json
+import sys
+import libs.core.video_types
+import libs.core.video_propagation
+print(json.dumps(sorted(sys.modules)))
+"""
+    process = subprocess.run(
+        [sys.executable, '-c', script], check=True, text=True,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    imported = set(json.loads(process.stdout))
     assert not any(name.startswith('PyQt') for name in imported)
     assert 'av' not in imported
     assert 'cv2' not in imported

--- a/tests/video/test_model.py
+++ b/tests/video/test_model.py
@@ -1,5 +1,5 @@
 from libs.core.video_model import VideoProjectModel
-from libs.core.video_types import ObservationRecord
+from libs.core.video_types import ObservationRecord, TrackGapRecord
 
 
 def _track(model, shape_type='rectangle'):
@@ -116,3 +116,43 @@ def test_rerun_replaces_pending_and_rejected_but_never_accepted_or_manual():
     model.upsert_manual(track.track_id, 10, [3, 3, 13, 13])
     manual = model.observations[(track.track_id, 10)]
     assert model.upsert_tracker(pending) == manual
+
+
+def test_gaps_round_trip_through_snapshot_restore_and_save_delta():
+    model = VideoProjectModel()
+    track = _track(model)
+    model.upsert_manual(track.track_id, 0, [0, 0, 10, 10])
+    model.upsert_manual(track.track_id, 20, [20, 20, 30, 30])
+    baseline = model.snapshot_state()
+
+    first = model.upsert_gap(TrackGapRecord(
+        track.track_id, 5, 10, 'occluded', 'opencv'))
+    assert model.materialize_one(track.track_id, 7) is None
+    request = model.build_save_request('/tmp/project.sqlite')
+    assert request.gaps == (first,)
+    assert request.deleted_gaps == ()
+
+    model.restore_state(baseline)
+    assert model.gaps == {}
+    restored = model.build_save_request('/tmp/project.sqlite')
+    assert restored.deleted_gaps == ((track.track_id, 5, 10),)
+
+
+def test_gap_replacement_deletion_and_track_cascade_are_revisioned():
+    model = VideoProjectModel()
+    track = _track(model)
+    first = model.upsert_gap(TrackGapRecord(
+        track.track_id, 5, 10, 'occluded', 'opencv'))
+    replacement = model.upsert_gap(TrackGapRecord(
+        track.track_id, 5, 10, 'scene_cut', 'opencv'))
+    assert replacement.revision > first.revision
+    assert tuple(model.gaps.values()) == (replacement,)
+    assert model.delete_gap(track.track_id, 5, 10) is True
+    assert model.delete_gap(track.track_id, 5, 10) is False
+    assert model.build_save_request(
+        '/tmp/project.sqlite').deleted_gaps == ((track.track_id, 5, 10),)
+
+    model.upsert_gap(TrackGapRecord(
+        track.track_id, 20, 30, 'out_of_frame', 'opencv'))
+    model.delete_track(track.track_id)
+    assert model.gaps == {}

--- a/tests/video/test_opening.py
+++ b/tests/video/test_opening.py
@@ -1,4 +1,5 @@
 import os
+import sqlite3
 import time
 from unittest.mock import patch
 
@@ -9,6 +10,7 @@ from labelImgPlusPlus import DocumentKind, get_main_app
 from libs.core.video_decoder import VideoDependencyError
 from libs.core.video_project import default_project_path
 from libs.core.video_project import read_project_source
+from libs.core.video_types import ObservationRecord
 
 
 def _wait(app, predicate, timeout=5):
@@ -129,10 +131,17 @@ def test_cli_positional_argument_accepts_video_project(tmp_path, make_video):
     first.close()
 
     _same_app, window = get_main_app(['labelimgpp', project])
+    source_problems = []
     try:
         assert _same_app is app
-        assert _wait(
-            app, lambda: window.document_kind == DocumentKind.VIDEO)
+        with patch.object(
+                window, '_video_source_changed_choice',
+                side_effect=lambda message: source_problems.append(message)
+                or 'cancel'):
+            assert _wait(
+                app, lambda: window.document_kind == DocumentKind.VIDEO
+                or bool(source_problems))
+        assert not source_problems, source_problems
         assert window.video_snapshot.project_path == project
         assert window.file_path == video
     finally:
@@ -236,6 +245,58 @@ def test_read_only_video_blocks_controller_mutations_and_keeps_clean(
         assert not window.actions.pasteFromClipboard.isEnabled()
         assert window.dirty is False
         assert window.request_save_video_project() is None
+    finally:
+        window.dirty = False
+        window.close()
+
+
+def test_failed_v1_migration_surfaces_warning_and_preserves_pending_rows(
+        tmp_path, make_video):
+    _app, window = get_main_app()
+    video = make_video(tmp_path / 'legacy.mp4')
+    try:
+        assert window.open_video(video)
+        track = window.video_model.create_track(
+            'car', 'rectangle', (0, 255, 0, 255), track_id='track-1')
+        pending = ObservationRecord(
+            track.track_id, window.current_video_frame_ref.pts,
+            [2, 3, 22, 23], source='tracker', review_state='pending',
+            anchor=False, quality=.75)
+        window.video_model.upsert_tracker(pending)
+        window._on_video_model_mutation()
+        assert window.save_video_project()
+        project = window.video_snapshot.project_path
+        window.reset_state()
+
+        connection = sqlite3.connect(project)
+        try:
+            connection.execute('DROP TABLE track_gaps')
+            connection.execute(
+                'UPDATE project_meta SET schema_version=1 WHERE singleton=1')
+            connection.execute('PRAGMA user_version=1')
+            connection.commit()
+        finally:
+            connection.close()
+
+        from libs.core import video_project
+        create_schema = video_project._create_track_gaps_schema
+
+        def fail_after_schema(connection):
+            create_schema(connection)
+            raise sqlite3.OperationalError('simulated full disk')
+
+        with patch.object(
+                video_project, '_create_track_gaps_schema',
+                fail_after_schema):
+            assert window.open_video(project)
+
+        loaded = window.video_model.observations[
+            ('track-1', pending.pts)]
+        assert window.video_snapshot.read_only is True
+        assert loaded.review_state == 'pending'
+        assert loaded.quality == .75
+        assert 'reopened read-only' in window.statusBar().currentMessage()
+        assert not window.actions.save.isEnabled()
     finally:
         window.dirty = False
         window.close()

--- a/tests/video/test_project.py
+++ b/tests/video/test_project.py
@@ -3,14 +3,15 @@ import sqlite3
 
 import pytest
 
+from libs.core import video_project
 from libs.core.video_project import (
-    APPLICATION_ID, ProjectRevisionConflict, UnknownProjectError,
-    default_project_path, fingerprint_video, initialize_project, load_project,
-    read_project_source, save_project_as, save_project_delta,
-    validate_project_source,
+    APPLICATION_ID, SCHEMA_VERSION, ProjectRevisionConflict,
+    UnknownProjectError, default_project_path, fingerprint_video,
+    initialize_project, load_project, read_project_source, save_project_as,
+    save_project_delta, validate_project_source,
 )
 from libs.core.video_types import (
-    ObservationRecord, TrackRecord, VideoSaveRequest,
+    ObservationRecord, TrackGapRecord, TrackRecord, VideoSaveRequest,
 )
 
 
@@ -37,19 +38,44 @@ def _project(tmp_path):
     return source, project, fingerprint
 
 
+def _downgrade_to_v1(project):
+    connection = sqlite3.connect(project)
+    try:
+        connection.execute('DROP TABLE track_gaps')
+        connection.execute(
+            'UPDATE project_meta SET schema_version=1 WHERE singleton=1')
+        connection.execute('PRAGMA user_version=1')
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def _raw_observation_rows(project):
+    connection = sqlite3.connect(project)
+    try:
+        return connection.execute(
+            'SELECT track_id, pts, geometry_json, keypoints_json, present, '
+            'source, review_state, anchor, quality, revision '
+            'FROM observations ORDER BY pts').fetchall()
+    finally:
+        connection.close()
+
+
 def test_project_schema_has_fixed_identity_and_safe_pragmas(tmp_path):
     _source, project, _fingerprint = _project(tmp_path)
     connection = sqlite3.connect(project)
     try:
         assert connection.execute('PRAGMA application_id').fetchone()[0] == \
             APPLICATION_ID
-        assert connection.execute('PRAGMA user_version').fetchone()[0] == 1
+        assert connection.execute('PRAGMA user_version').fetchone()[0] == \
+            SCHEMA_VERSION
         assert connection.execute('PRAGMA journal_mode').fetchone()[0] == 'wal'
         tables = {row[0] for row in connection.execute(
             "SELECT name FROM sqlite_master WHERE type='table'")}
         assert {
             'project_meta', 'video_source', 'classes', 'tracks',
             'observations', 'interpolation_segments', 'frame_state',
+            'track_gaps',
         } <= tables
     finally:
         connection.close()
@@ -74,6 +100,153 @@ def test_revision_guard_rolls_back_conflicting_delta(tmp_path):
     assert [track.track_id for track in contents.tracks] == ['track-1']
     assert contents.observations == (observation,)
     assert contents.classes == ('car',)
+
+
+def test_gap_delta_insert_replace_delete_and_revision_conflict(tmp_path):
+    _source, project, _fingerprint = _project(tmp_path)
+    track = TrackRecord(
+        'track-1', 'car', 'rectangle', (1, 2, 3, 255), revision=1)
+    first = VideoSaveRequest(project, 0, 1, tracks=(track,))
+    assert save_project_delta(first) == 1
+    gap = TrackGapRecord(
+        'track-1', 10, 20, 'occluded', 'opencv', revision=2)
+    assert save_project_delta(VideoSaveRequest(
+        project, 1, 2, gaps=(gap,), touched_tracks=('track-1',))) == 2
+    assert load_project(project).gaps == (gap,)
+
+    replacement = TrackGapRecord(
+        'track-1', 10, 20, 'scene_cut', 'opencv', revision=3)
+    assert save_project_delta(VideoSaveRequest(
+        project, 2, 3, gaps=(replacement,),
+        touched_tracks=('track-1',))) == 3
+    assert load_project(project).gaps == (replacement,)
+
+    with pytest.raises(ProjectRevisionConflict):
+        save_project_delta(VideoSaveRequest(
+            project, 2, 4,
+            deleted_gaps=(('track-1', 10, 20),)))
+    contents = load_project(project)
+    assert contents.revision == 3
+    assert contents.gaps == (replacement,)
+
+    assert save_project_delta(VideoSaveRequest(
+        project, 3, 4,
+        deleted_gaps=(('track-1', 10, 20),),
+        touched_tracks=('track-1',))) == 4
+    assert load_project(project).gaps == ()
+
+
+def test_gap_schema_uses_inclusive_validated_pts_bounds(tmp_path):
+    _source, project, _fingerprint = _project(tmp_path)
+    track = TrackRecord('track-1', 'car', 'rectangle', (1, 2, 3, 255))
+    save_project_delta(VideoSaveRequest(project, 0, 1, tracks=(track,)))
+    connection = sqlite3.connect(project)
+    try:
+        connection.execute(
+            "INSERT INTO track_gaps VALUES "
+            "('track-1', 10, 10, 'occluded', 'opencv', 1)")
+        with pytest.raises(sqlite3.IntegrityError):
+            connection.execute(
+                "INSERT INTO track_gaps VALUES "
+                "('track-1', 30, 20, 'occluded', 'opencv', 1)")
+    finally:
+        connection.rollback()
+        connection.close()
+
+
+def test_writable_v1_migrates_transactionally_without_changing_observations(
+        tmp_path):
+    _source, project, _fingerprint = _project(tmp_path)
+    track = TrackRecord('track-1', 'car', 'rectangle', (1, 2, 3, 255))
+    observations = (
+        ObservationRecord(
+            'track-1', 1, [1, 2, 3, 4], source='manual',
+            review_state='accepted', anchor=True, revision=1),
+        ObservationRecord(
+            'track-1', 2, [2, 3, 4, 5], source='tracker',
+            review_state='pending', anchor=False, quality=.8, revision=1),
+        ObservationRecord(
+            'track-1', 3, [3, 4, 5, 6], source='tracker',
+            review_state='rejected', anchor=False, quality=.2, revision=1),
+    )
+    save_project_delta(VideoSaveRequest(
+        project, 0, 1, tracks=(track,), observations=observations,
+        touched_tracks=('track-1',)))
+    _downgrade_to_v1(project)
+    before = _raw_observation_rows(project)
+
+    contents = load_project(project)
+
+    assert contents.observations == observations
+    assert contents.gaps == ()
+    assert contents.read_only is False
+    assert contents.warning is None
+    assert _raw_observation_rows(project) == before
+    connection = sqlite3.connect(project)
+    try:
+        assert connection.execute('PRAGMA user_version').fetchone()[0] == 2
+        assert connection.execute(
+            "SELECT name FROM sqlite_master WHERE name='track_gaps'"
+        ).fetchone() == ('track_gaps',)
+        assert connection.execute(
+            'SELECT schema_version FROM project_meta').fetchone()[0] == 2
+    finally:
+        connection.close()
+
+
+def test_read_only_v1_loads_with_empty_gap_projection(tmp_path):
+    _source, project, _fingerprint = _project(tmp_path)
+    _downgrade_to_v1(project)
+
+    contents = load_project(project, read_only=True)
+
+    assert contents.gaps == ()
+    assert contents.read_only is True
+    assert contents.warning is None
+    connection = sqlite3.connect(project)
+    try:
+        assert connection.execute('PRAGMA user_version').fetchone()[0] == 1
+    finally:
+        connection.close()
+
+
+def test_failed_v1_migration_rolls_back_and_reopens_read_only(
+        tmp_path, monkeypatch):
+    _source, project, _fingerprint = _project(tmp_path)
+    track = TrackRecord('track-1', 'car', 'rectangle', (1, 2, 3, 255))
+    observation = ObservationRecord(
+        'track-1', 1, [1, 2, 3, 4], source='tracker',
+        review_state='pending', anchor=False, quality=.75, revision=1)
+    save_project_delta(VideoSaveRequest(
+        project, 0, 1, tracks=(track,), observations=(observation,),
+        touched_tracks=('track-1',)))
+    _downgrade_to_v1(project)
+    before = _raw_observation_rows(project)
+    create_schema = video_project._create_track_gaps_schema
+
+    def fail_after_schema(connection):
+        create_schema(connection)
+        raise sqlite3.OperationalError('simulated full disk')
+
+    monkeypatch.setattr(
+        video_project, '_create_track_gaps_schema', fail_after_schema)
+    contents = load_project(project)
+
+    assert contents.read_only is True
+    assert 'reopened read-only' in contents.warning
+    assert 'free disk space' in contents.warning
+    assert contents.observations == (observation,)
+    assert _raw_observation_rows(project) == before
+    connection = sqlite3.connect(project)
+    try:
+        assert connection.execute('PRAGMA user_version').fetchone()[0] == 1
+        assert connection.execute(
+            "SELECT name FROM sqlite_master WHERE name='track_gaps'"
+        ).fetchone() is None
+        assert connection.execute(
+            'SELECT schema_version FROM project_meta').fetchone()[0] == 1
+    finally:
+        connection.close()
 
 
 def test_moved_source_is_repaired_when_sampled_content_matches(tmp_path):


### PR DESCRIPTION
## Summary

- add frozen Qt-free propagation requests, batches, results, gap records, and a stateless backend interface
- keep public package/core exports lazy so importing plain contracts does not load Qt or optional video dependencies
- migrate writable v1 projects transactionally to schema v2 with persisted inclusive PTS gap records
- roll migration failures back completely, reopen read-only, preserve legacy accepted/pending/rejected rows, and surface an actionable warning
- include gaps in model snapshots, restoration/undo, save deltas, revision conflicts, materialization, export snapshots, and track deletion

## Verification

- full suite: 1011 passed, 1 skipped
- video suite: 91 passed
- plugin suite: 53 passed
- combined SAM/video: 148 passed, 1 skipped
- changed-file Ruff and `git diff --check`
- Python 3.8 AST and compileall
- wheel/sdist build, Twine check, and wheel content inspection
- explicit v1/v2, rollback, read-only, legacy-pending, gap replacement/deletion, restoration, and revision-conflict tests