### PR TITLE
feat(video): regenerate corrected track segments

### DIFF
--- a/labelImgPlusPlus.py
+++ b/labelImgPlusPlus.py
@@ -273,6 +273,7 @@ class MainWindow(QMainWindow, WindowMixin):
         self._propagation_preview = {}
         self._propagation_preview_gaps = {}
         self._propagation_before_state = None
+        self._regeneration_runs = {}
         self._video_export_handle = None
         self._load_request_id = 0
         self._pending_navigation_index = None
@@ -1759,6 +1760,8 @@ class MainWindow(QMainWindow, WindowMixin):
             self.pause_video()
         if hasattr(self, '_propagation_handle'):
             self.cancel_video_propagation()
+        if hasattr(self, '_regeneration_runs'):
+            self._cancel_all_regeneration()
         if hasattr(self, '_tracking_handle'):
             self.cancel_video_tracking()
         if hasattr(self, '_video_export_handle'):
@@ -2167,13 +2170,8 @@ class MainWindow(QMainWindow, WindowMixin):
                 self._materialize_video_frame(
                     self.current_video_frame_ref.pts)
                 return
-            before = self.video_model.snapshot_state()
-            self._store_video_shape_as_manual(shape)
-            after = self.video_model.snapshot_state()
-            self.undo_stack.push(VideoModelCommand(
-                self, before, after, 'Edit video polygon keyframe'))
-            self._on_video_model_mutation()
-            self._materialize_video_frame(self.current_video_frame_ref.pts)
+            self._commit_video_correction(
+                shape, 'Edit video polygon keyframe')
             return
         cmd = EditPolygonVerticesCommand(
             self, shape, old_points, list(shape.points))
@@ -2187,13 +2185,8 @@ class MainWindow(QMainWindow, WindowMixin):
                 self._materialize_video_frame(
                     self.current_video_frame_ref.pts)
                 return
-            before = self.video_model.snapshot_state()
-            self._store_video_shape_as_manual(shape)
-            after = self.video_model.snapshot_state()
-            self.undo_stack.push(VideoModelCommand(
-                self, before, after, 'Edit video track keyframe'))
-            self._on_video_model_mutation()
-            self._materialize_video_frame(self.current_video_frame_ref.pts)
+            self._commit_video_correction(
+                shape, 'Edit video track keyframe')
             return
         cmd = MoveShapeCommand(self, shape, old_points, list(shape.points))
         self.undo_stack.push(cmd)
@@ -2206,13 +2199,7 @@ class MainWindow(QMainWindow, WindowMixin):
                 self._materialize_video_frame(
                     self.current_video_frame_ref.pts)
                 return
-            before = self.video_model.snapshot_state()
-            self._store_video_shape_as_manual(shape)
-            after = self.video_model.snapshot_state()
-            self.undo_stack.push(VideoModelCommand(
-                self, before, after, 'Edit video keypoints'))
-            self._on_video_model_mutation()
-            self._materialize_video_frame(self.current_video_frame_ref.pts)
+            self._commit_video_correction(shape, 'Edit video keypoints')
             return
         cmd = EditKeypointsCommand(
             self, shape, old_keypoints,
@@ -3567,6 +3554,8 @@ class MainWindow(QMainWindow, WindowMixin):
     def _on_video_model_mutation(self):
         if not self._ensure_video_editable():
             return
+        if self._regeneration_runs:
+            self._cancel_all_regeneration()
         if (self._active_tracking_request is not None
                 and not self._applying_tracking_batch):
             self.cancel_video_tracking()
@@ -3614,6 +3603,28 @@ class MainWindow(QMainWindow, WindowMixin):
         self.video_model.upsert_manual(
             track_id, self.current_video_frame_ref.pts,
             geometry, keypoints=keypoints)
+        return track_id
+
+    def _commit_video_correction(self, shape, description):
+        """Promote an edited generated shape, then regenerate its segments."""
+        model = self.video_model
+        frame_ref = self.current_video_frame_ref
+        track_id = getattr(shape, 'video_track_id', None)
+        if model is None or frame_ref is None or track_id not in model.tracks:
+            return None
+        current = model.observations.get((track_id, frame_ref.pts))
+        generated = (
+            getattr(shape, 'video_render_state', None) == 'interpolation'
+            or (current is not None and current.source != 'manual'))
+        before = model.snapshot_state()
+        self._store_video_shape_as_manual(shape)
+        after = model.snapshot_state()
+        self.undo_stack.push(VideoModelCommand(
+            self, before, after, description))
+        self._on_video_model_mutation()
+        self._materialize_video_frame(frame_ref.pts)
+        if generated:
+            self._start_correction_regeneration(track_id, frame_ref.pts)
         return track_id
 
     def _shape_for_materialized(self, materialized):
@@ -4034,6 +4045,170 @@ class MainWindow(QMainWindow, WindowMixin):
         if handle is not None:
             handle.cancel()
         self._clear_propagation_state()
+
+    def _start_correction_regeneration(self, track_id, correction_pts):
+        model = self.video_model
+        snapshot = self.video_snapshot
+        if model is None or snapshot is None or track_id not in model.tracks:
+            return None
+        seed = model.observations.get((track_id, int(correction_pts)))
+        if (seed is None or seed.source != 'manual'
+                or seed.review_state != 'accepted' or not seed.anchor):
+            return None
+        anchors = tuple(sorted(
+            (item for item in model.observations.values()
+             if item.track_id == track_id and item.source == 'manual'
+             and item.review_state == 'accepted' and item.anchor),
+            key=lambda item: item.pts))
+        media_start = int(snapshot.start_pts or 0)
+        media_end = media_start + int(snapshot.duration_pts or 0)
+        left = next((item.pts for item in reversed(anchors)
+                     if item.pts < correction_pts), media_start)
+        right = next((item.pts for item in anchors
+                      if item.pts > correction_pts), media_end)
+        intervals = tuple(
+            value for value in ((left, int(correction_pts)),
+                                (int(correction_pts), right))
+            if value[1] > value[0])
+        directions = tuple(
+            (-1 if end == correction_pts else 1)
+            for _start, end in intervals)
+        if not intervals:
+            return None
+
+        self._cancel_regeneration(track_id)
+        self._tracking_request_id += 1
+        track_revision = model.tracks[track_id].revision
+        request = PropagationRequest(
+            request_id=self._tracking_request_id,
+            generation=self._dataset_generation,
+            document_revision=model.revision,
+            source_path=snapshot.source_path,
+            fingerprint=snapshot.fingerprint,
+            stream_index=snapshot.stream_index,
+            time_base_num=snapshot.time_base_num,
+            time_base_den=snapshot.time_base_den,
+            start_pts=left, end_pts=right,
+            current_pts=int(correction_pts), direction=0,
+            seeds=(seed,), manual_anchors=anchors,
+            track_revisions=((track_id, track_revision),),
+            average_rate_num=snapshot.average_rate_num,
+            average_rate_den=snapshot.average_rate_den)
+        run = {
+            'request': request, 'intervals': intervals,
+            'before': model.snapshot_state(), 'handle': None,
+        }
+        self._regeneration_runs[track_id] = run
+        backend = OpenCVPropagationBackend()
+
+        def regenerate(handle):
+            results = []
+            for direction in directions:
+                handle.check_cancelled()
+                directional = replace(request, direction=direction)
+                results.append(backend.propagate(
+                    directional, direction, handle.is_cancelled,
+                    lambda _batch: handle.check_cancelled()))
+            observations = {}
+            gaps = {}
+            failures = {}
+            for result in results:
+                observations.update(
+                    ((item.track_id, item.pts), item)
+                    for item in result.observations)
+                gaps.update(
+                    ((item.track_id, item.start_pts, item.end_pts), item)
+                    for item in result.gaps)
+                failures.update(result.failures)
+            return PropagationResult(
+                request.request_id, request.generation,
+                request.document_revision,
+                observations=tuple(observations.values()),
+                gaps=tuple(gaps.values()),
+                failures=tuple(sorted(failures.items())))
+
+        handle = self.task_coordinator.submit(
+            'background', regenerate, priority=JobPriority.BULK,
+            key='video-regeneration-' + track_id, latest=True,
+            generation=self._dataset_generation)
+        run['handle'] = handle
+        handle.result.connect(
+            lambda result, tid=track_id, rid=request.request_id:
+            self._on_regeneration_result(tid, rid, result))
+        handle.error.connect(
+            lambda message, tid=track_id, rid=request.request_id:
+            self._on_regeneration_error(tid, rid, message))
+        handle.finished.connect(
+            lambda current=handle, tid=track_id:
+            self._on_regeneration_finished(tid, current))
+        self.status('Regenerating corrected track segments…')
+        return handle
+
+    def _regeneration_is_current(self, track_id, request_id, result):
+        run = self._regeneration_runs.get(track_id)
+        model = self.video_model
+        snapshot = self.video_snapshot
+        if run is None or model is None or snapshot is None:
+            return False
+        request = run['request']
+        track = model.tracks.get(track_id)
+        return (
+            request.request_id == request_id
+            and result.request_id == request_id
+            and result.generation == request.generation
+            and request.generation == self._dataset_generation
+            and result.document_revision == request.document_revision
+            and model.revision == request.document_revision
+            and track is not None
+            and track.revision == request.track_revisions[0][1]
+            and snapshot.source_path == request.source_path
+            and snapshot.fingerprint == request.fingerprint
+            and snapshot.stream_index == request.stream_index
+            and snapshot.time_base_num == request.time_base_num
+            and snapshot.time_base_den == request.time_base_den)
+
+    def _on_regeneration_result(self, track_id, request_id, result):
+        if not self._regeneration_is_current(track_id, request_id, result):
+            self._cancel_regeneration(track_id)
+            return
+        run = self._regeneration_runs.pop(track_id)
+        model = self.video_model
+        applied = model.apply_regeneration_result(
+            result, track_id, run['intervals'])
+        after = model.snapshot_state()
+        if run['before'] != after:
+            self.undo_stack.push(VideoModelCommand(
+                self, run['before'], after,
+                'Regenerate corrected video segments'))
+            self._on_video_model_mutation()
+            self._materialize_video_frame(
+                self.current_video_frame_ref.pts)
+        self.status(
+            'Correction regeneration complete: %s observations, %s gaps' % (
+                len(applied.observations), len(applied.gaps)))
+
+    def _on_regeneration_error(self, track_id, request_id, message):
+        run = self._regeneration_runs.get(track_id)
+        if run is None or run['request'].request_id != request_id:
+            return
+        self._regeneration_runs.pop(track_id, None)
+        self.status(
+            'Correction kept; segment regeneration failed: ' + message,
+            delay=10000)
+
+    def _on_regeneration_finished(self, track_id, handle):
+        run = self._regeneration_runs.get(track_id)
+        if run is not None and run['handle'] is handle:
+            self._regeneration_runs.pop(track_id, None)
+
+    def _cancel_regeneration(self, track_id):
+        run = self._regeneration_runs.pop(track_id, None)
+        if run is not None and run.get('handle') is not None:
+            run['handle'].cancel()
+
+    def _cancel_all_regeneration(self):
+        for track_id in tuple(self._regeneration_runs):
+            self._cancel_regeneration(track_id)
 
     def _video_track_item_changed(self, item):
         """Legacy entry point retained for controller compatibility."""
@@ -6551,6 +6726,8 @@ class MainWindow(QMainWindow, WindowMixin):
         if (self.document_kind == DocumentKind.VIDEO
                 and not self._ensure_video_editable()):
             return
+        if self.document_kind == DocumentKind.VIDEO:
+            self._cancel_all_regeneration()
         if self.undo_stack.can_undo():
             self.undo_stack.undo()
             self.set_dirty()
@@ -6561,6 +6738,8 @@ class MainWindow(QMainWindow, WindowMixin):
         if (self.document_kind == DocumentKind.VIDEO
                 and not self._ensure_video_editable()):
             return
+        if self.document_kind == DocumentKind.VIDEO:
+            self._cancel_all_regeneration()
         if self.undo_stack.can_redo():
             self.undo_stack.redo()
             self.set_dirty()

--- a/libs/core/video_model.py
+++ b/libs/core/video_model.py
@@ -317,6 +317,120 @@ class VideoProjectModel:
             gaps=tuple(self.gaps[key] for key in gaps),
             failures=result.failures)
 
+    def apply_regeneration_result(self, result, track_id, intervals):
+        """Replace generated data strictly inside correction segments.
+
+        Manual anchors, other tracks, and generated data outside the supplied
+        open intervals are preserved. The replacement advances the model at
+        most once so it can be represented by one undo command.
+        """
+        if not isinstance(result, PropagationResult):
+            raise TypeError('result must be a PropagationResult')
+        if track_id not in self.tracks:
+            raise KeyError(track_id)
+        ranges = tuple(sorted(
+            (int(start), int(end)) for start, end in intervals))
+        if not ranges or any(end <= start for start, end in ranges):
+            raise ValueError('regeneration intervals must have start < end')
+
+        def inside(pts):
+            return any(start < int(pts) < end for start, end in ranges)
+
+        observations = {}
+        for item in result.observations:
+            if item.track_id != track_id:
+                raise ValueError('regeneration result contains another track')
+            if (item.source != 'tracker'
+                    or item.review_state != 'accepted' or item.anchor):
+                raise ValueError(
+                    'regeneration observations must be accepted tracker data')
+            if inside(item.pts):
+                observations[(track_id, int(item.pts))] = item
+        gaps = {}
+        for item in result.gaps:
+            if not isinstance(item, TrackGapRecord):
+                raise TypeError('regeneration gaps must be TrackGapRecord values')
+            if item.track_id != track_id:
+                raise ValueError('regeneration gap contains another track')
+            for start, end in ranges:
+                start_pts = max(int(item.start_pts), start + 1)
+                end_pts = min(int(item.end_pts), end - 1)
+                if end_pts >= start_pts:
+                    value = replace(
+                        item, start_pts=start_pts, end_pts=end_pts)
+                    gaps[(track_id, start_pts, end_pts)] = value
+
+        stale_observations = [
+            key for key, item in self.observations.items()
+            if key[0] == track_id and inside(key[1])
+            and item.source != 'manual']
+        stale_gaps = [
+            key for key, item in self.gaps.items()
+            if item.track_id == track_id
+            and any(item.end_pts > start and item.start_pts < end
+                    for start, end in ranges)]
+        retained_gap_pieces = []
+        for key in stale_gaps:
+            item = self.gaps[key]
+            pieces = [(int(item.start_pts), int(item.end_pts))]
+            for start, end in ranges:
+                cut_start, cut_end = start + 1, end - 1
+                next_pieces = []
+                for piece_start, piece_end in pieces:
+                    if piece_end < cut_start or piece_start > cut_end:
+                        next_pieces.append((piece_start, piece_end))
+                        continue
+                    if piece_start < cut_start:
+                        next_pieces.append((piece_start, cut_start - 1))
+                    if piece_end > cut_end:
+                        next_pieces.append((cut_end + 1, piece_end))
+                pieces = next_pieces
+            retained_gap_pieces.extend(
+                replace(item, start_pts=start, end_pts=end)
+                for start, end in pieces if end >= start)
+        if not stale_observations and not stale_gaps \
+                and not observations and not gaps:
+            return result
+
+        revision = self._advance()
+        for key in stale_observations:
+            del self.observations[key]
+            self._changed_observations.pop(key, None)
+            self._deleted_observations[key] = revision
+        for key in stale_gaps:
+            del self.gaps[key]
+            self._changed_gaps.pop(key, None)
+            self._deleted_gaps[key] = revision
+        for item in retained_gap_pieces:
+            key = (track_id, int(item.start_pts), int(item.end_pts))
+            value = replace(item, revision=revision)
+            self.gaps[key] = value
+            self._changed_gaps[key] = value
+            self._deleted_gaps.pop(key, None)
+        for key, item in observations.items():
+            existing = self.observations.get(key)
+            if existing is not None and existing.source == 'manual':
+                continue
+            value = replace(item, pts=key[1], revision=revision)
+            self.observations[key] = value
+            self._changed_observations[key] = value
+            self._deleted_observations.pop(key, None)
+        for key, item in gaps.items():
+            value = replace(item, revision=revision)
+            self.gaps[key] = value
+            self._changed_gaps[key] = value
+            self._deleted_gaps.pop(key, None)
+        track = replace(self.tracks[track_id], revision=revision)
+        self.tracks[track_id] = track
+        self._changed_tracks[track_id] = track
+        return PropagationResult(
+            result.request_id, result.generation, revision,
+            observations=tuple(
+                self.observations[key] for key in observations
+                if key in self.observations),
+            gaps=tuple(self.gaps[key] for key in gaps),
+            failures=result.failures)
+
     def delete_gap(self, track_id, start_pts, end_pts):
         key = (track_id, int(start_pts), int(end_pts))
         if key not in self.gaps:

--- a/tests/video/test_model.py
+++ b/tests/video/test_model.py
@@ -218,3 +218,85 @@ def test_invalid_propagation_result_cannot_partially_mutate_model():
                 'missing', 6, 7, 'occluded', 'opencv'),)))
     assert model.revision == revision
     assert model.snapshot_state() == baseline
+
+
+def test_regeneration_replaces_only_generated_data_inside_open_segments():
+    model = VideoProjectModel()
+    track = _track(model)
+    for pts in (0, 10, 20):
+        model.upsert_manual(track.track_id, pts, [pts, 0, pts + 10, 10])
+    for pts in (3, 7, 13, 17, 25):
+        model.upsert_tracker(ObservationRecord(
+            track.track_id, pts, [pts, 0, pts + 10, 10],
+            source='tracker', review_state='accepted', anchor=False))
+    model.upsert_gap(TrackGapRecord(
+        track.track_id, 4, 6, 'occluded', 'opencv'))
+    other = model.create_track(
+        'person', 'rectangle', (255, 0, 0, 255), track_id='track-2')
+    other_value = model.upsert_tracker(ObservationRecord(
+        other.track_id, 7, [0, 0, 5, 5], source='tracker',
+        review_state='accepted', anchor=False))
+    before_revision = model.revision
+
+    applied = model.apply_regeneration_result(PropagationResult(
+        2, 3, before_revision,
+        observations=(ObservationRecord(
+            track.track_id, 5, [50, 0, 60, 10], source='tracker',
+            review_state='accepted', anchor=False),),
+        gaps=(TrackGapRecord(
+            track.track_id, 14, 18, 'scene_cut', 'opencv'),)),
+        track.track_id, ((0, 10), (10, 20)))
+
+    assert model.revision == before_revision + 1
+    assert set(pts for tid, pts in model.observations if tid == track.track_id) \
+        == {0, 5, 10, 20, 25}
+    assert model.observations[(track.track_id, 5)].geometry[0] == 50
+    assert model.observations[(other.track_id, 7)] == other_value
+    assert set(model.gaps) == {(track.track_id, 14, 18)}
+    assert applied.observations[0].revision == model.revision
+
+
+def test_regeneration_filters_segment_boundaries_and_rejects_other_tracks():
+    model = VideoProjectModel()
+    track = _track(model)
+    model.upsert_manual(track.track_id, 10, [0, 0, 10, 10])
+    result = model.apply_regeneration_result(PropagationResult(
+        1, 1, model.revision,
+        observations=(
+            ObservationRecord(
+                track.track_id, 0, [0, 0, 10, 10], source='tracker',
+                review_state='accepted', anchor=False),
+            ObservationRecord(
+                track.track_id, 5, [5, 0, 15, 10], source='tracker',
+                review_state='accepted', anchor=False),
+            ObservationRecord(
+                track.track_id, 10, [10, 0, 20, 10], source='tracker',
+                review_state='accepted', anchor=False),
+        )), track.track_id, ((0, 10),))
+    assert [item.pts for item in result.observations] == [5]
+    assert (track.track_id, 0) not in model.observations
+    assert model.observations[(track.track_id, 10)].source == 'manual'
+
+    baseline = model.snapshot_state()
+    with pytest.raises(ValueError, match='another track'):
+        model.apply_regeneration_result(PropagationResult(
+            2, 1, model.revision,
+            observations=(ObservationRecord(
+                'other', 6, [0, 0, 1, 1], source='tracker',
+                review_state='accepted', anchor=False),)),
+            track.track_id, ((0, 10),))
+    assert model.snapshot_state() == baseline
+
+
+def test_regeneration_preserves_gap_portions_outside_segments():
+    model = VideoProjectModel()
+    track = _track(model)
+    model.upsert_gap(TrackGapRecord(
+        track.track_id, 0, 20, 'occluded', 'opencv'))
+    model.apply_regeneration_result(
+        PropagationResult(1, 1, model.revision),
+        track.track_id, ((5, 15),))
+    assert set(model.gaps) == {
+        (track.track_id, 0, 5),
+        (track.track_id, 15, 20),
+    }

--- a/tests/video/test_regeneration_ui.py
+++ b/tests/video/test_regeneration_ui.py
@@ -1,0 +1,203 @@
+import threading
+import time
+from unittest.mock import patch
+
+from PyQt5.QtCore import QPointF
+
+from labelImgPlusPlus import get_main_app
+from libs.core.video_types import ObservationRecord, PropagationResult
+
+
+def _wait(app, predicate, timeout=8):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        app.processEvents()
+        if predicate():
+            return True
+        time.sleep(.002)
+    return False
+
+
+def _close_window(app, window):
+    window.dirty = False
+    window.close()
+    app.processEvents()
+    app.processEvents()
+
+
+def _generated_correction_fixture(window):
+    model = window.video_model
+    first_pts = window.current_video_frame_ref.pts
+    snapshot = window.video_snapshot
+    step = int(round(
+        snapshot.average_rate_den / snapshot.average_rate_num /
+        (snapshot.time_base_num / snapshot.time_base_den)))
+    correction_pts = first_pts + 8 * step
+    track = model.create_track(
+        'object', 'rectangle', (0, 255, 0, 255), track_id='track-1')
+    model.upsert_manual(track.track_id, first_pts, [16, 14, 52, 50])
+    model.upsert_tracker(ObservationRecord(
+        track.track_id, correction_pts - step, [23, 14, 59, 50],
+        source='tracker', review_state='accepted', anchor=False))
+    model.upsert_tracker(ObservationRecord(
+        track.track_id, correction_pts, [24, 14, 60, 50],
+        source='tracker', review_state='accepted', anchor=False))
+    model.upsert_tracker(ObservationRecord(
+        track.track_id, correction_pts + step, [25, 14, 61, 50],
+        source='tracker', review_state='accepted', anchor=False))
+    model.upsert_manual(
+        track.track_id, first_pts + 16 * step, [32, 14, 68, 50])
+    window._selected_video_track_id = track.track_id
+    window._on_video_model_mutation()
+    window.request_video_frame(window.video_timeline._normalized_to_ref(
+        window.video_timeline._pts_to_normalized(correction_pts)))
+    return track, correction_pts, step
+
+
+def _edit_current_generated_shape(app, window, correction_pts):
+    assert _wait(
+        app, lambda: window.current_video_frame_ref.pts == correction_pts)
+    shape = window.canvas.shapes[0]
+    old_points = [QPointF(point) for point in shape.points]
+    shape.points = [QPointF(point.x() + 4, point.y())
+                    for point in shape.points]
+    window._on_shape_move_finished(shape, old_points)
+
+
+def test_generated_correction_and_regeneration_are_two_undo_entries(
+        tmp_path, make_video):
+    app, window = get_main_app()
+    video = make_video(
+        tmp_path / 'regenerate.mp4', frames=20, width=128, height=96,
+        tracking_stress=True)
+    gate = threading.Event()
+    started = threading.Event()
+
+    def staged(_backend, request, direction, cancelled, _emit):
+        started.set()
+        while not gate.wait(.002) and not cancelled():
+            pass
+        frame_step = int(round(
+            request.average_rate_den / request.average_rate_num /
+            (request.time_base_num / request.time_base_den)))
+        pts = request.current_pts + direction * frame_step
+        item = ObservationRecord(
+            request.seeds[0].track_id, pts,
+            [80 + direction, 14, 116 + direction, 50],
+            source='tracker', review_state='accepted', anchor=False)
+        return PropagationResult(
+            request.request_id, request.generation,
+            request.document_revision, observations=(item,))
+
+    try:
+        assert window.open_video(video)
+        track, correction_pts, step = _generated_correction_fixture(window)
+        baseline_undo = len(window.undo_stack)
+        with patch(
+                'labelImgPlusPlus.OpenCVPropagationBackend.propagate',
+                staged):
+            _edit_current_generated_shape(app, window, correction_pts)
+            assert window.video_model.observations[
+                (track.track_id, correction_pts)].source == 'manual'
+            assert len(window.undo_stack) == baseline_undo + 1
+            assert track.track_id in window._regeneration_runs
+            assert started.wait(1)
+            gate.set()
+            assert _wait(
+                app, lambda: track.track_id not in window._regeneration_runs)
+
+        assert len(window.undo_stack) == baseline_undo + 2
+        assert window.video_model.observations[
+            (track.track_id, correction_pts - step)].geometry[0] == 79
+        assert window.video_model.observations[
+            (track.track_id, correction_pts + step)].geometry[0] == 81
+
+        window.undo_action()
+        assert window.video_model.observations[
+            (track.track_id, correction_pts)].source == 'manual'
+        assert window.video_model.observations[
+            (track.track_id, correction_pts - step)].geometry[0] == 23
+        window.undo_action()
+        assert window.video_model.observations[
+            (track.track_id, correction_pts)].source == 'tracker'
+    finally:
+        gate.set()
+        _close_window(app, window)
+
+
+def test_regeneration_failure_preserves_correction_and_prior_generated_data(
+        tmp_path, make_video):
+    app, window = get_main_app()
+    video = make_video(
+        tmp_path / 'failure.mp4', frames=20, width=128, height=96,
+        tracking_stress=True)
+
+    def fail(_backend, _request, _direction, _cancelled, _emit):
+        raise RuntimeError('decoder failed')
+
+    try:
+        assert window.open_video(video)
+        track, correction_pts, step = _generated_correction_fixture(window)
+        with patch(
+                'labelImgPlusPlus.OpenCVPropagationBackend.propagate', fail):
+            _edit_current_generated_shape(app, window, correction_pts)
+            assert _wait(
+                app, lambda: track.track_id not in window._regeneration_runs)
+        assert window.video_model.observations[
+            (track.track_id, correction_pts)].source == 'manual'
+        assert window.video_model.observations[
+            (track.track_id, correction_pts - step)].geometry[0] == 23
+        assert window.video_model.observations[
+            (track.track_id, correction_pts + step)].geometry[0] == 25
+    finally:
+        _close_window(app, window)
+
+
+def test_undoing_correction_cancels_and_discards_regeneration(
+        tmp_path, make_video):
+    app, window = get_main_app()
+    video = make_video(
+        tmp_path / 'undo.mp4', frames=20, width=128, height=96,
+        tracking_stress=True)
+    gate = threading.Event()
+    started = threading.Event()
+
+    def delayed(_backend, request, direction, cancelled, _emit):
+        started.set()
+        while not gate.wait(.002) and not cancelled():
+            pass
+        frame_step = int(round(
+            request.average_rate_den / request.average_rate_num /
+            (request.time_base_num / request.time_base_den)))
+        item = ObservationRecord(
+            request.seeds[0].track_id,
+            request.current_pts + direction * frame_step,
+            [90, 14, 126, 50], source='tracker',
+            review_state='accepted', anchor=False)
+        return PropagationResult(
+            request.request_id, request.generation,
+            request.document_revision, observations=(item,))
+
+    try:
+        assert window.open_video(video)
+        track, correction_pts, step = _generated_correction_fixture(window)
+        with patch(
+                'labelImgPlusPlus.OpenCVPropagationBackend.propagate',
+                delayed):
+            _edit_current_generated_shape(app, window, correction_pts)
+            assert started.wait(1)
+            window.undo_action()
+            assert track.track_id not in window._regeneration_runs
+            gate.set()
+            assert _wait(app, lambda: not window._regeneration_runs)
+        assert window.video_model.observations[
+            (track.track_id, correction_pts)].source == 'tracker'
+        assert window.video_model.observations[
+            (track.track_id, correction_pts - step)].geometry[0] == 23
+        assert not any(
+            item.geometry[0] == 90
+            for item in window.video_model.observations.values()
+            if item.track_id == track.track_id)
+    finally:
+        gate.set()
+        _close_window(app, window)


### PR DESCRIPTION
## Summary

- keep edits of tracker/interpolated geometry as an immediate accepted manual anchor and their own undo entry
- regenerate only the open segments between the correction and nearest manual anchors, using media bounds when an anchor is absent
- atomically replace only generated observations and overlapping gap portions for the corrected track and intervals
- preserve manual anchors, other tracks, outside generated data, and the correction on failure or stale results
- record successful regeneration as a second undo entry
- cancel regeneration after correction undo, intervening mutations, document replacement, shutdown, or a superseding correction

## Verification

- changed-file Ruff and `git diff --check`
- Python 3.8 AST parsing and compileall
- optional-import guard passed
- full suite: `1028 passed, 1 skipped`
- video suite: `108 passed`
- plugin gate: `53 passed`
- combined SAM/video gate: `165 passed, 1 skipped`
