### PR TITLE
chore(release): prepare 3.4.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,85 @@
 History
 =======
 
+3.4.0 (2026-08-12)
+------------------
+
+Portable whole-video propagation release adding multi-object OpenCV tracking,
+durable gap records, atomic preview and commit, and bounded correction
+regeneration while preserving legacy pending observations, annotation formats,
+filenames, command-line entry points, plugin APIs, shortcut identifiers, and
+Python 3.8 through 3.13 support. Optional SAM 2 propagation remains deferred to
+3.5 and is not bundled or downloaded by this release.
+
+Propagation and Gap Contracts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Add frozen, Qt-free propagation requests, batches, results, and gap records,
+  plus a stateless backend interface. Workers exchange immutable plain data;
+  Qt widgets, canvas shapes, model mutation, and undo commands stay on the GUI
+  thread.
+* Upgrade video projects transactionally from schema v1 to v2 with inclusive,
+  revisioned ``track_gaps``. Writable migration failure rolls back and reopens
+  read-only with an actionable warning, while read-only v1 projects retain an
+  empty gap projection.
+* Preserve accepted, pending, and rejected legacy observations and extend
+  snapshots and save deltas for gap insertion, replacement, deletion, undo,
+  restoration, export, and revision conflicts.
+
+Portable Whole-Video Propagation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Add **Propagate across video** and **Propagate selected object** beside the
+  integrated timeline. Existing directional commands now use the same accepted
+  atomic result path rather than creating new pending suggestions.
+* Decode each requested direction once and update all active tracks together
+  with bounded Lucas-Kanade flow and affine estimation. Rectangles transform
+  their corners, polygons transform every vertex, and associated keypoints use
+  the same affine transform.
+* Protect every accepted manual anchor. Reaching another manual anchor retains
+  and reseeds it; a failed track records a stable ``low_confidence``,
+  ``occluded``, ``out_of_frame``, or ``scene_cut`` gap while other tracks
+  continue.
+* Stream generated observations into a preview-only canvas layer excluded from
+  canonical shapes, dirty state, saves, exports, plugins, inspectors, and undo.
+  Frame navigation remains available while geometry and class mutation, save,
+  export, undo, and redo are disabled.
+* Validate document generation and revision, media fingerprint, stream and time
+  base, and every track revision before applying accepted tracker observations
+  and gaps in one model revision and one undo command. Cancellation, stale
+  state, source replacement, shutdown, or decoder failure clears preview state
+  without changing the model or durable project.
+
+Correction Regeneration
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* Editing tracker or interpolated geometry immediately creates an accepted
+  manual anchor as its own undoable correction.
+* Regenerate only frames strictly between that correction and the nearest
+  manual anchor on each side, using media bounds where an anchor is absent.
+  Successful replacement affects only generated observations and overlapping
+  gap portions for that track and those intervals, and is recorded as a second
+  undo entry.
+* Cancel superseded regeneration and discard results after correction undo,
+  intervening document or track revision, document replacement, or shutdown.
+  Failures preserve the correction, all manual anchors, other tracks, and prior
+  generated data.
+
+Qualification
+~~~~~~~~~~~~~
+
+* Cover CFR and VFR media, forward and backward propagation, rectangles,
+  polygons, keypoints, multiple tracks, manual-anchor reseeding, scene cuts,
+  occlusion, out-of-frame loss, corrupted media, read-only and legacy projects,
+  cancellation, stale revisions, atomic undo, gap persistence, save/export
+  blocking, navigation during work, document close, and repeated teardown.
+* Qualify Python 3.8 through 3.13, plugin, SAM, video, and combined extras while
+  keeping PyAV, NumPy, OpenCV, ONNX Runtime, Torch, and SAM 2 lazy or absent from
+  the base import path as applicable.
+* Review the integrated propagation preview at fixed Linux 1366x768 and
+  1440x900 approval sizes with no clipped primary controls, docks, or detached
+  windows.
+
 3.3.0 (2026-08-12)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ polygons, and keypoints, designed for machine learning and computer vision
 projects. It is forked from the original LabelImg with significant
 enhancements.
 
-    **Version 3.3.0 (stable).** Install with
+    **Version 3.4.0 (stable).** Install with
     ``pip install labelimgplusplus``.
 
 .. image:: https://raw.githubusercontent.com/abhiksark/labelImg-plus-plus/c7fbd5fc08a561206b210706143a50023c82a782/resources/demo/demo.gif
@@ -91,6 +91,15 @@ Workflow and Interface
     While Smart Select is active, choose **Box** or **Polygon** from the compact
     canvas control. The choice persists between sessions, and either result
     follows the same provisional class-confirmation and undo workflow.
+
+**Portable Whole-Video Propagation**
+    From the integrated timeline, propagate every accepted manual anchor on
+    the current frame or only the selected object. The portable OpenCV backend
+    processes rectangles, polygons, and associated keypoints together, shows
+    preview-only progress, protects later manual anchors, and commits accepted
+    observations and explicit gap records atomically in one undo step. Editing
+    generated geometry creates a manual correction first, then regenerates only
+    the bounded neighboring segments as a separate undoable change.
 
 **Direct Ultralytics Dataset Export**
     Choose **Tools → Export Ultralytics Dataset…** to create a ready-to-train
@@ -361,7 +370,7 @@ Or use **Menu > File > Reset All**
 Release History
 ---------------
 
-This source tree identifies itself as **3.3.0**, the stable 3.3 release. See
+This source tree identifies itself as **3.4.0**, the stable 3.4 release. See
 the `release history
 <https://github.com/abhiksark/labelImg-plus-plus/blob/master/HISTORY.rst>`__ for
 version-by-version changes and `GitHub Releases

--- a/build-tools/README.md
+++ b/build-tools/README.md
@@ -11,8 +11,8 @@ Normal releases are published by the tag workflow. The tag must exactly match
 the package version, point to a commit on ``origin/master``, and be pushed only
 after the release pull request and ``master`` CI pass:
 ```bash
-git tag -a v3.3.0 -m "labelImg++ 3.3.0"
-git push origin v3.3.0
+git tag -a v3.4.0 -m "labelImg++ 3.4.0"
+git push origin v3.4.0
 ```
 
 The workflow tests Python 3.8 through 3.13, tests the optional SAM dependency

--- a/labelimgplusplus.egg-info/PKG-INFO
+++ b/labelimgplusplus.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.1
 Name: labelimgplusplus
-Version: 3.3.0
+Version: 3.4.0
 Summary: labelImg++ is an enhanced graphical image annotation tool with Gallery Mode for browsing and labeling images
 Author-email: Abhik Sarkar <abhiksark@gmail.com>
 License: Copyright (c) <2015-Present> Tzutalin
@@ -78,7 +78,7 @@ polygons, and keypoints, designed for machine learning and computer vision
 projects. It is forked from the original LabelImg with significant
 enhancements.
 
-    **Version 3.3.0 (stable).** Install with
+    **Version 3.4.0 (stable).** Install with
     ``pip install labelimgplusplus``.
 
 .. image:: https://raw.githubusercontent.com/abhiksark/labelImg-plus-plus/c7fbd5fc08a561206b210706143a50023c82a782/resources/demo/demo.gif
@@ -143,6 +143,15 @@ Workflow and Interface
     While Smart Select is active, choose **Box** or **Polygon** from the compact
     canvas control. The choice persists between sessions, and either result
     follows the same provisional class-confirmation and undo workflow.
+
+**Portable Whole-Video Propagation**
+    From the integrated timeline, propagate every accepted manual anchor on
+    the current frame or only the selected object. The portable OpenCV backend
+    processes rectangles, polygons, and associated keypoints together, shows
+    preview-only progress, protects later manual anchors, and commits accepted
+    observations and explicit gap records atomically in one undo step. Editing
+    generated geometry creates a manual correction first, then regenerates only
+    the bounded neighboring segments as a separate undoable change.
 
 **Direct Ultralytics Dataset Export**
     Choose **Tools → Export Ultralytics Dataset…** to create a ready-to-train
@@ -413,7 +422,7 @@ Or use **Menu > File > Reset All**
 Release History
 ---------------
 
-This source tree identifies itself as **3.3.0**, the stable 3.3 release. See
+This source tree identifies itself as **3.4.0**, the stable 3.4 release. See
 the `release history
 <https://github.com/abhiksark/labelImg-plus-plus/blob/master/HISTORY.rst>`__ for
 version-by-version changes and `GitHub Releases

--- a/libs/__init__.py
+++ b/libs/__init__.py
@@ -3,7 +3,7 @@
 
 import importlib
 
-__version__ = '3.3.0'
+__version__ = '3.4.0'
 __version_info__ = tuple(__version__.split('.'))
 
 __all__ = ['core', 'formats', 'utils', 'widgets']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "labelimgplusplus"
-version = "3.3.0"
+version = "3.4.0"
 description = "labelImg++ is an enhanced graphical image annotation tool with Gallery Mode for browsing and labeling images"
 readme = "README.rst"
 license = {file = "LICENSE"}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.3.0
+current_version = 3.4.0
 commit = True
 tag = True
 


### PR DESCRIPTION
## Summary

- bump package/runtime metadata to 3.4.0
- document schema-v2 gap persistence, portable multi-object OpenCV propagation, atomic preview/commit, and bounded correction regeneration
- keep SAM 2 explicitly deferred to 3.5 and issue #99 open
- update release tooling examples for the exact `v3.4.0` tag

## Verification

- full suite: `1028 passed, 1 skipped`
- wheel and sdist built successfully
- `twine check` passed for both distributions
- all 49 Qt resource aliases verified
- checked wheel contents for propagation contracts/backend/model and public plugin namespace
- `git diff --check` passed

After merge, promote the exact tested `dev` commit to `master`, tag that master commit `v3.4.0`, and verify GitHub Release, PyPI, clean installed startup, and base PyInstaller boot before beginning 3.5.
