### PR TITLE
chore(release): prepare 3.5.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,60 @@
 History
 =======
 
+3.5.0 (2026-08-12)
+------------------
+
+Optional SAM 2 propagation release adding a lazy Linux/CUDA backend behind the
+same whole-video propagation contract while preserving portable OpenCV as the
+automatic fallback. Torch, torchvision, SAM 2, checkpoints, and model configs
+remain user-managed and are not bundled, downloaded, or added to any published
+extra.
+
+Optional SAM 2 Backend
+~~~~~~~~~~~~~~~~~~~~~~
+
+* Add Auto, OpenCV, and explicit SAM 2 backend settings plus local checkpoint
+  and model-config paths. Auto evaluates availability only when propagation is
+  invoked; explicit SAM 2 reports an actionable error and never silently falls
+  back.
+* Require Linux, Python 3.10 or newer, compatible CUDA-enabled PyTorch and
+  torchvision, an official source-installed SAM 2, and matching local files.
+  Base startup remains free of Torch, torchvision, SAM 2, PyAV, NumPy, and
+  OpenCV imports.
+* Stage exact display-oriented PTS frames only in the requested direction,
+  seed every accepted present manual anchor, and run Meta's official video
+  predictor without importing Qt into the backend.
+* Convert masks to simplified polygons or tight half-open rectangles according
+  to track type, transform associated keypoints, protect manual anchors, and
+  represent no-object output with the shared inclusive gap contract.
+* Reuse the existing preview-only streaming, cancellation, revision/media
+  validation, atomic commit, correction regeneration, and undo pipelines.
+
+Workspace and Compatibility
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Extend **Tools -> SAM Settings...** with propagation controls while
+  preserving the existing image-SAM ``values()`` interface and settings.
+* Persist ``video/propagationBackend``, ``video/sam2Checkpoint``, and
+  ``video/sam2Config`` with Auto and empty paths as safe defaults.
+* Keep Python 3.8 through 3.13 base support and all annotation formats,
+  filenames, command-line entry points, plugin APIs, document methods,
+  shortcut identifiers, and legacy pending video observations unchanged.
+
+Qualification
+~~~~~~~~~~~~~
+
+* Cover availability selection, source-install validation, explicit failure,
+  automatic OpenCV fallback, mask conversion, gaps, anchors, keypoints,
+  settings persistence, UI error handling, optional-import guards, and cleanup.
+* Qualify the ordinary Python, plugin, SAM, video, and combined-extra matrix on
+  Python 3.8 through 3.13 plus Windows and macOS video smoke jobs.
+* Exercise the official SAM 2.1 Hiera Tiny backend on an RTX A6000 in both
+  directions over exact PTS media, with 23 accepted observations per run, no
+  gaps, and zero PyTorch allocated or reserved CUDA bytes after teardown.
+* Review fixed Linux light/dark and 1x/2x settings screenshots at 1366x768 and
+  1440x900 logical sizes with no clipped controls.
+
 3.4.0 (2026-08-12)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ polygons, and keypoints, designed for machine learning and computer vision
 projects. It is forked from the original LabelImg with significant
 enhancements.
 
-    **Version 3.4.0 (stable).** Install with
+    **Version 3.5.0 (stable).** Install with
     ``pip install labelimgplusplus``.
 
 .. image:: https://raw.githubusercontent.com/abhiksark/labelImg-plus-plus/c7fbd5fc08a561206b210706143a50023c82a782/resources/demo/demo.gif
@@ -386,7 +386,7 @@ Or use **Menu > File > Reset All**
 Release History
 ---------------
 
-This source tree identifies itself as **3.4.0**, the stable 3.4 release. See
+This source tree identifies itself as **3.5.0**, the stable 3.5 release. See
 the `release history
 <https://github.com/abhiksark/labelImg-plus-plus/blob/master/HISTORY.rst>`__ for
 version-by-version changes and `GitHub Releases

--- a/build-tools/README.md
+++ b/build-tools/README.md
@@ -11,8 +11,8 @@ Normal releases are published by the tag workflow. The tag must exactly match
 the package version, point to a commit on ``origin/master``, and be pushed only
 after the release pull request and ``master`` CI pass:
 ```bash
-git tag -a v3.4.0 -m "labelImg++ 3.4.0"
-git push origin v3.4.0
+git tag -a v3.5.0 -m "labelImg++ 3.5.0"
+git push origin v3.5.0
 ```
 
 The workflow tests Python 3.8 through 3.13, tests the optional SAM dependency

--- a/labelimgplusplus.egg-info/PKG-INFO
+++ b/labelimgplusplus.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.1
 Name: labelimgplusplus
-Version: 3.4.0
+Version: 3.5.0
 Summary: labelImg++ is an enhanced graphical image annotation tool with Gallery Mode for browsing and labeling images
 Author-email: Abhik Sarkar <abhiksark@gmail.com>
 License: Copyright (c) <2015-Present> Tzutalin
@@ -78,7 +78,7 @@ polygons, and keypoints, designed for machine learning and computer vision
 projects. It is forked from the original LabelImg with significant
 enhancements.
 
-    **Version 3.4.0 (stable).** Install with
+    **Version 3.5.0 (stable).** Install with
     ``pip install labelimgplusplus``.
 
 .. image:: https://raw.githubusercontent.com/abhiksark/labelImg-plus-plus/c7fbd5fc08a561206b210706143a50023c82a782/resources/demo/demo.gif
@@ -438,7 +438,7 @@ Or use **Menu > File > Reset All**
 Release History
 ---------------
 
-This source tree identifies itself as **3.4.0**, the stable 3.4 release. See
+This source tree identifies itself as **3.5.0**, the stable 3.5 release. See
 the `release history
 <https://github.com/abhiksark/labelImg-plus-plus/blob/master/HISTORY.rst>`__ for
 version-by-version changes and `GitHub Releases

--- a/libs/__init__.py
+++ b/libs/__init__.py
@@ -3,7 +3,7 @@
 
 import importlib
 
-__version__ = '3.4.0'
+__version__ = '3.5.0'
 __version_info__ = tuple(__version__.split('.'))
 
 __all__ = ['core', 'formats', 'utils', 'widgets']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "labelimgplusplus"
-version = "3.4.0"
+version = "3.5.0"
 description = "labelImg++ is an enhanced graphical image annotation tool with Gallery Mode for browsing and labeling images"
 readme = "README.rst"
 license = {file = "LICENSE"}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.4.0
+current_version = 3.5.0
 commit = True
 tag = True
 


### PR DESCRIPTION
## Summary
- bump package, runtime, bumpversion, README, and generated metadata to 3.5.0
- document the optional source-installed SAM 2 backend and its compatibility guarantees
- update release commands for the v3.5.0 annotated tag

## Qualification
- `1038 passed, 1 skipped`
- changed-file Ruff, `git diff --check`, Python 3.8 AST parsing, and compileall passed
- wheel/sdist build and Twine validation passed
- wheel and sdist contain `libs/core/video_sam2.py`
- no Torch, torchvision, or SAM 2 requirement is present in the published metadata
- local wheel SHA-256: `3a853e80d77187c54c0c61c397606b10f65a19cdff847bb6bb9943835946910c`
- local sdist SHA-256: `152e5b4dfd09c04bb49d609ff17b6e5d0f49ede2040a578aa58b9047ceca8295`

After merge, the exact tested `dev` commit will be promoted to `master` and tagged `v3.5.0`; public GitHub/PyPI artifacts and clean-install/PyInstaller boots remain post-tag gates.
