### PR TITLE
docs(repo): add scoped contribution guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,74 @@
+# Repository Agent Instructions
+
+## Scope
+
+This file governs the entire repository. Nested `AGENTS.md` files add rules for the public plugin API, annotation formats, widgets, and tests.
+
+- Treat this `AGENTS.md` hierarchy as local workspace policy. Do not stage or commit these files unless the user explicitly requests it.
+- Run repository commands from the repository root. Some tests open `pyproject.toml` relative to the current directory.
+- Keep production code compatible with Python 3.8 through 3.13.
+
+## Core commands
+
+- Install base and test dependencies with `pip install -r requirements/requirements-linux-python3.txt pytest`.
+- Run the application with `python3 labelImgPlusPlus.py`.
+- During iteration, run the closest test with `QT_QPA_PLATFORM=offscreen python3 -m pytest path/to/test_file.py -v`.
+- Before finishing a base change, run `make test`.
+- There is no repository lint, formatter, or type-check command. Do not invent or report one as a required gate.
+- Do not run `make clean` for routine cleanup; it deletes `~/.labelImgSettings.json` as well as build outputs.
+
+## Runtime and data-safety contracts
+
+- Keep base startup free of optional feature imports. Load PyAV, NumPy, OpenCV, ONNX Runtime, Torch, torchvision, and SAM 2 only inside operations that require them. The only current module-level heavy adapters are `libs/integrations/image_convert.py` and `libs/integrations/mask_to_polygon.py`, and their callers import them lazily.
+- Route new production background work through the MainWindow-owned `TaskCoordinator` using the existing `interactive`, `background`, `sam`, or serialized `video` lane. Existing standalone pools in compatibility/test fallbacks are not patterns to copy.
+- Submit and cancel coordinator work on the GUI thread. Use `latest=True` with a stable namespaced key when only the newest request is valid.
+- Workers may return immutable/plain records and detached `QImage` values. Create `QPixmap` and `Shape` objects and mutate widgets or models only on the GUI thread.
+- Reject stale asynchronous results before mutation. Recheck every applicable request ID, generation, document/media fingerprint, stream/time base, and model or document revision.
+- Shut down plugins and plugin-owned tasks before shutting down the shared coordinator.
+- Push annotation mutations through the existing `Command`/`UndoStack` path, then mark the document dirty. Push video mutations through `VideoModelCommand` and `_on_video_model_mutation()`.
+- Route new production asynchronous image-annotation writes through immutable `SaveRequest` plus `write_save_request()`. Do not copy the synchronous compatibility save path or weaken the temp-file, fsync, commit-fence, and `os.replace` publication path.
+- Mark an image clean or navigate after save only when that exact image and document revision are still current.
+- Canvas geometry is display-space. Convert through `_image_scale_factor` before persistence or export; do not write `canvas.shapes` coordinates directly.
+
+## Compatibility boundaries
+
+- Treat `labelimgplusplus/` as the shipped public plugin API and `libs/` as internal. Read `labelimgplusplus/AGENTS.md` before changing the public package.
+- Do not import `MainWindow` from `libs/core` or construct or mutate widgets there off the GUI thread.
+- Preserve existing QAction and shortcut identities. UI wrappers must reuse host-owned actions rather than create parallel state.
+- Keep plugin activation transactional. On failure, restore staged settings, run host cleanup rollback, close the activation context, and call `deactivate()`.
+- Keep plugin settings strict untagged JSON and reject the reserved `__type__` key at any depth.
+- Address video frames by stream PTS plus time base, never by inferred frame index. Preserve source fingerprint, stream, and time-base fences through requests, caches, seeks, and manifests.
+- New tracking or SAM 2 worker output must use `source='tracker'`, `review_state='pending'`, and `anchor=False`. Human acceptance does not promote it to an interpolation anchor, and export continues to exclude pending and rejected suggestions.
+- Treat `*.labelimgpp.sqlite` as a versioned transactional format. Any schema change requires a `SCHEMA_VERSION` bump and a transactional migration; preserve read-only fallback on migration failure.
+- Keep optional dependency markers in `pyproject.toml` aligned with `tests/video/test_compatibility.py`; that test intentionally asserts exact PyAV markers, two OpenCV entries, and no packaged Torch or SAM 2 dependency.
+
+## Generated files and release metadata
+
+- Do not edit `libs/resources.py` directly. Edit `resources.qrc` or its source asset, run `make qt5py3`, then run `python3 scripts/verify_qt_resources.py`; keep source and generated output together.
+- Add every new `get_str()` key to `resources/strings/strings.properties` before rebuilding resources.
+- Keep release versions synchronized in `pyproject.toml`, `libs/__init__.py`, `setup.cfg`, and `labelimgplusplus.egg-info/PKG-INFO`.
+- Treat `build-tools/build-for-pypi.sh` as a destructive manual-release script: it removes tracked egg metadata before rebuilding and can upload interactively.
+
+## Validation
+
+- For plugin API or host changes, run the explicit gate in `labelimgplusplus/AGENTS.md`; for SAM, video, or combined-feature changes, run the corresponding suite in `tests/AGENTS.md`. Also run `make test`.
+- Check the base import boundary with `QT_QPA_PLATFORM=offscreen python3 -c "import sys, labelImgPlusPlus; assert not {'av', 'cv2', 'numpy', 'onnxruntime', 'torch', 'torchvision', 'sam2'} & sys.modules.keys()"`.
+- After resource changes, regenerate and run `python3 scripts/verify_qt_resources.py`.
+- After version or packaging changes, run `python3 -m pytest tests/test_release_consistency.py tests/video/test_compatibility.py -v`. For a distribution build, install `build` and `twine`, then run `python3 -m build` and `twine check dist/*`.
+- For UI changes, run affected widget and integration tests and inspect the real flow in light and dark themes at 1x and 2x scaling.
+- Leave the full supported-Python matrix and Windows/macOS video smoke to CI unless those environments are available locally.
+
+## Git and delivery
+
+- Branch `feature/*`, `fix/*`, and `chore/*` work from `dev` and target pull requests to `dev`. Do not follow the obsolete `develop` references in `CONTRIBUTING.rst`.
+- Use Conventional Commit subjects in the form `type(scope): lowercase imperative`.
+- Do not add AI-tool attribution, `Co-Authored-By` trailers, or tool branding to commits or pull-request text.
+- Squash-merge feature, fix, and chore pull requests into `dev` after required checks and review approval; refresh `dev` before starting dependent work.
+- Preserve unrelated working-tree changes and stage only the intended implementation files.
+- For releases, read `build-tools/README.md` and `.github/workflows/ci.yaml`; a release tag must match the package version and point to a commit already on `origin/master`.
+
+## Read before changing
+
+- Before changing async runtime, plugin hosting, or video pipelines, read the runtime sections at the start of `docs/architecture.md`; verify later legacy diagrams against current code.
+- Before changing Smart Video behavior, read `docs/features/smart-video-annotation.md` for workflow context and use current code and tests as the behavioral authority.
+- Before changing SAM behavior or dependencies, read `docs/features/sam-assisted-polygon.md` and `docs/guides/optional-dependencies.md`.

--- a/labelimgplusplus/AGENTS.md
+++ b/labelimgplusplus/AGENTS.md
@@ -1,0 +1,33 @@
+# Public Plugin API Instructions
+
+## Scope
+
+This file governs the shipped public package under `labelimgplusplus/`. It extends the repository-wide instructions in the root `AGENTS.md`.
+
+## Contracts
+
+- Treat `labelimgplusplus/plugins.py` as a third-party compatibility boundary; `libs/**` remains internal and is not a plugin contract.
+- Keep this package standard-library-only. Do not import PyQt, `libs`, or optional runtime dependencies here.
+- Preserve compatibility within the current `PLUGIN_API_MAJOR` through additive changes. Do not remove, rename, or change existing public fields, protocols, or semantics without an explicitly approved `PLUGIN_API_MAJOR` bump.
+- Keep the entry-point name equal to `PluginMetadata.id`.
+- Preserve command identities as `plugin.<plugin-id>.<command-id>` because they are persisted in shortcut settings.
+- Keep exposed document records immutable and host services narrow; do not expose `MainWindow`, widgets, `QAction`, `Shape`, or internal job handles.
+- Before changing the contract, read `docs/reference/plugin-api-v1.md` and `docs/guides/plugin-authoring.md`.
+
+## Validation
+
+Run the explicit plugin CI gate from the repository root:
+
+```bash
+pip install wheel
+QT_QPA_PLATFORM=offscreen python3 -m pytest \
+  tests/core/test_plugin_discovery.py \
+  tests/core/test_plugin_manager.py \
+  tests/core/test_shortcut_config.py \
+  tests/integration/test_plugins.py \
+  tests/integration/test_plugin_packaging.py \
+  tests/integration/test_plugin_performance.py \
+  -v
+```
+
+Also run the base-startup optional-import check from the root `AGENTS.md`.

--- a/libs/formats/AGENTS.md
+++ b/libs/formats/AGENTS.md
@@ -1,0 +1,29 @@
+# Annotation Format Instructions
+
+## Scope
+
+This file governs annotation readers, writers, metadata, path resolution, probes, and loader glue under `libs/formats/`. It extends the repository-wide instructions in the root `AGENTS.md`.
+
+## Contracts
+
+- Treat annotation formats as a closed registry, not a plugin extension point.
+- Never construct annotation paths manually. Use `annotation_output_base()` and `find_existing_annotation()` with the active `AnnotationResolver`.
+- Do not add a production asynchronous save path that invokes a writer directly. Register it with `SaveRequest` and `write_save_request()` so publication remains atomic.
+- Writers receive a temporary path in the destination directory. Derive sibling files such as `classes.txt` from `target_file`, not from the source image path.
+- Preserve the ordering of an existing YOLO `classes.txt`; append new labels without renumbering existing annotations.
+- Reader shape tuples are not uniform: YOLO and CreateML return 5 fields, VOC and YOLO-seg return 6, and COCO returns 7. Callers must handle the actual tuple arity.
+
+## Adding a format
+
+- Add the reader/writer and update `LabelFileFormat` plus its `LabelFile` save adapter.
+- Update `libs/utils/constants.py`, `format_metadata.py` (`_FORMATS`, `_CYCLE_WARNINGS`, and the predecessor warning), `libs/core/save_pipeline.py`, `annotation_loader.py`, `libs/core/image_pipeline.py`, and `annotation_probe.py`.
+- Update the synchronous load/map paths in `labelImgPlusPlus.py` and format parsing in `libs/widgets/galleryWidget.py`.
+- Add a non-XML/TXT/JSON extension to `ANNOTATION_EXTENSIONS`.
+- If the format appears in video export, update `libs/widgets/videoExportDialog.py` and `libs/core/video_export.py`.
+- If an icon or resource alias changes, run `make qt5py3` and `python3 scripts/verify_qt_resources.py`.
+
+## Validation
+
+- Run `python3 -m pytest tests/formats tests/core/test_save_pipeline.py -v`.
+- Add integration, gallery, or export tests when those call paths change.
+- Do not use `docs/guides/adding-formats.md` or `docs/formats/overview.md` as implementation authority; both describe the older format layout.

--- a/libs/widgets/AGENTS.md
+++ b/libs/widgets/AGENTS.md
@@ -1,0 +1,29 @@
+# Widget Instructions
+
+## Scope
+
+This file governs canvas widgets, workspace chrome, galleries, dialogs, and video views under `libs/widgets/`. It extends the repository-wide instructions in the root `AGENTS.md`.
+
+## Workspace contracts
+
+- For persistent workspace chrome, extend `WorkspaceSplitterShell`, `WorkspacePages`, or `WorkspaceInspector`; do not introduce a `QDockWidget` or a second toolbar.
+- Bind command controls to the existing MainWindow-owned `QAction` with `setDefaultAction()`. Do not copy enabled, checked, text, icon, or shortcut state into widget-owned state.
+
+## Theme and DPI
+
+- Add semantic colors to both `LIGHT_COLORS` and `DARK_COLORS` in `libs/utils/styles.py`; do not add color literals to widgets.
+- For self-styled widgets, set an object name, enable `WA_StyledBackground`, implement `apply_theme()`, and ensure the active theme reaches it through its owner or `MainWindow._apply_theme()`.
+- Theme lazily created dialogs from their caller before showing them.
+- Define dimensions in logical pixels and call `scale_px()` at construction or use time. Do not freeze scaled values at module import.
+
+## Canvas changes
+
+- Keep unclassified geometry in `canvas.provisional_shape`; do not append it to `canvas.shapes` before class confirmation.
+- Geometry mutations must emit the appropriate pre-mutation undo signal and update the spatial index with `reindex_shape()` or `rebuild_spatial_index()`.
+- New canvas modes must perform the cleanup and conditional `modeChanged` emission used by `set_sam_mode()`.
+
+## Validation
+
+- Run the closest file under `tests/widgets/` and any affected test under `tests/integration/`.
+- For theme changes, run `python3 -m pytest tests/ -k theme -v` and inspect the affected flow in light and dark themes at 1x and 2x scaling.
+- Before theme testing, read `docs/testing/theme-testing.md`.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,51 @@
+# Test Instructions
+
+## Scope
+
+This file governs tests and fixtures under `tests/`. It extends the repository-wide instructions in the root `AGENTS.md`.
+
+## Commands
+
+- Run all commands from the repository root.
+- While iterating, run `python3 -m pytest path/to/test_file.py -v`.
+- For video coverage, install `pip install '.[video]' pytest`, then run `python3 -m pytest tests/video -v`.
+- For SAM coverage, install `pip install '.[sam]' pytest`, then run:
+
+```bash
+python3 -m pytest \
+  tests/integrations \
+  tests/integration/test_sam_controller.py \
+  tests/integration/test_sam_mainwindow.py \
+  tests/widgets/test_canvas_sam.py \
+  tests/widgets/test_sam_settings_dialog.py \
+  tests/utils/test_sam_constants.py \
+  -v
+```
+
+- For changes crossing SAM and video, install `pip install '.[sam,video]' pytest`, then run:
+
+```bash
+python3 -m pytest \
+  tests/video \
+  tests/integrations \
+  tests/integration/test_sam_controller.py \
+  tests/integration/test_sam_mainwindow.py \
+  tests/widgets/test_canvas_sam.py \
+  tests/widgets/test_sam_settings_dialog.py \
+  tests/utils/test_sam_constants.py \
+  -v
+```
+
+## Placement and dependencies
+
+- Put base-installed MainWindow and workflow tests in `tests/integration/`.
+- Put tests for optional modules under `libs/integrations/` in `tests/integrations/`.
+- Put video-extra tests in `tests/video/`.
+- Call `pytest.importorskip()` before importing a module that pulls an optional dependency.
+- Separate optional-dependency tests from stdlib-only tests; a module-level skip discards the entire test file.
+- Add new plugin compatibility tests to the explicit `plugin-test` file list in `.github/workflows/ci.yaml`.
+- Reuse `tests/video/conftest.py::make_video`; do not commit video clips as fixtures.
+
+## Completion
+
+- Run the closest affected file while iterating, then the owning optional-feature suite when applicable. The root completion gates still apply.


### PR DESCRIPTION
## Summary

- replace the oversized root guidance with a compact repository-wide policy
- add scoped instructions for the public plugin API, annotation formats, widgets, and tests
- document verified validation, compatibility, generated-file, and delivery constraints

## Verification

- `QT_QPA_PLATFORM=offscreen python3 -m pytest tests/ -q` — 1196 passed, 1 skipped
- base-startup optional-import assertion — passed
- `git diff --cached --check` — passed