### PR TITLE
fix(annotation): prevent fixed-class selection crash

### DIFF
--- a/labelImgPlusPlus.py
+++ b/labelImgPlusPlus.py
@@ -2917,10 +2917,10 @@ class MainWindow(QMainWindow, WindowMixin):
             return
         self.default_label = label
         if label in self.label_hist:
-            blocked = self.default_label_combo_box.blockSignals(True)
-            self.default_label_combo_box.setCurrentIndex(
+            blocked = self.default_label_combo_box.cb.blockSignals(True)
+            self.default_label_combo_box.cb.setCurrentIndex(
                 self.label_hist.index(label))
-            self.default_label_combo_box.blockSignals(blocked)
+            self.default_label_combo_box.cb.blockSignals(blocked)
         self._sync_inspector_context()
 
     def _sync_inspector_context(self):

--- a/labelImgPlusPlus.py
+++ b/labelImgPlusPlus.py
@@ -2917,10 +2917,14 @@ class MainWindow(QMainWindow, WindowMixin):
             return
         self.default_label = label
         if label in self.label_hist:
-            blocked = self.default_label_combo_box.cb.blockSignals(True)
-            self.default_label_combo_box.cb.setCurrentIndex(
-                self.label_hist.index(label))
-            self.default_label_combo_box.cb.blockSignals(blocked)
+            combo = self.default_label_combo_box.cb
+            blocked = combo.blockSignals(True)
+            index = combo.findText(label)
+            if index < 0:
+                combo.addItem(label)
+                index = combo.count() - 1
+            combo.setCurrentIndex(index)
+            combo.blockSignals(blocked)
         self._sync_inspector_context()
 
     def _sync_inspector_context(self):

--- a/tests/integration/test_inline_class_picker.py
+++ b/tests/integration/test_inline_class_picker.py
@@ -171,6 +171,43 @@ def test_annotation_session_is_the_only_visible_class_strategy_surface(
         app.processEvents()
 
 
+def test_changing_fixed_class_preserves_dirty_annotation_and_labels_next(
+        tmp_path):
+    app, window = get_main_app()
+    try:
+        _prepare_image(window, tmp_path)
+        existing = _finalise_rectangle(window)
+        _enter_class(window, 'dog')
+        app.processEvents()
+
+        assert window.canvas.shapes == [existing]
+        assert existing.label == 'dog'
+        assert window.dirty
+
+        card = window.inspector_context_card
+        card.class_strategy_combo.setCurrentIndex(
+            card.class_strategy_combo.findData('fixed'))
+        card.fixed_class_combo.setCurrentIndex(
+            card.fixed_class_combo.findText('car'))
+        app.processEvents()
+
+        assert window.canvas.shapes == [existing]
+        assert window.dirty
+        assert card.fixed_class_combo.currentText() == 'car'
+        assert window.default_label_combo_box.cb.currentText() == 'car'
+
+        created = _finalise_rectangle(window, 55, 10)
+        app.processEvents()
+        assert window.canvas.shapes == [existing, created]
+        assert [shape.label for shape in window.canvas.shapes] == [
+            'dog', 'car']
+    finally:
+        window.dirty = False
+        window.close()
+        app.processEvents()
+        app.processEvents()
+
+
 def test_escape_discards_provisional_shape_without_document_mutation(tmp_path):
     app, window = get_main_app()
     try:

--- a/tests/integration/test_inline_class_picker.py
+++ b/tests/integration/test_inline_class_picker.py
@@ -208,6 +208,31 @@ def test_changing_fixed_class_preserves_dirty_annotation_and_labels_next(
         app.processEvents()
 
 
+def test_fixed_class_selects_label_created_after_window_construction(tmp_path):
+    app, window = get_main_app()
+    try:
+        _prepare_image(window, tmp_path)
+        _finalise_rectangle(window)
+        _enter_class(window, 'delivery robot')
+        app.processEvents()
+
+        card = window.inspector_context_card
+        card.class_strategy_combo.setCurrentIndex(
+            card.class_strategy_combo.findData('fixed'))
+        card.fixed_class_combo.setCurrentIndex(
+            card.fixed_class_combo.findText('delivery robot'))
+        app.processEvents()
+
+        assert card.fixed_class_combo.currentText() == 'delivery robot'
+        assert window.default_label_combo_box.cb.currentText() == \
+            'delivery robot'
+    finally:
+        window.dirty = False
+        window.close()
+        app.processEvents()
+        app.processEvents()
+
+
 def test_escape_discards_provisional_shape_without_document_mutation(tmp_path):
     app, window = get_main_app()
     try:

--- a/tests/integration/test_inline_class_picker.py
+++ b/tests/integration/test_inline_class_picker.py
@@ -136,8 +136,7 @@ def test_annotation_session_is_the_only_visible_class_strategy_surface(
     app, window = get_main_app()
     try:
         _prepare_image(window, tmp_path)
-        window.label_hist = ['car', 'person']
-        window.default_label = 'car'
+        window.default_label = 'dog'
         window._session_last_class = 'person'
         window._sync_inspector_context()
         card = window.inspector_context_card
@@ -163,6 +162,7 @@ def test_annotation_session_is_the_only_visible_class_strategy_surface(
         assert window.use_default_label_checkbox.isChecked()
         assert not window.single_class_mode.isChecked()
         assert window.default_label == 'car'
+        assert window.default_label_combo_box.cb.currentText() == 'car'
         assert not card.fixed_class_combo.isHidden()
     finally:
         window.dirty = False


### PR DESCRIPTION
## Summary

Changing **Fixed class** now updates the wrapped Qt combo box without aborting the application. Existing unsaved annotations remain intact, both class projections show the new value, and the next object uses that class. Labels created during the current session are synchronized before selection.

This is the safety baseline for the frozen user-experience audit. The audit and its report remain follow-on work after this PR lands.

## Verification

- The new regression aborts with exit 134 on archived `060dafa`.
- `tests/integration/test_inline_class_picker.py`: 20 passed.
- Base optional-import boundary: passed.
- `make test`: 1,260 passed, 1 real-model test skipped.

Fixes #125
